### PR TITLE
Add support for running the ANISE GUI in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/dist
 /target
 Cargo.lock
 *.anis*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hifitime = "3.8"
+hifitime = {version = "3.8", git="https://github.com/nyx-space/hifitime", branch="master"}
 memmap2 = "=0.9.0"
 crc32fast = "=1.3.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ egui_extras = { version = "0.24.0", features = [
 egui-toast = { version = "0.10.0", optional = true }
 rfd = { version = "0.12.1", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4"
+poll-promise = { version = "0.3.0", features = ["web"] }
+
 [dev-dependencies]
 rust-spice = "0.7.6"
 parquet = "49.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hifitime = {version = "3.8", git="https://github.com/nyx-space/hifitime", branch="master"}
+hifitime = "3.8.6"
 memmap2 = "=0.9.0"
 crc32fast = "=1.3.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <link data-trunk rel="rust" data-bin="anise-gui" />
+  </head>
+  <body>
+    <!-- The WASM code will resize the canvas dynamically -->
+    <!-- the id is hardcoded in main.rs . so, make sure both match. -->
+    <canvas id="anise_canvas"></canvas>
+
+  </body>
+</html>

--- a/src/almanac/mod.rs
+++ b/src/almanac/mod.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use bytes::Bytes;
 use log::info;
 use snafu::ResultExt;
 use std::fs::File;
@@ -94,7 +95,11 @@ impl Almanac {
         let bytes = file2heap!(path).with_context(|_| LoadingSnafu {
             path: path.to_string(),
         })?;
+        info!("Loading almanac from {path}");
+        self.load_from_bytes(bytes)
+    }
 
+    pub fn load_from_bytes(&self, bytes: Bytes) -> Result<Self, AlmanacError> {
         // Try to load as a SPICE DAF first (likely the most typical use case)
 
         // Load the header only
@@ -103,7 +108,7 @@ impl Almanac {
         if let Ok(fileid) = file_record.identification() {
             match fileid {
                 "PCK" => {
-                    info!("Loading {path} as DAF/PCK");
+                    info!("Loading as DAF/PCK");
                     let bpc = BPC::parse(bytes)
                         .with_context(|_| BPCSnafu {
                             action: "parsing bytes",
@@ -116,7 +121,7 @@ impl Almanac {
                     })
                 }
                 "SPK" => {
-                    info!("Loading {path:?} as DAF/SPK");
+                    info!("Loading as DAF/SPK");
                     let spk = SPK::parse(bytes)
                         .with_context(|_| SPKSnafu {
                             action: "parsing bytes",

--- a/src/bin/anise-gui/main.rs
+++ b/src/bin/anise-gui/main.rs
@@ -1,13 +1,14 @@
-use pretty_env_logger;
-use std::env::{set_var, var};
-
+#[allow(dead_code)]
 const LOG_VAR: &str = "ANISE_LOG";
 
 mod ui;
 
 use ui::UiApp;
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
+    use std::env::{set_var, var};
+
     if var(LOG_VAR).is_err() {
         set_var(LOG_VAR, "INFO");
     }
@@ -19,4 +20,25 @@ fn main() {
         eframe::NativeOptions::default(),
         Box::new(|cc| Box::new(UiApp::new(cc))),
     );
+}
+
+// Entrypoint for WebAssembly
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    use log::info;
+
+    eframe::WebLogger::init(log::LevelFilter::Debug).ok();
+    let web_options = eframe::WebOptions::default();
+
+    info!("Starting ANISE in WebAssembly mode");
+    wasm_bindgen_futures::spawn_local(async {
+        eframe::WebRunner::new()
+            .start(
+                "anise_canvas",
+                web_options,
+                Box::new(|cc| Box::new(UiApp::new(cc))),
+            )
+            .await
+            .expect("failed to start eframe");
+    });
 }


### PR DESCRIPTION
# Summary

This PR makes some changes that enable running the ANISE GUI in the browser. This could be deployed to a static HTML page and hosted on Github Pages for ease-of-access.

Running the web version locally is best done using [Trunk](https://trunkrs.dev/#install). Install it by running `cargo install --locked trunk` (or follow instructions in the linked page above). The ANISE GUI can then be built and launched by running

```
trunk serve --features gui
```

This will start up a web server (only used for local testing), at http://127.0.0.1:8080/.

Trunk can also be used for building the WASM binary and associated index.html and JS file by running:
```
trunk build --release --features gui
```

The files generated in `dist/` can be published to Github pages or any other static web-host.


## Architectural Changes

* An updated version of `hifitime` is required. See this PR: https://github.com/nyx-space/hifitime/pull/262 . Currently, `Cargo.toml` points to my branch of `hifitime`. Once that PR is merged, I can update it to point to the new version on crates.io.

* `Almanac::load()` has been split up into two methods: `Almanac::load()` and `Almanac::load_from_bytes()`. The latter is used when loading files from the GUI running in the browser.

* Additional logic in `ui.rs` for loading the file using a browser-based file picker instead of the native file picker. This required some additional `async` stuff in the code. However, all of these new things are only built if compiled for the `wasm32-unknown-unknown` target

* The browser does *not* have an implementation of memory-mapped IO. So loading large files might use up a bunch of memory.

## New Features

This PR enables running the ANISE GUI from a web browser.

## Testing and validation

Manually tested the GUI.

<img width="1512" alt="image" src="https://github.com/nyx-space/anise/assets/1804570/73775b10-5d3b-4d8f-87e0-2714eec1f896">


<!-- Thank you for contributing to ANISE! -->