### PR TITLE
Sun observer angle calculation (or solar probe angle)

### DIFF
--- a/anise-py/tutorials/Tutorial 04 - Computing Azimuth Elevation and Range data.ipynb
+++ b/anise-py/tutorials/Tutorial 04 - Computing Azimuth Elevation and Range data.ipynb
@@ -22,7 +22,7 @@
    "id": "645bb375-58da-42a2-8107-2af6bbb38b5f",
    "metadata": {},
    "source": [
-    "## Loading the latest orientation and planteray data\n",
+    "## Loading the latest orientation and planetary data\n",
     "\n",
     "In this tutorial, we're using the latest Earth orientation parameters from JPL, and the latest planetary ephemerides, constants, and high precision Moon rotation parameters. These can be downloaded automatically by ANISE using the MetaAlmanac class (refer to tutorial #02 for details)."
    ]

--- a/anise-py/tutorials/Tutorial 05 - Using frame kernels and text planetary kernels.ipynb
+++ b/anise-py/tutorials/Tutorial 05 - Using frame kernels and text planetary kernels.ipynb
@@ -246,13 +246,69 @@
    "source": [
     "## Euler Parameter ANISE kernel\n",
     "\n",
-    "Euler parameters are a normalized quaternion. In fact, in the ANISE code in Rust, `EulerParameter` is an alias for `Quaternion`. Euler parameters are useful for defining fixed rotations, e.g. the rotation from the Moon Principal Axes frame to the Moon Mean Earth frame."
+    "Euler parameters are a normalized quaternion. In fact, in the ANISE code in Rust, `EulerParameter` is an alias for `Quaternion`. Euler parameters are useful for defining fixed rotations, e.g. the rotation from the Moon Principal Axes frame to the Moon Mean Earth frame.\n",
+    "\n",
+    "Euler Parameter ANISE kernels (EPA) can be used to store these fixed rotations between frames, and reference them either by their ID or by their name. **They are the equivalent of SPICE's `FK` text files.**\n",
+    "\n",
+    "Until [#175](https://github.com/nyx-space/anise/issues/175), rotation data is _not_ exposed to Python. \n",
+    "\n",
+    "However, it's possible to convert an FK file into the EPA file using the following function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "263507b1-8f58-44e5-b0b3-4abcf0a00b92",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mconvert_fk\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mfk_file_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0manise_output_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mshow_comments\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moverwrite\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Converts a KPL/FK file, that defines frame constants like fixed rotations, and frame name to ID mappings into the EulerParameterDataSet equivalent ANISE file.\n",
+       "KPL/FK files must be converted into \"PCA\" (Planetary Constant ANISE) files before being loaded into ANISE.\n",
+       "\u001b[0;31mType:\u001b[0m      builtin_function_or_method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from anise.utils import convert_fk\n",
+    "convert_fk?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e26f92f9-9fa6-4fb7-b142-8bcaf0451b28",
+   "metadata": {},
+   "source": [
+    "On the Nyx Space Cloud, you'll find the `moon.fk` file, which includes the mapping between the Moon PA and Moon ME frame. The latest Almanac also includes the high precision Moon ME frame. Hence, with default data, you can rotate an object from any frame into the high precision Moon ME frame.\n",
+    "\n",
+    "## Exercise\n",
+    "\n",
+    "Using tutorial 04, compute the azimuth, elevation, and range of the [Shackleton](https://en.wikipedia.org/wiki/Shackleton_(crater)) crater on the Moon to the city of Paris, France.\n",
+    "\n",
+    "Here are the general steps:\n",
+    "\n",
+    "1. Load the latest Almanac, and check (by printing it) that it includes both EPA and PCA data. Else, load the moon_fk.epa file from the Nyx Space Cloud using a MetaFile with the URL <http://public-data.nyxspace.com/anise/v0.3/moon_fk.epa>.\n",
+    "2. Define a time series over a year with a granularity of 12 hours. This crater is on the South Pole of the Moon, and its visibility is often below the horizon of an object as far north as Paris.\n",
+    "3. For each epoch, define Paris as an `Orbit` instance from its longitude and latitde (recall that the constants include the mean Earth angular rotation rate), in the IAU_EARTH frame. Also build the crater in the IAU_MOON frame.\n",
+    "4. Finally, call the AER function of the Almanac with each epoch to compute the AER data. Plot it!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "263507b1-8f58-44e5-b0b3-4abcf0a00b92",
+   "id": "0a91851b-188a-4dc8-9e8c-40276012dbd1",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/anise-py/tutorials/Tutorial 06 - Sun probe Earth angle.ipynb
+++ b/anise-py/tutorials/Tutorial 06 - Sun probe Earth angle.ipynb
@@ -1,0 +1,620 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "142de0bb-6053-4122-9777-ea9db5dd61ce",
+   "metadata": {},
+   "source": [
+    "# ANISE\n",
+    "\n",
+    "ANISE is a modern rewrite of NAIF SPICE, written in Rust and providing interfaces to other languages including Python.\n",
+    "\n",
+    "Evidently, this tutorial applies to the Python usage of ANISE.\n",
+    "\n",
+    "## Goal\n",
+    "By the end of this tutorial, you should know how to build a data frame containing the Sun probe Earth angle of a given spacecraft BSP and plot that information. Your exercise will be to confirm that this calculation is correct by computing the Sun elevation at nadir below the spacecraft as detailed in tutorial 04.## Loading the latest orientation and planetary data\n",
+    "\n",
+    "Let's start by installing ANISE: `pip install anise`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20351a7f-e6b0-4d0c-ac6b-0cfabb6d76ca",
+   "metadata": {},
+   "source": [
+    "## Load a BSP containing a spacecraft trajectory\n",
+    "\n",
+    "In this tutorial, we will use the `gmat-hermite.bsp` file which contains some trajectory data build in GMAT and used in ANISE for validation purposes. Although the Sun probe Earth angle _typically_ applies to spacecraft trajectories, the calculation works for any two objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "59c15415-c54d-465f-962b-585e870d296b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== SPK #0 ===\n",
+      "┌─────────────┬──────────────────────┬─────────────┬───────────────────────────────────┬───────────────────────────────────┬────────────┬──────────────────────┐\n",
+      "│ Name        │ Target               │ Center      │ Start epoch                       │ End epoch                         │ Duration   │ Interpolation kind   │\n",
+      "├─────────────┼──────────────────────┼─────────────┼───────────────────────────────────┼───────────────────────────────────┼────────────┼──────────────────────┤\n",
+      "│ SPK_SEGMENT │ body -10000001 J2000 │ Earth J2000 │ 2000-01-01T12:00:32.183927328 TDB │ 2000-01-01T15:20:32.183931556 TDB │ 3 h 20 min │ Hermite Unequal Step │\n",
+      "└─────────────┴──────────────────────┴─────────────┴───────────────────────────────────┴───────────────────────────────────┴────────────┴──────────────────────┘\n",
+      "=== SPK #1 ===\n",
+      "┌────────────────┬─────────────────────────────┬─────────��─────────────────────┬───────────────────────────────────┬───────────────────────────────────┬─────────────┬────────────────────┐\n",
+      "│ Name           │ Target                      │ Center                        │ Start epoch                       │ End epoch                         │ Duration    │ Interpolation kind │\n",
+      "├────────────────┼─────────────────────────────┼───────────────────────────────┼───────────────────────────────────┼───────────────────��───────────────┼─────────────┼────────────────────┤\n",
+      "│ DE-0440LE-0440 │ Mercury J2000               │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Venus J2000                 │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Earth-Moon Barycenter J2000 │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Mars Barycenter J2000       │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Jupiter Barycenter J2000    │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Saturn Barycenter J2000     │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Uranus Barycenter J2000     │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Neptune Barycenter J2000    │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Pluto Barycenter J2000      │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Sun J2000                   │ Solar System Barycenter J2000 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Moon J2000                  │ Earth-Moon Barycenter J2000   │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ Earth J2000                 │ Earth-Moon Barycenter J2000   │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ body 199 J2000              │ Mercury J2000                 │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "│ DE-0440LE-0440 │ body 299 J2000              │ Venus J2000                   │ 1849-12-26T00:00:00.000046818 TDB │ 2150-01-21T23:59:59.999955683 TDB │ 109600 days │ Chebyshev Triplet  │\n",
+      "└────────────────┴─────────────────────────────┴───────────────────────────────┴───────────────────────────────────┴───────────────────────────────────┴─────────────┴────────────────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "from anise import MetaAlmanac\n",
+    "almanac = MetaAlmanac.latest().load(\"../../data/gmat-hermite.bsp\")\n",
+    "almanac.describe(spk=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f1d744b-461a-4a38-9d24-b5e989747355",
+   "metadata": {},
+   "source": [
+    "We have successfully loaded two BSP files, one with the planetary data and the other with spacecraft data. We now know that this spacecraft has the ID `-10000001`. We can actually query the Almanac for the precise start and stop epochs (returned as hifitime `Epoch` objects) of this ID in our loaded files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c85fc5ec-7b54-4c00-9a1a-9722d7a80cd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2000-01-01T11:59:28.000000021 UTC 2000-01-01T15:19:28.000000226 UTC\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_epoch, stop_epoch = almanac.spk_domain(-10000001)\n",
+    "print(start_epoch, stop_epoch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "414d228b-1b69-4352-b415-0ebcd71a669c",
+   "metadata": {},
+   "source": [
+    "The Sun Probe Earth angle is the angle between a probe and the Sun and the probe the Earth. It allows one to know whether the point exactly nadir (i.e. below) the spacecraft is illuminated by the Sun or not. This is helpful information if the spacecraft carries a visible light camera and needs to take pictures when it's daytime below the spacecraft.\n",
+    "\n",
+    "Let's look at the signature of this function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "40176b6b-dfb8-4d9d-a6c2-93cc5c8cd751",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0malmanac\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msun_angle_deg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtarget_id\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobserver_id\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mepoch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Returns the angle (between 0 and 180 degrees) between the observer and the Sun, and the observer and the target body ID.\n",
+       "This computes the Sun Probe Earth angle (SPE) if the probe is in a loaded, its ID is the \"observer_id\", and the target is set to its central body.\n",
+       "\n",
+       "# Geometry\n",
+       "If the SPE is greater than 90 degrees, then the celestial object below the probe is in sunlight.\n",
+       "\n",
+       "## Sunrise at nadir\n",
+       "```text\n",
+       "Sun\n",
+       " |  \\      \n",
+       " |   \\\n",
+       " |    \\\n",
+       " Obs. -- Target\n",
+       "```\n",
+       "## Sun high at nadir\n",
+       "```text\n",
+       "Sun\n",
+       " \\        \n",
+       "  \\  __ θ > 90\n",
+       "   \\     \\\n",
+       "    Obs. ---------- Target\n",
+       "```\n",
+       "\n",
+       "## Sunset at nadir\n",
+       "```text\n",
+       "         Sun\n",
+       "       /  \n",
+       "      /  __ θ < 90\n",
+       "     /    /\n",
+       " Obs. -- Target\n",
+       "```\n",
+       "\n",
+       "# Algorithm\n",
+       "1. Compute the position of the Sun as seen from the observer\n",
+       "2. Compute the position of the target as seen from the observer\n",
+       "3. Return the arccosine of the dot product of the norms of these vectors.\n",
+       "\u001b[0;31mType:\u001b[0m      builtin_function_or_method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "almanac.sun_angle_deg?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b36bb3ec-8f8a-4298-90ea-2579c3f74ea5",
+   "metadata": {},
+   "source": [
+    "One will note that this function is generic to what the \"probe\" SPK ID is (\"observer\") and what its central object should be instead of Earth (\"target\").\n",
+    "\n",
+    "The other crucial point here is that this is one of the few functions where the object _ID_ is required instead of a frame. This is because the Almanac will compute everything in the J2000 frame. Don't worry, if you have frame objects instead, you may use the `sun_angle_deg_from_frame` function instead.\n",
+    "\n",
+    "Let's see what is the SPE of our spacecraft at the start of the trajectory.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0366c5b9-cf4d-473e-9385-3a425fd554bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "83.87312777296376"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from anise.astro.constants import CelestialObjects\n",
+    "almanac.sun_angle_deg(-10000001, CelestialObjects.EARTH, start_epoch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c18f00cf-fdc7-4050-b8b4-4f951e6e11e6",
+   "metadata": {},
+   "source": [
+    "A angle of less than 90 degrees means that the nadir point is in the darkness. Let's look at the evolution of the SPE over the duration of the trajectory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d8a8d44-b433-4955-a0e5-81988decafce",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Package installation for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b91b712a-3fe7-41a9-9e7d-78cabb756b9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: polars[plot] in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (0.20.4)\n",
+      "Requirement already satisfied: hvplot in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (0.9.1)\n",
+      "Collecting geoviews\n",
+      "  Downloading geoviews-1.11.0-py2.py3-none-any.whl (511 kB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m511.2/511.2 kB\u001b[0m \u001b[31m690.4 kB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m kB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: bokeh>=1.0.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (3.3.3)\n",
+      "Requirement already satisfied: colorcet>=2 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (3.0.1)\n",
+      "Requirement already satisfied: holoviews>=1.11.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (1.18.1)\n",
+      "Requirement already satisfied: pandas in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (2.1.4)\n",
+      "Requirement already satisfied: numpy>=1.15 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (1.26.3)\n",
+      "Requirement already satisfied: packaging in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (23.2)\n",
+      "Requirement already satisfied: panel>=0.11.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (1.3.6)\n",
+      "Requirement already satisfied: param<3.0,>=1.12.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from hvplot) (2.0.1)\n",
+      "Collecting cartopy>=0.18.0 (from geoviews)\n",
+      "  Downloading Cartopy-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.9 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.9/11.9 MB\u001b[0m \u001b[31m14.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0mm eta \u001b[36m0:00:01\u001b[0m[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hCollecting shapely (from geoviews)\n",
+      "  Downloading shapely-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.5 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.5/2.5 MB\u001b[0m \u001b[31m54.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m31m72.7 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hCollecting pyproj (from geoviews)\n",
+      "  Downloading pyproj-3.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.6 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.6/8.6 MB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0mm eta \u001b[36m0:00:01\u001b[0m0:01\u001b[0m:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: xyzservices in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from geoviews) (2023.10.1)\n",
+      "Requirement already satisfied: Jinja2>=2.9 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bokeh>=1.0.0->hvplot) (3.1.2)\n",
+      "Requirement already satisfied: contourpy>=1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bokeh>=1.0.0->hvplot) (1.2.0)\n",
+      "Requirement already satisfied: pillow>=7.1.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bokeh>=1.0.0->hvplot) (10.2.0)\n",
+      "Requirement already satisfied: PyYAML>=3.10 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bokeh>=1.0.0->hvplot) (6.0.1)\n",
+      "Requirement already satisfied: tornado>=5.1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bokeh>=1.0.0->hvplot) (6.4)\n",
+      "Collecting matplotlib>=3.4 (from cartopy>=0.18.0->geoviews)\n",
+      "  Downloading matplotlib-3.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.6 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.6/11.6 MB\u001b[0m \u001b[31m47.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0mm eta \u001b[36m0:00:01\u001b[0m[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hCollecting pyshp>=2.1 (from cartopy>=0.18.0->geoviews)\n",
+      "  Downloading pyshp-2.3.1-py2.py3-none-any.whl (46 kB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.5/46.5 kB\u001b[0m \u001b[31m14.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: pyct>=0.4.4 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from colorcet>=2->hvplot) (0.5.0)\n",
+      "Requirement already satisfied: pyviz-comms>=0.7.4 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from holoviews>=1.11.0->hvplot) (3.0.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from pandas->hvplot) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from pandas->hvplot) (2023.3.post1)\n",
+      "Requirement already satisfied: tzdata>=2022.1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from pandas->hvplot) (2023.4)\n",
+      "Requirement already satisfied: markdown in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (3.5.2)\n",
+      "Requirement already satisfied: markdown-it-py in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (3.0.0)\n",
+      "Requirement already satisfied: linkify-it-py in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (2.0.2)\n",
+      "Requirement already satisfied: mdit-py-plugins in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (0.4.0)\n",
+      "Requirement already satisfied: requests in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (2.31.0)\n",
+      "Requirement already satisfied: tqdm>=4.48.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (4.66.1)\n",
+      "Requirement already satisfied: bleach in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (6.1.0)\n",
+      "Requirement already satisfied: typing-extensions in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from panel>=0.11.0->hvplot) (4.9.0)\n",
+      "Requirement already satisfied: certifi in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from pyproj->geoviews) (2023.11.17)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from Jinja2>=2.9->bokeh>=1.0.0->hvplot) (2.1.3)\n",
+      "Collecting cycler>=0.10 (from matplotlib>=3.4->cartopy>=0.18.0->geoviews)\n",
+      "  Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)\n",
+      "Collecting fonttools>=4.22.0 (from matplotlib>=3.4->cartopy>=0.18.0->geoviews)\n",
+      "  Downloading fonttools-4.47.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.9 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.9/4.9 MB\u001b[0m \u001b[31m49.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m31m56.4 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hCollecting kiwisolver>=1.3.1 (from matplotlib>=3.4->cartopy>=0.18.0->geoviews)\n",
+      "  Downloading kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.4 MB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.4/1.4 MB\u001b[0m \u001b[31m47.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting pyparsing>=2.3.1 (from matplotlib>=3.4->cartopy>=0.18.0->geoviews)\n",
+      "  Downloading pyparsing-3.1.1-py3-none-any.whl (103 kB)\n",
+      "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m103.1/103.1 kB\u001b[0m \u001b[31m42.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.5 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from python-dateutil>=2.8.2->pandas->hvplot) (1.16.0)\n",
+      "Requirement already satisfied: webencodings in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from bleach->panel>=0.11.0->hvplot) (0.5.1)\n",
+      "Requirement already satisfied: uc-micro-py in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from linkify-it-py->panel>=0.11.0->hvplot) (1.0.2)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from markdown-it-py->panel>=0.11.0->hvplot) (0.1.2)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from requests->panel>=0.11.0->hvplot) (3.3.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from requests->panel>=0.11.0->hvplot) (3.6)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/chris/Workspace/nyx-space/anise/anise-py/.venv/lib64/python3.11/site-packages (from requests->panel>=0.11.0->hvplot) (2.1.0)\n",
+      "Installing collected packages: shapely, pyshp, pyproj, pyparsing, kiwisolver, fonttools, cycler, matplotlib, cartopy, geoviews\n",
+      "Successfully installed cartopy-0.22.0 cycler-0.12.1 fonttools-4.47.2 geoviews-1.11.0 kiwisolver-1.4.5 matplotlib-3.8.2 pyparsing-3.1.1 pyproj-3.6.1 pyshp-2.3.1 shapely-2.0.2\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install \"polars[plot]\" hvplot geoviews # geoviews for geographic data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70a3ddf6-18d7-4f94-94c4-14d73018b2ea",
+   "metadata": {},
+   "source": [
+    "## Evolution of SPE over time\n",
+    "\n",
+    "We'll plot the change in Sun probe Earth angle over time. We'll also grab the latitude and longitude data so we can plot the position of the spacecraft above the Earth at those times (as a separate plot)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "55ec0bf7-2ec8-480f-89be-cd698d0d1e55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anise.time import TimeSeries, Unit, Epoch\n",
+    "from anise.astro import Frame\n",
+    "from anise.astro.constants import Frames, Orientations\n",
+    "\n",
+    "import polars as pl\n",
+    "from datetime import datetime\n",
+    "\n",
+    "def hifitime_to_datetime(e: Epoch) -> datetime:\n",
+    "    return datetime.fromisoformat(str(e).replace(\" UTC\", \"\")[:23])\n",
+    "\n",
+    "epochs = []\n",
+    "spe_deg = []\n",
+    "lat_deg = []\n",
+    "long_deg = []\n",
+    "\n",
+    "# Let's be sure to load the PCK data, which includes the frame information such as the shape of\n",
+    "# the ellipsoid and how to compute the rotation of the body fixed frames\n",
+    "almanac = almanac.load(\"../../data/pck08.pca\")\n",
+    "\n",
+    "SC_ID = -10000001\n",
+    "SC_J2K = Frame(SC_ID, Orientations.J2000)\n",
+    "\n",
+    "for epoch in TimeSeries(start_epoch, stop_epoch, Unit.Minute*1, inclusive=True):\n",
+    "    epochs += [hifitime_to_datetime(epoch)]\n",
+    "    spe_deg += [almanac.sun_angle_deg(CelestialObjects.EARTH, SC_ID, epoch)]\n",
+    "    # Grab position of the spacecraft in the IAU Earth frame\n",
+    "    sc_iau_earth = almanac.transform(SC_J2K, Frames.IAU_EARTH_FRAME, epoch)\n",
+    "    lat_deg += [sc_iau_earth.latitude_deg()]\n",
+    "    long_deg += [sc_iau_earth.longitude_deg()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "4f6a34a7-ddae-430d-a138-e3111e7b696c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build the data frame\n",
+    "df = pl.DataFrame(\n",
+    "    {\n",
+    "        'Epoch': epochs,\n",
+    "        'Sun Probe Earth angle (deg)': spe_deg,\n",
+    "        'Latitude (deg)': lat_deg,\n",
+    "        'Longitude (deg)': long_deg\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "614ff2ee-593c-41a6-8932-72671c430ac7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {},
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.holoviews_exec.v0+json": "",
+      "text/html": [
+       "<div id='p2696'>\n",
+       "  <div id=\"a9b07ef4-1563-4f6b-82f6-d1775f043b78\" data-root-id=\"p2696\" style=\"display: contents;\"></div>\n",
+       "</div>\n",
+       "<script type=\"application/javascript\">(function(root) {\n",
+       "  var docs_json = {\"c4d768b9-cc45-4f15-b361-986c2a46aa8c\":{\"version\":\"3.3.3\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"Row\",\"id\":\"p2696\",\"attributes\":{\"name\":\"Row04004\",\"tags\":[\"embedded\"],\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2699\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/css/loading.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2767\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/css/listpanel.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2697\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/bundled/theme/default.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2698\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/bundled/theme/native.css\"}}],\"min_width\":700,\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\",\"children\":[{\"type\":\"object\",\"name\":\"Spacer\",\"id\":\"p2700\",\"attributes\":{\"name\":\"HSpacer04011\",\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"id\":\"p2699\"},{\"id\":\"p2697\"},{\"id\":\"p2698\"}],\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\"}},{\"type\":\"object\",\"name\":\"Figure\",\"id\":\"p2708\",\"attributes\":{\"width\":700,\"height\":300,\"margin\":[5,10],\"sizing_mode\":\"fixed\",\"align\":\"start\",\"x_range\":{\"type\":\"object\",\"name\":\"Range1d\",\"id\":\"p2701\",\"attributes\":{\"tags\":[[[\"Epoch\",\"Epoch\",null]],[]],\"start\":946727968000.0,\"end\":946739967999.0001,\"reset_start\":946727968000.0,\"reset_end\":946739967999.0001}},\"y_range\":{\"type\":\"object\",\"name\":\"Range1d\",\"id\":\"p2702\",\"attributes\":{\"tags\":[[[\"Sun Probe Earth angle (deg)\",\"Sun Probe Earth angle (deg)\",null]],{\"type\":\"map\",\"entries\":[[\"invert_yaxis\",false],[\"autorange\",false]]}],\"start\":2.5590908527804554,\"end\":177.392232338912,\"reset_start\":2.5590908527804554,\"reset_end\":177.392232338912}},\"x_scale\":{\"type\":\"object\",\"name\":\"LinearScale\",\"id\":\"p2718\"},\"y_scale\":{\"type\":\"object\",\"name\":\"LinearScale\",\"id\":\"p2719\"},\"title\":{\"type\":\"object\",\"name\":\"Title\",\"id\":\"p2711\",\"attributes\":{\"text\":\"Sun probe Earth angle over time\",\"text_color\":\"black\",\"text_font_size\":\"12pt\"}},\"renderers\":[{\"type\":\"object\",\"name\":\"GlyphRenderer\",\"id\":\"p2760\",\"attributes\":{\"data_source\":{\"type\":\"object\",\"name\":\"ColumnDataSource\",\"id\":\"p2751\",\"attributes\":{\"selected\":{\"type\":\"object\",\"name\":\"Selection\",\"id\":\"p2752\",\"attributes\":{\"indices\":[],\"line_indices\":[]}},\"selection_policy\":{\"type\":\"object\",\"name\":\"UnionRenderers\",\"id\":\"p2753\"},\"data\":{\"type\":\"map\",\"entries\":[[\"Epoch\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"AACgS6yNa0IAAOxorI1rQgDgN4asjWtCAOCDo6yNa0IA4M/ArI1rQgDgG96sjWtCAOBn+6yNa0IA4LMYrY1rQgDg/zWtjWtCAOBLU62Na0IA4JdwrY1rQgDg442tjWtCAOAvq62Na0IA4HvIrY1rQgDgx+WtjWtCAOATA66Na0IA4F8gro1rQgDgqz2ujWtCAOD3Wq6Na0IA4EN4ro1rQgDgj5WujWtCAODbsq6Na0IA4CfQro1rQgDgc+2ujWtCAOC/Cq+Na0IA4Asor41rQgDgV0WvjWtCAOCjYq+Na0IA4O9/r41rQgDgO52vjWtCAOCHuq+Na0IA4NPXr41rQgDgH/WvjWtCAOBrErCNa0IA4LcvsI1rQgDgA02wjWtCAOBParCNa0IA4JuHsI1rQgDg56SwjWtCAOAzwrCNa0IA4H/fsI1rQgDgy/ywjWtCAOAXGrGNa0IA4GM3sY1rQgDgr1SxjWtCAOD7cbGNa0IA4EePsY1rQgDgk6yxjWtCAODfybGNa0IA4CvnsY1rQgDgdwSyjWtCAODDIbKNa0IA4A8/so1rQgDgW1yyjWtCAOCnebKNa0IA4POWso1rQgDgP7SyjWtCAOCL0bKNa0IA4Nfuso1rQgDgIwyzjWtCAOBvKbONa0IA4LtGs41rQgDgB2SzjWtCAOBTgbONa0IA4J+es41rQgDg67uzjWtCAOA32bONa0IA4IP2s41rQgDgzxO0jWtCAOAbMbSNa0IA4GdOtI1rQgDgs2u0jWtCAOD/iLSNa0IA4EumtI1rQgDgl8O0jWtCAODj4LSNa0IA4C/+tI1rQgDgexu1jWtCAODHOLWNa0IA4BNWtY1rQgDgX3O1jWtCAOCrkLWNa0IA4PettY1rQgDgQ8u1jWtCAOCP6LWNa0IA4NsFto1rQgDgJyO2jWtCAOBzQLaNa0IA4L9dto1rQgDgC3u2jWtCAOBXmLaNa0IA4KO1to1rQgDg79K2jWtCAOA78LaNa0IA4IcNt41rQgDg0yq3jWtCAOAfSLeNa0IA4Gtlt41rQgDgt4K3jWtCAOADoLeNa0IA4E+9t41rQgDgm9q3jWtCAODn97eNa0IA4DMVuI1rQgDgfzK4jWtCAODLT7iNa0IA4BdtuI1rQgDgY4q4jWtCAOCvp7iNa0IA4PvEuI1rQgDgR+K4jWtCAOCT/7iNa0IA4N8cuY1rQgDgKzq5jWtCAOB3V7mNa0IA4MN0uY1rQgDgD5K5jWtCAOBbr7mNa0IA4KfMuY1rQgDg8+m5jWtCAOA/B7qNa0IA4Iskuo1rQgDg10G6jWtCAOAjX7qNa0IA4G98uo1rQgDgu5m6jWtCAOAHt7qNa0IA4FPUuo1rQgDgn/G6jWtCAODrDruNa0IA4Dcsu41rQgDgg0m7jWtCAODPZruNa0IA4BuEu41rQgDgZ6G7jWtCAOCzvruNa0IA4P/bu41rQgDgS/m7jWtCAOCXFryNa0IA4OMzvI1rQgDgL1G8jWtCAOB7bryNa0IA4MeLvI1rQgDgE6m8jWtCAOBfxryNa0IA4KvjvI1rQgDg9wC9jWtCAOBDHr2Na0IA4I87vY1rQgDg21i9jWtCAOAndr2Na0IA4HOTvY1rQgDgv7C9jWtCAOALzr2Na0IA4FfrvY1rQgDgowi+jWtCAODvJb6Na0IA4DtDvo1rQgDgh2C+jWtCAODTfb6Na0IA4B+bvo1rQgDga7i+jWtCAOC31b6Na0IA4APzvo1rQgDgTxC/jWtCAOCbLb+Na0IA4OdKv41rQgDgM2i/jWtCAOB/hb+Na0IA4Muiv41rQgDgF8C/jWtCAOBj3b+Na0IA4K/6v41rQgDg+xfAjWtCAOBHNcCNa0IA4JNSwI1rQgDg32/AjWtCAOArjcCNa0IA4HeqwI1rQgDgw8fAjWtCAOAP5cCNa0IA4FsCwY1rQgDgpx/BjWtCAODzPMGNa0IA4D9awY1rQgDgi3fBjWtCAODXlMGNa0IA4COywY1rQgDgb8/BjWtCAOC77MGNa0IA4AcKwo1rQgDgUyfCjWtCAOCfRMKNa0IA4Othwo1rQgDgN3/CjWtCAOCDnMKNa0IA4M+5wo1rQgDgG9fCjWtCAOBn9MKNa0IA4LMRw41rQgDg/y7DjWtC\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Sun Probe Earth angle (deg)\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"AqM+4PAHWEBJ99DcUTBXQO3HgyFHWVZAoN7p396CVUBYe/iIJq1UQIcL9lMr2FNA4dMQyfoDU0BTtLFXozBSQLbCzwA1XlFAPDlgH8KMUEAXaDi6wHhPQKw9WslT2k1A6Of01X0+TECqTzZkj6VKQIZxBG/uD0lAslMnrB1+R0APiAGNxvBFQHe6FTTHaERAGgAeMkbnQkDs/2C3zm1BQPM6ay/y/D9AZkQy0kk4PUB420oClpU6QD176szXHzhAB8AHgynmNUAHdlh7qPwzQCEwO0NjfDJAXkJ1bbqAMUCqLDmk5iAxQHrUTXllZzFA+SUZhTVNMkDVAfNqMb0zQE5SmvtqnDVAATLE0UvRN0DtHuWL30Y6QDIVUhBA7TxAa0uAKsi4P0D/F+3lhFBBQJbQcG70z0JAyw8QO3dYRED7ZzjMZuhFQIFKV4KGfkdArFooouUZSUDK1qhbyrlKQBrdLfqiXUxAl4ShTPsETkAS3Bz3dK9PQMAIKeVgrlBAkT29w0+GUUDkEtZSal9SQLfRIeeWOVNAEav57b0UVED7ftMayfBUQKY2RLSizVVAgQvs9DSrVkBfwYB3aYlXQGQ3qaQoaFhAPNE3GllHWUBFJQ8D3yZaQPxR8VObBltAQFFl32rmW0Cp+RMuJcZcQJAE7QCbpV1AuGiRWZSEXkAzQH7SzWJfQC1KZ3z6H2BA58rxmNGNYECjuSY9q/pgQA8x6HUzZmFAA8rRsvvPYUCFyklpbzdiQCeLHCfDm2JAjbX7gNv7YkDcoAIEKVZjQGV1LWJ4qGNA7guqob/vY0DxHKGfCyhkQLozUiLeTGRARmLOaFRaZEB7xqisz05kQGW/mZLWK2RA98PEo0X1Y0DYCH8lpq9jQCUz6JL8XmNAqTvxhWIGY0DOJE2UFqhiQKtvjFKvRWJAIhKZH0zgYUDZiDsfunhhQFNkgvuND2FAiUYiSzWlYEARV+E/AjpgQDaWphJnnF9AfT8cb/PDXkAuzTDt9epdQAmx/V2rEV1AlwgPz0Q4XEAoYnxI6l5bQG15Jta8hVpANIeXEtisWUCTQdJYU9RYQDEDardC/FdAmryht7ckV0CUzYUGwk1WQMCYzApwd1VAhsT4b8+hVECDWpmu7cxTQJDv3ZjY+FJAxZv98p4lUkAYbZAgUVNRQKvjy/ABglBAwpZHMI9jT0DBc1/SecVNQPDJP80FKkxA9sQTo4WRSkAM5BjPYfxIQH4MtTQga0dAl4rDWm7eRUD/8ZiyL1dEQF5VL8SR1kJA3YSe9iheQUB0iyKzM+A/QEsNTV+oHj1AGfVhmMt/OkBnd99j0g44QNax9LMQ2zVAXKizq9P4M0DRBtYlLYEyQEvQOOchjzFAJpRH/BM5MUCp7/WGaYgxQElOPwFNdTJA6iIUm13qM0CDMXfd7cw1QDbR3b7WAzhA6DjOEYx6OkDNM51qdiE9QACOImkm7T9AdHidlqhqQUDAJuqX+OlCQFEtEvhOckRA3eWd0AkCRkANTmx075dHQIx1PQwRM0lAbEsd/rXSSkACKuNZTXZMQMe4/2djHU5AUDdqE5rHT0DG7ZioUbpQQHmiGnceklFAkah8rRZrUkCWM/OVIEVTQOgBJI0kIFRAeLQrMAz8VEByyEipwdhVQAez0RAvtlZArC6k1z2UV0BTTMQz1nJYQGFSEIbeUVlA5ko9rzoxWkAY12BJyxBbQPFWV7ds8FtASSn79vXPXEABvtobN69dQNA7TEz3jV5AmRbJCvJrX0BLXrC9aSRgQPe4PpYZkmBA0JdvVsb+YEBZdjlsGmphQHnUixel02FAkpi41M46YkBqO4MkyJ5iQA2o2SNw/mJAWJU7PDBYY0DX1IORzKljQGHxNvsy8GNAY39Zh20nZEArfbQwCUtkQI3d+HpCV2RA6SsYm6RKZECjYVSZ0yZkQNRdy/qv72NAAX9PrrWpY0CBJyf511hjQMPmDWwiAGNA7AwTB8qhYkDFYW1SXz9iQJLnT/z92WFA2Zpp73ByYUC6s6iASwlhQDVpTHv6nmBAuqsrmc8zYEDobGmKEpBfQAbwftWvt15Abnb2ScPeXUDtOfOwiQVdQPhCiyA0LFxAkrKotOpSW0BuL9CUznlaQB4Gonz7oFlA\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Sun_Probe_Earth_angle_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"AqM+4PAHWEBJ99DcUTBXQO3HgyFHWVZAoN7p396CVUBYe/iIJq1UQIcL9lMr2FNA4dMQyfoDU0BTtLFXozBSQLbCzwA1XlFAPDlgH8KMUEAXaDi6wHhPQKw9WslT2k1A6Of01X0+TECqTzZkj6VKQIZxBG/uD0lAslMnrB1+R0APiAGNxvBFQHe6FTTHaERAGgAeMkbnQkDs/2C3zm1BQPM6ay/y/D9AZkQy0kk4PUB420oClpU6QD176szXHzhAB8AHgynmNUAHdlh7qPwzQCEwO0NjfDJAXkJ1bbqAMUCqLDmk5iAxQHrUTXllZzFA+SUZhTVNMkDVAfNqMb0zQE5SmvtqnDVAATLE0UvRN0DtHuWL30Y6QDIVUhBA7TxAa0uAKsi4P0D/F+3lhFBBQJbQcG70z0JAyw8QO3dYRED7ZzjMZuhFQIFKV4KGfkdArFooouUZSUDK1qhbyrlKQBrdLfqiXUxAl4ShTPsETkAS3Bz3dK9PQMAIKeVgrlBAkT29w0+GUUDkEtZSal9SQLfRIeeWOVNAEav57b0UVED7ftMayfBUQKY2RLSizVVAgQvs9DSrVkBfwYB3aYlXQGQ3qaQoaFhAPNE3GllHWUBFJQ8D3yZaQPxR8VObBltAQFFl32rmW0Cp+RMuJcZcQJAE7QCbpV1AuGiRWZSEXkAzQH7SzWJfQC1KZ3z6H2BA58rxmNGNYECjuSY9q/pgQA8x6HUzZmFAA8rRsvvPYUCFyklpbzdiQCeLHCfDm2JAjbX7gNv7YkDcoAIEKVZjQGV1LWJ4qGNA7guqob/vY0DxHKGfCyhkQLozUiLeTGRARmLOaFRaZEB7xqisz05kQGW/mZLWK2RA98PEo0X1Y0DYCH8lpq9jQCUz6JL8XmNAqTvxhWIGY0DOJE2UFqhiQKtvjFKvRWJAIhKZH0zgYUDZiDsfunhhQFNkgvuND2FAiUYiSzWlYEARV+E/AjpgQDaWphJnnF9AfT8cb/PDXkAuzTDt9epdQAmx/V2rEV1AlwgPz0Q4XEAoYnxI6l5bQG15Jta8hVpANIeXEtisWUCTQdJYU9RYQDEDardC/FdAmryht7ckV0CUzYUGwk1WQMCYzApwd1VAhsT4b8+hVECDWpmu7cxTQJDv3ZjY+FJAxZv98p4lUkAYbZAgUVNRQKvjy/ABglBAwpZHMI9jT0DBc1/SecVNQPDJP80FKkxA9sQTo4WRSkAM5BjPYfxIQH4MtTQga0dAl4rDWm7eRUD/8ZiyL1dEQF5VL8SR1kJA3YSe9iheQUB0iyKzM+A/QEsNTV+oHj1AGfVhmMt/OkBnd99j0g44QNax9LMQ2zVAXKizq9P4M0DRBtYlLYEyQEvQOOchjzFAJpRH/BM5MUCp7/WGaYgxQElOPwFNdTJA6iIUm13qM0CDMXfd7cw1QDbR3b7WAzhA6DjOEYx6OkDNM51qdiE9QACOImkm7T9AdHidlqhqQUDAJuqX+OlCQFEtEvhOckRA3eWd0AkCRkANTmx075dHQIx1PQwRM0lAbEsd/rXSSkACKuNZTXZMQMe4/2djHU5AUDdqE5rHT0DG7ZioUbpQQHmiGnceklFAkah8rRZrUkCWM/OVIEVTQOgBJI0kIFRAeLQrMAz8VEByyEipwdhVQAez0RAvtlZArC6k1z2UV0BTTMQz1nJYQGFSEIbeUVlA5ko9rzoxWkAY12BJyxBbQPFWV7ds8FtASSn79vXPXEABvtobN69dQNA7TEz3jV5AmRbJCvJrX0BLXrC9aSRgQPe4PpYZkmBA0JdvVsb+YEBZdjlsGmphQHnUixel02FAkpi41M46YkBqO4MkyJ5iQA2o2SNw/mJAWJU7PDBYY0DX1IORzKljQGHxNvsy8GNAY39Zh20nZEArfbQwCUtkQI3d+HpCV2RA6SsYm6RKZECjYVSZ0yZkQNRdy/qv72NAAX9PrrWpY0CBJyf511hjQMPmDWwiAGNA7AwTB8qhYkDFYW1SXz9iQJLnT/z92WFA2Zpp73ByYUC6s6iASwlhQDVpTHv6nmBAuqsrmc8zYEDobGmKEpBfQAbwftWvt15Abnb2ScPeXUDtOfOwiQVdQPhCiyA0LFxAkrKotOpSW0BuL9CUznlaQB4Gonz7oFlA\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Latitude_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"dug+fFvfJEAGkg8G6MUlQBUnydLDliZA5u/1b0VRJ0AXwyLI2vQnQBa6h3gJgShAmAzECG/1KEB/ZfYBwVEpQEbnxePMlSlA58lm9nfBKUChdhn5vtQpQElpE661zylAAmQiRYayKUDI7KqncH0pQPUoHanJMClAa/e6H/rMKEBp41rqfVIoQLmmrOfiwSdA0aZt5McbJ0B1lUqF22AmQAVDgjHbkSVAPlMzA5KvJEByTEjB17ojQOL+xOaPtCJAnQTPuqidIUCkmKt7GncgQNrHOT3Ngx5Ai2DkSi7+G0DHXCUVfF8ZQMF3hIXpqRZATBJkp7ffE0D45HP8NAMRQMQE6uV5LQxAowYZ8245BkCUpBVUMS8AQDleSgqCJ/Q/pvJqfaph3z8gMdiwHRLSv7iiznrL5PC/JrY+9609/b/FxRYpKcIEwOKBTNDa1grADbbdhKxrEMBVW5PbAF8TwJJFAiuTQhbAOlg6vocTGcA9qJqKAM8bwElg9rMfch7AvgWVPwV9IMD3UPFa9rEhwB6scT5+1iLAi1qkTT/pI8C29COW5egkwD5huVgp1CXAYEUNu9GpJsDWz++Yt2gnwNgSb2jIDyjAdhj5IgmeKMBKrkIkmRIpwO3sau20bCnAZZEEu7irKcAg0oXcIs8pwORoV7yV1inAI3rMidnBKcDTchV43ZApwDfBy4i4QynAPY/326naKMDXXDeDGFYowDaW3NmStifA5xIoZ838JsCOozNToSkmwPlvlXoKPiXAyWAHLiU7JMBI41ytKyIjwMR1z21z9CHAqLrTO2qzIMBugYqNJsEewAdqAUsI+xvAUayPwsMXGcB6oQgevBoWwHBLpgRoBxPAU60agZjCD8AjkedY7VcJwHRCHOHy1QLAienxRJqH+L/ULkN5XqLmvyYnVEtKlL4/QxUWKbIz7j9OXJou4TL8Pz4pPb57kwRACMVkjIT0CkCVgbwDGJsQQJ3rckUrqRNA5Q/xLYShFkAwCEz/SIEZQKQOWizARRxAeoDLUVLsHkAgEMcMRrkgQGYfVgQQ6yFAAYMjG3QKI0Dvs8f0cxYkQFCEW40mDiVApq8v6bjwJUAI2fewbr0mQLjQXbeicydAy38qZccSKEBQYNQIZ5ooQHPM5AYkCilAhtUS6bhhKUC1S09K+KApQG9pQ5/MxylASgXt2jfWKUBc6XXwUswpQGrJ/TNNqilA904EnWtwKUBshOrtBx8pQLv8mMSPtihALpj6mIM3KED8FjGudaInQGC4qvsI+CZAmpk8E/A4JkClkFEJ7GUlQK12h2PLfyRA3NU/EmmHI0Dc54p4q30iQMmvcoWDYyFAVRVT4es5IECZc05g0AMeQK/j8tQIeRtAsIQJmajVGECRHTG35RsWQJnZhAAEThNAwpyzZ1RuEEDAp8j6aP4KQJcV2BMcBgVAsUox8Vrx/T/q1FefP7bxP6B7SoNklNU/RUKJzOPe27/il9aGq1Xzvwo2ZIsJqv+/0NYm/fr0BcAfYdtGNwUMwC48GNMTABHACi66yBXwE8Dh4Axry88WwPcChJVanBnAsfVrQedSHMDsLxcXlvAewDPtY7ZHuSDA2HrKWwHrIcC5Hws3FQwjwIhIdS0oGyTArIxmLOkWJcBPz/61E/4lwImg35VyzybAdWF9suKJJ8CRL0TwVSwowNwVqhfWtSjAEOUgroclKcBUqlSxrHopwPQD8CKntCnAHN+sU/vSKcAjK1DdUdUpwM0v3Tx5uynApXoBAWeFKcCPboKDODMpwI2tOCgzxSjARUwBIMQ7KMCbvWaxf5cnwKhsGQ0g2SbAGU9It4MBJsBz4miRqxElwGD7VJK4CiTA+2luPOntIsCEgNbglrwhwO3kMMAyeCDANh8ML4ZEHsC5Xp9OwHgbwK3hKoNikBjARP890NOOFcA6lcAIjncSwBN82f4wnA7Apqf4/QUsCMBSNh0jwqUBwKjbwGEWIfa/c6DAofXN4b/4G0I+4FLRP94bVQwchPE/6aJFDIiZ/j8vA8MGzsMFQKzLAiSmIAxANoG85HouEUAZJ1lJTTkUQM1bjnLVLRdAH/gXKD0JGkA8bSHbzsgcQPs96qT3aR9AboO2liT1IEA6u4++vSMiQNZvrVu3PyNA\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Longitude_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"ic2IcvztU0BRDFq0s8FUQKfJSGRllVVAlEmkNQppVkDEFJcmmTxXQLzx+rMHEFhAGnKKFUrjWEAkjrGAU7ZZQLW08HAWiVpA5Cus9IRbW0BBtvL7kC1cQGxJkKgs/1xAVNG7nErQXUDaqyNH3qBeQKTlJyvccF9AcpbGER0gYECe1hrPd4dgQJHCYuh67mBApw9T8iNVYUAyxVuNcbthQEduGHNjIWJADVtFf/qGYkDj/Iq0OOxiQCejRT0hUWNAiht0aLi1Y0A2NTejAxpkQHr7I28JfmRAoE/SVdHhZEC1GNPZY0VlQOJKgWXKqGVASenpNw8MZkBwIOJPPW9mQDqSqVVg0mZARhwRg4Q1Z0DjKUqKtphnQNL9m3sD/GdAmUGiqXhfaEBN53SMI8NoQKsFcqMRJ2lA69KuVVCLaUDQCFnR7O9pQF/YkOnzVGpAmrMx83G6akAlWm+gciBrQEkQnNsAh2tAzHJMoSbua0BN813a7FVsQPeSKzZbvmxAkL/iBXgnbUD4gY0ZSJFtQCjNt5/O+21AAtTNCA1nbkDmZDLvAtNuQDrxOwWuP29AgHcOCgqtb0DGS15jiA1wQLAtHQrdRHBAlrpx9X18cEAmZS0+ZbRwQPa2wiuM7HBAQfQ+S+skcUCkbfSKel1xQP/sFloxlnFA0CLnywbPcUDC6TK98QdyQPAhQvvoQHJAcMQXa+N5ckDM7eUv2LJyQFTHgc++63JABMr1U48kc0BDr1RpQl1zQF9x83bRlXNAKpa2szbOc0C2gBo1bQZ0QI8Q2vhwPnRAtolC6T52dECwH6jc1K10QHeWKpAx5XRAQYotnlQcdUB1D4JxPlN1QPitXzXwiXVAPBjqwmvAdUCIEOOMs/Z1QGwJ+InKLHZAoLArHrRidkB3kurMA3T4P3iRERWNgxNA6gh3MNpwIECaqDfgQRwnQKSOqJmDxC1A4y6oKRE1MkBXmPvFzYY1QIgh84Sy1zhAD5j/ZPUnPEDSN7GRxnc/QCdBVsqnY0FAyM4GU1kLQ0B2JskPBbNEQJ3NXQq0WkZAZ0nGCGsCSEDRJAWBKqpJQCUOj6HuUUtAWkHZbq/5TEBsEdD1YKFOQL3UPMl5JFBANzIfJSr4UEBVGeubtstRQF0zggMTn1JAFGX+PjJyU0C3a12IBkVUQJ7EWr6BF1VAroP9s5XpVUCO57qANLtWQM96CM9QjFdAWlgwKN5cWEBLV2k70SxZQFZnVR8g/FlAt55xjMLKWkDK/NkPsphbQD26qjXqZVxAHE2kqmgyXUBJcd1ULf5dQFhI8GM6yV5ADdWHWJSTX0DEcgICoS5gQNtQXUAmk2BAsGSQkV/3YEB3CJqyU1thQM3TCWYKv2FASLZ9ZIwiYkBoFuhK44ViQDhUAocZ6WJAVlgJQjpMY0DeQBRKUa9jQNqU6vlqEmRAS62pH5R1ZEDX5Sji2dhkQI/pIqVJPGVAD2Aa7PCfZUC58AU83QNmQCJVy/sbaGZA6+E4U7rMZkDtSgMJxTFnQEflU19Il2dA1cB+70/9Z0CjjMWE5mNoQF/cm/YVy2hA8cDLAucyaUDv1A0oYZtpQOB8sYGKBGpAUrU6pWduakBAILWC+9hqQLmA3khHRGtAMkhTTkqwa0AnpJEAAh1sQEAcbNppimxACks8Ynv4bEC1XWsxLmdtQAzRuAV41m1ArmZz3ExGbkDC3foXn7ZuQP4HB69fJ29ATrAHZX6Yb0DKykgF9QRwQKhuBWLIPXBAxJ57KrB2cEA6zfE2o69wQOJCN32Y6HBAtwqiNochcUASQxkEZ1pxQKS9+g4wk3FAEo0WJtvLcUA9RSjWYQRyQKtyTX2+PHJAEJ0dWex0ckCjw4WP56xyQCQpWjKt5HJArMwBPjscc0APEZeTkFNzQMD74u6sinNA7Cv82JDBc0CzT+eXPfhzQJ/gyxu1LnRAXx5x6vlkdECRtmAJD5t0QAEQPuf30HRAIhq3RLgGdUBU5VIdVDx1QGuYp5DPcXVAXdELzC6ndUBTvx31ddx1QEMUShWpEXZARvWNBsxGdkBZnZlh4nt2QEPAKcC2dwhA9V9xToR9GUCtCWPdGF8jQHZQ6Csy/ylAtHLqOJ9PMEBG06qprp8zQB9A+qTO7zZA\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}]]}}},\"view\":{\"type\":\"object\",\"name\":\"CDSView\",\"id\":\"p2761\",\"attributes\":{\"filter\":{\"type\":\"object\",\"name\":\"AllIndices\",\"id\":\"p2762\"}}},\"glyph\":{\"type\":\"object\",\"name\":\"Line\",\"id\":\"p2757\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Epoch\"},\"y\":{\"type\":\"field\",\"field\":\"Sun Probe Earth angle (deg)\"},\"line_color\":\"#30a2da\",\"line_width\":2}},\"selection_glyph\":{\"type\":\"object\",\"name\":\"Line\",\"id\":\"p2763\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Epoch\"},\"y\":{\"type\":\"field\",\"field\":\"Sun Probe Earth angle (deg)\"},\"line_color\":\"#30a2da\",\"line_width\":2}},\"nonselection_glyph\":{\"type\":\"object\",\"name\":\"Line\",\"id\":\"p2758\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Epoch\"},\"y\":{\"type\":\"field\",\"field\":\"Sun Probe Earth angle (deg)\"},\"line_color\":\"#30a2da\",\"line_alpha\":0.1,\"line_width\":2}},\"muted_glyph\":{\"type\":\"object\",\"name\":\"Line\",\"id\":\"p2759\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Epoch\"},\"y\":{\"type\":\"field\",\"field\":\"Sun Probe Earth angle (deg)\"},\"line_color\":\"#30a2da\",\"line_alpha\":0.2,\"line_width\":2}}}}],\"toolbar\":{\"type\":\"object\",\"name\":\"Toolbar\",\"id\":\"p2717\",\"attributes\":{\"tools\":[{\"type\":\"object\",\"name\":\"WheelZoomTool\",\"id\":\"p2706\",\"attributes\":{\"tags\":[\"hv_created\"],\"renderers\":\"auto\",\"zoom_together\":\"none\"}},{\"type\":\"object\",\"name\":\"HoverTool\",\"id\":\"p2707\",\"attributes\":{\"tags\":[\"hv_created\"],\"renderers\":[{\"id\":\"p2760\"}],\"tooltips\":[[\"Epoch\",\"@{Epoch}{%F %T}\"],[\"Sun Probe Earth angle (deg)\",\"@{Sun_Probe_Earth_angle_left_parenthesis_deg_right_parenthesis}\"],[\"Latitude (deg)\",\"@{Latitude_left_parenthesis_deg_right_parenthesis}\"],[\"Longitude (deg)\",\"@{Longitude_left_parenthesis_deg_right_parenthesis}\"]],\"formatters\":{\"type\":\"map\",\"entries\":[[\"@{Epoch}\",\"datetime\"]]}}},{\"type\":\"object\",\"name\":\"SaveTool\",\"id\":\"p2742\"},{\"type\":\"object\",\"name\":\"PanTool\",\"id\":\"p2743\"},{\"type\":\"object\",\"name\":\"BoxZoomTool\",\"id\":\"p2744\",\"attributes\":{\"overlay\":{\"type\":\"object\",\"name\":\"BoxAnnotation\",\"id\":\"p2745\",\"attributes\":{\"syncable\":false,\"level\":\"overlay\",\"visible\":false,\"left\":{\"type\":\"number\",\"value\":\"nan\"},\"right\":{\"type\":\"number\",\"value\":\"nan\"},\"top\":{\"type\":\"number\",\"value\":\"nan\"},\"bottom\":{\"type\":\"number\",\"value\":\"nan\"},\"left_units\":\"canvas\",\"right_units\":\"canvas\",\"top_units\":\"canvas\",\"bottom_units\":\"canvas\",\"line_color\":\"black\",\"line_alpha\":1.0,\"line_width\":2,\"line_dash\":[4,4],\"fill_color\":\"lightgrey\",\"fill_alpha\":0.5}}}},{\"type\":\"object\",\"name\":\"ResetTool\",\"id\":\"p2750\"}],\"active_drag\":{\"id\":\"p2743\"},\"active_scroll\":{\"id\":\"p2706\"}}},\"left\":[{\"type\":\"object\",\"name\":\"LinearAxis\",\"id\":\"p2737\",\"attributes\":{\"ticker\":{\"type\":\"object\",\"name\":\"BasicTicker\",\"id\":\"p2738\",\"attributes\":{\"mantissas\":[1,2,5]}},\"formatter\":{\"type\":\"object\",\"name\":\"BasicTickFormatter\",\"id\":\"p2739\"},\"axis_label\":\"Sun Probe Earth angle (deg)\",\"major_label_policy\":{\"type\":\"object\",\"name\":\"AllLabels\",\"id\":\"p2740\"}}}],\"below\":[{\"type\":\"object\",\"name\":\"DatetimeAxis\",\"id\":\"p2720\",\"attributes\":{\"ticker\":{\"type\":\"object\",\"name\":\"DatetimeTicker\",\"id\":\"p2721\",\"attributes\":{\"num_minor_ticks\":5,\"tickers\":[{\"type\":\"object\",\"name\":\"AdaptiveTicker\",\"id\":\"p2722\",\"attributes\":{\"num_minor_ticks\":0,\"mantissas\":[1,2,5],\"max_interval\":500.0}},{\"type\":\"object\",\"name\":\"AdaptiveTicker\",\"id\":\"p2723\",\"attributes\":{\"num_minor_ticks\":0,\"base\":60,\"mantissas\":[1,2,5,10,15,20,30],\"min_interval\":1000.0,\"max_interval\":1800000.0}},{\"type\":\"object\",\"name\":\"AdaptiveTicker\",\"id\":\"p2724\",\"attributes\":{\"num_minor_ticks\":0,\"base\":24,\"mantissas\":[1,2,4,6,8,12],\"min_interval\":3600000.0,\"max_interval\":43200000.0}},{\"type\":\"object\",\"name\":\"DaysTicker\",\"id\":\"p2725\",\"attributes\":{\"days\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]}},{\"type\":\"object\",\"name\":\"DaysTicker\",\"id\":\"p2726\",\"attributes\":{\"days\":[1,4,7,10,13,16,19,22,25,28]}},{\"type\":\"object\",\"name\":\"DaysTicker\",\"id\":\"p2727\",\"attributes\":{\"days\":[1,8,15,22]}},{\"type\":\"object\",\"name\":\"DaysTicker\",\"id\":\"p2728\",\"attributes\":{\"days\":[1,15]}},{\"type\":\"object\",\"name\":\"MonthsTicker\",\"id\":\"p2729\",\"attributes\":{\"months\":[0,1,2,3,4,5,6,7,8,9,10,11]}},{\"type\":\"object\",\"name\":\"MonthsTicker\",\"id\":\"p2730\",\"attributes\":{\"months\":[0,2,4,6,8,10]}},{\"type\":\"object\",\"name\":\"MonthsTicker\",\"id\":\"p2731\",\"attributes\":{\"months\":[0,4,8]}},{\"type\":\"object\",\"name\":\"MonthsTicker\",\"id\":\"p2732\",\"attributes\":{\"months\":[0,6]}},{\"type\":\"object\",\"name\":\"YearsTicker\",\"id\":\"p2733\"}]}},\"formatter\":{\"type\":\"object\",\"name\":\"DatetimeTickFormatter\",\"id\":\"p2734\",\"attributes\":{\"days\":\"%d/%m\"}},\"axis_label\":\"Epoch\",\"major_label_policy\":{\"type\":\"object\",\"name\":\"AllLabels\",\"id\":\"p2735\"}}}],\"center\":[{\"type\":\"object\",\"name\":\"Grid\",\"id\":\"p2736\",\"attributes\":{\"axis\":{\"id\":\"p2720\"},\"grid_line_color\":null}},{\"type\":\"object\",\"name\":\"Grid\",\"id\":\"p2741\",\"attributes\":{\"dimension\":1,\"axis\":{\"id\":\"p2737\"},\"grid_line_color\":null}}],\"min_border_top\":10,\"min_border_bottom\":10,\"min_border_left\":10,\"min_border_right\":10,\"output_backend\":\"webgl\"}},{\"type\":\"object\",\"name\":\"Spacer\",\"id\":\"p2765\",\"attributes\":{\"name\":\"HSpacer04012\",\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"id\":\"p2699\"},{\"id\":\"p2697\"},{\"id\":\"p2698\"}],\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\"}}]}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"copy_to_clipboard1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"c4d768b9-cc45-4f15-b361-986c2a46aa8c\",\"roots\":{\"p2696\":\"a9b07ef4-1563-4f6b-82f6-d1775f043b78\"},\"root_ids\":[\"p2696\"]}];\n",
+       "  var docs = Object.values(docs_json)\n",
+       "  if (!docs) {\n",
+       "    return\n",
+       "  }\n",
+       "  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')\n",
+       "  function embed_document(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "    for (const render_item of render_items) {\n",
+       "      for (const root_id of render_item.root_ids) {\n",
+       "\tconst id_el = document.getElementById(root_id)\n",
+       "\tif (id_el.children.length && (id_el.children[0].className === 'bk-root')) {\n",
+       "\t  const root_el = id_el.children[0]\n",
+       "\t  root_el.id = root_el.id + '-rendered'\n",
+       "\t}\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "  function get_bokeh(root) {\n",
+       "    if (root.Bokeh === undefined) {\n",
+       "      return null\n",
+       "    } else if (root.Bokeh.version !== py_version) {\n",
+       "      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {\n",
+       "\treturn null\n",
+       "      }\n",
+       "      return root.Bokeh.versions.get(py_version);\n",
+       "    } else if (root.Bokeh.version === py_version) {\n",
+       "      return root.Bokeh\n",
+       "    }\n",
+       "    return null\n",
+       "  }\n",
+       "  function is_loaded(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    return (Bokeh != null && Bokeh.Panel !== undefined)\n",
+       "  }\n",
+       "  if (is_loaded(root)) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    var attempts = 0;\n",
+       "    var timer = setInterval(function(root) {\n",
+       "      if (is_loaded(root)) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else if (document.readyState == \"complete\") {\n",
+       "        attempts++;\n",
+       "        if (attempts > 200) {\n",
+       "          clearInterval(timer);\n",
+       "\t  var Bokeh = get_bokeh(root)\n",
+       "\t  if (Bokeh == null || Bokeh.Panel == null) {\n",
+       "            console.warn(\"Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing\");\n",
+       "\t  } else {\n",
+       "\t    console.warn(\"Panel: WARNING: Attempting to render but not all required libraries could be resolved.\")\n",
+       "\t    embed_document(root)\n",
+       "\t  }\n",
+       "        }\n",
+       "      }\n",
+       "    }, 25, root)\n",
+       "  }\n",
+       "})(window);</script>"
+      ],
+      "text/plain": [
+       ":Curve   [Epoch]   (Sun Probe Earth angle (deg),Latitude (deg),Longitude (deg))"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {
+      "application/vnd.holoviews_exec.v0+json": {
+       "id": "p2696"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import hvplot.polars\n",
+    "from bokeh.models.formatters import DatetimeTickFormatter\n",
+    "\n",
+    "formatter = DatetimeTickFormatter(days='%d/%m') # Make the world a better place\n",
+    "\n",
+    "df.hvplot(x=\"Epoch\", y=\"Sun Probe Earth angle (deg)\", xformatter=formatter, \n",
+    "          title=\"Sun probe Earth angle over time\", hover_cols=[\"Latitude (deg)\", \"Longitude (deg)\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "abb43538-5c41-4481-96dc-eefcb36764a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {},
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.holoviews_exec.v0+json": "",
+      "text/html": [
+       "<div id='p2520'>\n",
+       "  <div id=\"b83cf433-199e-4405-83c3-69b1578a0d1d\" data-root-id=\"p2520\" style=\"display: contents;\"></div>\n",
+       "</div>\n",
+       "<script type=\"application/javascript\">(function(root) {\n",
+       "  var docs_json = {\"24340461-f171-489f-80b9-24867c79915b\":{\"version\":\"3.3.3\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"Row\",\"id\":\"p2520\",\"attributes\":{\"name\":\"Row03735\",\"tags\":[\"embedded\"],\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2523\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/css/loading.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2608\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/css/listpanel.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2521\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/bundled/theme/default.css\"}},{\"type\":\"object\",\"name\":\"ImportedStyleSheet\",\"id\":\"p2522\",\"attributes\":{\"url\":\"https://cdn.holoviz.org/panel/1.3.6/dist/bundled/theme/native.css\"}}],\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\",\"children\":[{\"type\":\"object\",\"name\":\"Spacer\",\"id\":\"p2524\",\"attributes\":{\"name\":\"HSpacer03741\",\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"id\":\"p2523\"},{\"id\":\"p2521\"},{\"id\":\"p2522\"}],\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\"}},{\"type\":\"object\",\"name\":\"Figure\",\"id\":\"p2553\",\"attributes\":{\"width\":null,\"height\":null,\"margin\":[5,10],\"sizing_mode\":\"fixed\",\"align\":\"start\",\"x_range\":{\"type\":\"object\",\"name\":\"Range1d\",\"id\":\"p2534\",\"attributes\":{\"tags\":[[[\"Longitude\",\"Longitude\",null]],[]],\"start\":-19981848.59739268,\"end\":19981848.59739268,\"reset_start\":-19981848.59739268,\"reset_end\":19981848.59739268,\"min_interval\":5}},\"y_range\":{\"type\":\"object\",\"name\":\"Range1d\",\"id\":\"p2535\",\"attributes\":{\"tags\":[[[\"Latitude\",\"Latitude\",null]],{\"type\":\"map\",\"entries\":[[\"invert_yaxis\",false],[\"autorange\",false]]}],\"start\":-8399737.667179434,\"end\":8399737.667179434,\"reset_start\":-8399737.667179434,\"reset_end\":8399737.667179434,\"min_interval\":5}},\"x_scale\":{\"type\":\"object\",\"name\":\"LinearScale\",\"id\":\"p2563\"},\"y_scale\":{\"type\":\"object\",\"name\":\"LinearScale\",\"id\":\"p2564\"},\"title\":{\"type\":\"object\",\"name\":\"Title\",\"id\":\"p2556\",\"attributes\":{\"text_color\":\"black\",\"text_font_size\":\"12pt\"}},\"renderers\":[{\"type\":\"object\",\"name\":\"TileRenderer\",\"id\":\"p2586\",\"attributes\":{\"level\":\"underlay\",\"tile_source\":{\"type\":\"object\",\"name\":\"WMTSTileSource\",\"id\":\"p2582\",\"attributes\":{\"url\":\"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg\",\"attribution\":\"&copy; <a href=\\\"http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf\\\">Esri</a>, Earthstar Geographics\"}}}},{\"type\":\"object\",\"name\":\"GlyphRenderer\",\"id\":\"p2599\",\"attributes\":{\"data_source\":{\"type\":\"object\",\"name\":\"ColumnDataSource\",\"id\":\"p2590\",\"attributes\":{\"selected\":{\"type\":\"object\",\"name\":\"Selection\",\"id\":\"p2591\",\"attributes\":{\"indices\":[],\"line_indices\":[]}},\"selection_policy\":{\"type\":\"object\",\"name\":\"UnionRenderers\",\"id\":\"p2592\"},\"data\":{\"type\":\"map\",\"entries\":[[\"Longitude (deg)\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"h62aUB7tYEHdf83C7aBhQfIx/3m4VGJBqnUbQ3gIY0Hm3cl3JbxjQfRcciq3b2RB8ZpcWSMjZUGT6G4nX9ZlQRCvqBlfiWZB84xeWBc8Z0Hv3yHye+5nQS5Vwh+BoGhBCFEghxtSaUHEhcN7QANqQVS3Mjzms2pBnX2ZKgRka0GkGYH/khNsQRQFhvaMwmxBMU+58+1wbUHw9fChsx5uQTFqm4ndy25B1uL2H214b0EQFJvnMhJwQe7s6XvmZ3BBCTOu9VS9cEEpXrHwghJxQbPHh/N1Z3FBak7/ZDS8cUGesFl/xRByQfV/tEExZXJBvsHRX4C5ckH83VQwvA1zQTJZNPEB1nLBZ06yjM6BcsF4Tblkjy1ywTdk/WA52XHBoirdMMGEccFPGOFjGzBxwQYgZIM823DBcDNhLRmGcMHfbycwpjBwwS18tU6xtW/BO+O4M0wJb8EJ82QxCVxuwUcNSr3VrW3BozjM4KD+bMENGaR5W05swZRbEXr4nGvBPrUjJ23qasHkDR1UsTZqwVN8Zpm/gWnBkHIyhZXLaMGk9xrEMxRowSDauT+eW2fBsKOYMdyhZsGU7xAo+OZlwS7QMfz/KmXBkShhtwRuZMF062hnGrBjwdZUWeFX8WLB5Mx7c9YxYsG011aHsXFhwTl8SjYGsWDBCqArpOXfX8EV4OHKLF1ewRLCoF8g2lzBH6cUQP5WW8Fu52ijAtRZwRUPmyJnUVjBZv9h1GHPVsHvEouCJE5VwRLak/7bzVPBNp25l69OUsF3Vda0wNBQwaeLnCVVqE7BqddQTgSyS8GgDIRHrL5IwaSetTRezkXBENmqeh/hQsGyjcHb1O0/wf6hrlheHzrBBFRQMalWNMHBUMu35SYtwfG1x5rVqiHBJv+9+qbhCMEPJ3vwocQEQaFyfh65kiBBtKkVvyjtK0FYOY3graAzQThTj+AaSDlBPeunmUrtPkFvFJDQU0hCQR/lzv5KGUVBTZ73srjpR0Hwnz3WxblKQdfZyK+ViU1B4w7Ip6IsUEFzNl6LdZRRQdPkuC9L/FJBZrWxoidkVEEHe4JIC8xVQY2v8OLyM1dBjZxnqtebWEHrEtR4rwNaQT4bogVta1tBnUdqMgDTXEGEW5tmVjpeQRCQkPhaoV9BJQsh0fuDYEFJBTR/CjdhQcWzW4bN6WFBZbmB3DicYkFA6K2xQE5jQX8xwbLZ/2NBjn3cSfmwZEFwFcLalWFlQa5PdfqmEWZBhSTcoCXBZkGOe9xTDHBnQfR+WktXHmhBh8vKjQTMaEG4visFFHlpQY2FwoyHJWpBBjiF92LRakFXfc0PrHxrQRicwJBqJ2xB7NW8GajRbEH4Z9UccHttQdv2acjPJG5BJpfN7NXNbkEDwireknZvQZ6ApimMD3BB1FnBoLxjcEF4dQ/b5LdwQe8bt1YPDHFBbt/S80ZgcUFJVtjdlrRxQY1l83MKCXJBnddNMK1dckE9Z02OirJyQSLOzu+tB3NBg73eCc7acsF2Oftu/YRywUPzQGHGLnLBAO7VBh/YccEgfOQ0/oBxwSdCp49bKXHBQyCQqi/RcMEKDg0odHhwwc/HZdgjH3DBLwffrXWKb8FJv+dJbdVuwUwtqYIsH27Bn67cd7RnbcFgqAyICa9swaxBzmAz9WvB2urQAT06a8FunRKwNH5qwQBlh9grwWnBMuXb4TYDacFE3L/sbERowYDVl4PnhGfBBiC7OsLEZsGB0gRDGgRmwUrzx/ENQ2XBcvfoQLyBZMFPuoJKRMBjwUlmWsTE/mLB6ozOfls9YsHBfmfqJHxhwedWFag7u2DB1Yd0TXD1X8FrbAygYHVewfLdsIxu9lzBPbu8abp4W8EcCfliXvxZwcQ+XGFugVjBSPQTFPgHV8FMOmsYA5BVwV2S3D2RGVTB5//44J6kUsF9DqdaIzFRwW72qP8ifk/BPIKnWbCcTMGYa9Wzxb1JwVu8jWo04UbBuShUf8kGRMEOTP/TTi5BwRuczMAYrzzBctgCw5IEN8Ecf2T6mlwxwfe63WGHbSfBBLQ/55BKGMG639u6tfbbwMc6OS/GxxRBgQ3knB+mJUF5B4xDw3MwQcsD85FCFDZBdkKUzra0O0EjgHVsnapAQateCn7tekNB\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Latitude (deg)\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"TA4yS2vTMUFQm78WqpoyQTcZiptsTzNB2IDPWQ7xM0HB0PQh/340QehrIQfE+DRBR8h1LfhdNUH5c/FrTa41QRMe4ruM6TVB9Lz4cJYPNkGU+I02YiA2QVNeBdH+GzZBVpjIo5ECNkHFDq3+VdQ1QQc5JDeckTVBgpVCk8g6NUGE6TgOUtA0QZJvYP7AUjRBoAE1pq3CM0EkmTS5viAzQbex592nbTJBGhwBNiiqMUF9/lX0CNcwQZqemg846i9Bt5H6wnUKLkEOkTa1ihAsQQ7W/3tB/ilBBCvu7m3VJ0EiU+/U65clQZ/0EeCdRyNBmw/+9WzmIEEeNYSEj+wcQcr9TxhF8hdBH5l0lO7hEkE6W2+sF38LQWLMsSRTHgFBSLYYDRSn6kAKL6OP9LHewNmHB9uDsvzAku8YF6vWCMErD9is3KIRwTxwEqrBzhbBiawm63rqG8G/NdLxtHggweG849Zt7yLB4cXjNgVXJcF1nIjPD60nwTkdarMb7ynBlPehhLIaLMFf9e9JXC0uwWzeg3JREjDBOBY/Fgv/MMFLz5lSqNsxwSJDqGj+pjLBYgaDge1fM8F7lsvNYwU0we+zhspgljTBepH0l/gRNcGihUtMV3c1wV3dMinExTXBdAp4mqT8NcHuw2jkfhs2wTuZoWn8ITbBs0Jlc+sPNsFVATtrQOU1wfkBSnoWojXB2ue1iK9GNcErJJ6dc9M0wfQx9qbvSDTBDsnttdOnM8Gd9pzB8PAywf/zCwY2JTLBNOJXF65FMcFTVkLCe1MwwdOBcaatny7BA0UMtxF4LMHgIKMR1DIqwaksBUO80ifBunugaaNaJcFhZ+MMb80iwXUcRX0MLiDBGc5ugtn+GsGVAfoaAokVwX0JQYdvABDB7zBerufVBMFnt5DRSDnzwPHuuPuS+MlA7uDdKtSm+UD3+1G79vMHQaq7y7QtexFB9JtBJf7nFkFlayW3PDscQZSOAcHstyBBE+JEfXNAI0GlT69CzrQlQeLub7CsEihBycqM9dNXKkG31bijIIIsQebEza+Ijy5B1EcszQ4/MEHhNw1cByYxQdnuecfV+zFBHjTdHLO/MkGW4J3h6nAzQedZqjPcDjRBKv1w1PqYNEGc01EV0A41QRH2Wp37bzVBn7z4ADS8NUHguEclR/M1Qb4sumoaFTZBqVL4m6ohNkFmeFKgCxk2QefF2vJn+zVBRhBH4f/INUGJ7IqXKII1Qaq/mv5KJzVBe4ImduK4NEFXyORxezc0Qfy1ogOyozNBxEV0WzD+MkFjJENHrUcyQQQxIrrqgDFBf16PY7SqMEEnVq66vIsvQUiPzeuHpi1B01jgN42nK0HPRj7cmZApQWl6XOODYydB6FqR4CgiJUGqnSb7bM4iQaKW30U6aiBBuDn1vgDvG0F/Rn2raPAWQaczq4qh3BFB62X4slhvCUHs+9lKWxb+QDpHBD7lU+JACSGE97ir58Do4VNoEWwAwf/wIk7U5QrBQ7xTLLqnEsG56mk0A9AXwUagq+g65xzBb7f3GmH0IMG2QS4B82cjwVR1tFjwyyXB9RulSu4dKMG267y1e1sqwUiib34jgizB/7cAe2+PLsF/XVMAdkAwwYtYtQkWKjHByfIpGmcDMsFqxbvgQMsywYbvs2uGgDPB7RjQSykiNMF+YaXaLK80wW5foY+pJjXBwLi1TNCHNcGXtEqK7dE1wad2lkhsBDbB6DYhrdgeNsH3m9w04iA2wcOrPWZdCjbB3udV80TbNcFvnANBupM1wapclE4FNDXBDOyf/5O8NMF9ZbLP+C00wZPWpP3oiDPBts0HQTrOMsHjwGkf4P4xwfdxwfnoGzHBtHmD63omMMFuZcAmoT8uweg4nbprEizBewbXwwnIKcE2WgHZRWMnwWSicGv75iTBiEvSthFWIsFTM2lx7mYfwXvls2k7BBrBgYz/he2JFMGTSVCDw/sNwcSmMu/TywLBJnFESUY+7sArzfFwHG3dQDW6tcAswf1ABh72qEH+CUFjmhkx6n0SQQ/YHO5a5xdBYtKQ8EQ2HUFaej1FzTIhQfDIpHA4uCNBvFkGUAEpJkHAfx5/2YIoQRk65JOIwypBA6+WAO7oLEHW/68jA/EuQWmsb7/ubDBB\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Longitude_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"h62aUB7tYEHdf83C7aBhQfIx/3m4VGJBqnUbQ3gIY0Hm3cl3JbxjQfRcciq3b2RB8ZpcWSMjZUGT6G4nX9ZlQRCvqBlfiWZB84xeWBc8Z0Hv3yHye+5nQS5Vwh+BoGhBCFEghxtSaUHEhcN7QANqQVS3Mjzms2pBnX2ZKgRka0GkGYH/khNsQRQFhvaMwmxBMU+58+1wbUHw9fChsx5uQTFqm4ndy25B1uL2H214b0EQFJvnMhJwQe7s6XvmZ3BBCTOu9VS9cEEpXrHwghJxQbPHh/N1Z3FBak7/ZDS8cUGesFl/xRByQfV/tEExZXJBvsHRX4C5ckH83VQwvA1zQTJZNPEB1nLBZ06yjM6BcsF4Tblkjy1ywTdk/WA52XHBoirdMMGEccFPGOFjGzBxwQYgZIM823DBcDNhLRmGcMHfbycwpjBwwS18tU6xtW/BO+O4M0wJb8EJ82QxCVxuwUcNSr3VrW3BozjM4KD+bMENGaR5W05swZRbEXr4nGvBPrUjJ23qasHkDR1UsTZqwVN8Zpm/gWnBkHIyhZXLaMGk9xrEMxRowSDauT+eW2fBsKOYMdyhZsGU7xAo+OZlwS7QMfz/KmXBkShhtwRuZMF062hnGrBjwdZUWeFX8WLB5Mx7c9YxYsG011aHsXFhwTl8SjYGsWDBCqArpOXfX8EV4OHKLF1ewRLCoF8g2lzBH6cUQP5WW8Fu52ijAtRZwRUPmyJnUVjBZv9h1GHPVsHvEouCJE5VwRLak/7bzVPBNp25l69OUsF3Vda0wNBQwaeLnCVVqE7BqddQTgSyS8GgDIRHrL5IwaSetTRezkXBENmqeh/hQsGyjcHb1O0/wf6hrlheHzrBBFRQMalWNMHBUMu35SYtwfG1x5rVqiHBJv+9+qbhCMEPJ3vwocQEQaFyfh65kiBBtKkVvyjtK0FYOY3graAzQThTj+AaSDlBPeunmUrtPkFvFJDQU0hCQR/lzv5KGUVBTZ73srjpR0Hwnz3WxblKQdfZyK+ViU1B4w7Ip6IsUEFzNl6LdZRRQdPkuC9L/FJBZrWxoidkVEEHe4JIC8xVQY2v8OLyM1dBjZxnqtebWEHrEtR4rwNaQT4bogVta1tBnUdqMgDTXEGEW5tmVjpeQRCQkPhaoV9BJQsh0fuDYEFJBTR/CjdhQcWzW4bN6WFBZbmB3DicYkFA6K2xQE5jQX8xwbLZ/2NBjn3cSfmwZEFwFcLalWFlQa5PdfqmEWZBhSTcoCXBZkGOe9xTDHBnQfR+WktXHmhBh8vKjQTMaEG4visFFHlpQY2FwoyHJWpBBjiF92LRakFXfc0PrHxrQRicwJBqJ2xB7NW8GajRbEH4Z9UccHttQdv2acjPJG5BJpfN7NXNbkEDwireknZvQZ6ApimMD3BB1FnBoLxjcEF4dQ/b5LdwQe8bt1YPDHFBbt/S80ZgcUFJVtjdlrRxQY1l83MKCXJBnddNMK1dckE9Z02OirJyQSLOzu+tB3NBg73eCc7acsF2Oftu/YRywUPzQGHGLnLBAO7VBh/YccEgfOQ0/oBxwSdCp49bKXHBQyCQqi/RcMEKDg0odHhwwc/HZdgjH3DBLwffrXWKb8FJv+dJbdVuwUwtqYIsH27Bn67cd7RnbcFgqAyICa9swaxBzmAz9WvB2urQAT06a8FunRKwNH5qwQBlh9grwWnBMuXb4TYDacFE3L/sbERowYDVl4PnhGfBBiC7OsLEZsGB0gRDGgRmwUrzx/ENQ2XBcvfoQLyBZMFPuoJKRMBjwUlmWsTE/mLB6ozOfls9YsHBfmfqJHxhwedWFag7u2DB1Yd0TXD1X8FrbAygYHVewfLdsIxu9lzBPbu8abp4W8EcCfliXvxZwcQ+XGFugVjBSPQTFPgHV8FMOmsYA5BVwV2S3D2RGVTB5//44J6kUsF9DqdaIzFRwW72qP8ifk/BPIKnWbCcTMGYa9Wzxb1JwVu8jWo04UbBuShUf8kGRMEOTP/TTi5BwRuczMAYrzzBctgCw5IEN8Ecf2T6mlwxwfe63WGHbSfBBLQ/55BKGMG639u6tfbbwMc6OS/GxxRBgQ3knB+mJUF5B4xDw3MwQcsD85FCFDZBdkKUzra0O0EjgHVsnapAQateCn7tekNB\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Latitude_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"TA4yS2vTMUFQm78WqpoyQTcZiptsTzNB2IDPWQ7xM0HB0PQh/340QehrIQfE+DRBR8h1LfhdNUH5c/FrTa41QRMe4ruM6TVB9Lz4cJYPNkGU+I02YiA2QVNeBdH+GzZBVpjIo5ECNkHFDq3+VdQ1QQc5JDeckTVBgpVCk8g6NUGE6TgOUtA0QZJvYP7AUjRBoAE1pq3CM0EkmTS5viAzQbex592nbTJBGhwBNiiqMUF9/lX0CNcwQZqemg846i9Bt5H6wnUKLkEOkTa1ihAsQQ7W/3tB/ilBBCvu7m3VJ0EiU+/U65clQZ/0EeCdRyNBmw/+9WzmIEEeNYSEj+wcQcr9TxhF8hdBH5l0lO7hEkE6W2+sF38LQWLMsSRTHgFBSLYYDRSn6kAKL6OP9LHewNmHB9uDsvzAku8YF6vWCMErD9is3KIRwTxwEqrBzhbBiawm63rqG8G/NdLxtHggweG849Zt7yLB4cXjNgVXJcF1nIjPD60nwTkdarMb7ynBlPehhLIaLMFf9e9JXC0uwWzeg3JREjDBOBY/Fgv/MMFLz5lSqNsxwSJDqGj+pjLBYgaDge1fM8F7lsvNYwU0we+zhspgljTBepH0l/gRNcGihUtMV3c1wV3dMinExTXBdAp4mqT8NcHuw2jkfhs2wTuZoWn8ITbBs0Jlc+sPNsFVATtrQOU1wfkBSnoWojXB2ue1iK9GNcErJJ6dc9M0wfQx9qbvSDTBDsnttdOnM8Gd9pzB8PAywf/zCwY2JTLBNOJXF65FMcFTVkLCe1MwwdOBcaatny7BA0UMtxF4LMHgIKMR1DIqwaksBUO80ifBunugaaNaJcFhZ+MMb80iwXUcRX0MLiDBGc5ugtn+GsGVAfoaAokVwX0JQYdvABDB7zBerufVBMFnt5DRSDnzwPHuuPuS+MlA7uDdKtSm+UD3+1G79vMHQaq7y7QtexFB9JtBJf7nFkFlayW3PDscQZSOAcHstyBBE+JEfXNAI0GlT69CzrQlQeLub7CsEihBycqM9dNXKkG31bijIIIsQebEza+Ijy5B1EcszQ4/MEHhNw1cByYxQdnuecfV+zFBHjTdHLO/MkGW4J3h6nAzQedZqjPcDjRBKv1w1PqYNEGc01EV0A41QRH2Wp37bzVBn7z4ADS8NUHguEclR/M1Qb4sumoaFTZBqVL4m6ohNkFmeFKgCxk2QefF2vJn+zVBRhBH4f/INUGJ7IqXKII1Qaq/mv5KJzVBe4ImduK4NEFXyORxezc0Qfy1ogOyozNBxEV0WzD+MkFjJENHrUcyQQQxIrrqgDFBf16PY7SqMEEnVq66vIsvQUiPzeuHpi1B01jgN42nK0HPRj7cmZApQWl6XOODYydB6FqR4CgiJUGqnSb7bM4iQaKW30U6aiBBuDn1vgDvG0F/Rn2raPAWQaczq4qh3BFB62X4slhvCUHs+9lKWxb+QDpHBD7lU+JACSGE97ir58Do4VNoEWwAwf/wIk7U5QrBQ7xTLLqnEsG56mk0A9AXwUagq+g65xzBb7f3GmH0IMG2QS4B82cjwVR1tFjwyyXB9RulSu4dKMG267y1e1sqwUiib34jgizB/7cAe2+PLsF/XVMAdkAwwYtYtQkWKjHByfIpGmcDMsFqxbvgQMsywYbvs2uGgDPB7RjQSykiNMF+YaXaLK80wW5foY+pJjXBwLi1TNCHNcGXtEqK7dE1wad2lkhsBDbB6DYhrdgeNsH3m9w04iA2wcOrPWZdCjbB3udV80TbNcFvnANBupM1wapclE4FNDXBDOyf/5O8NMF9ZbLP+C00wZPWpP3oiDPBts0HQTrOMsHjwGkf4P4xwfdxwfnoGzHBtHmD63omMMFuZcAmoT8uweg4nbprEizBewbXwwnIKcE2WgHZRWMnwWSicGv75iTBiEvSthFWIsFTM2lx7mYfwXvls2k7BBrBgYz/he2JFMGTSVCDw/sNwcSmMu/TywLBJnFESUY+7sArzfFwHG3dQDW6tcAswf1ABh72qEH+CUFjmhkx6n0SQQ/YHO5a5xdBYtKQ8EQ2HUFaej1FzTIhQfDIpHA4uCNBvFkGUAEpJkHAfx5/2YIoQRk65JOIwypBA6+WAO7oLEHW/68jA/EuQWmsb7/ubDBB\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Epoch\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"AACgS6yNa0IAAOxorI1rQgDgN4asjWtCAOCDo6yNa0IA4M/ArI1rQgDgG96sjWtCAOBn+6yNa0IA4LMYrY1rQgDg/zWtjWtCAOBLU62Na0IA4JdwrY1rQgDg442tjWtCAOAvq62Na0IA4HvIrY1rQgDgx+WtjWtCAOATA66Na0IA4F8gro1rQgDgqz2ujWtCAOD3Wq6Na0IA4EN4ro1rQgDgj5WujWtCAODbsq6Na0IA4CfQro1rQgDgc+2ujWtCAOC/Cq+Na0IA4Asor41rQgDgV0WvjWtCAOCjYq+Na0IA4O9/r41rQgDgO52vjWtCAOCHuq+Na0IA4NPXr41rQgDgH/WvjWtCAOBrErCNa0IA4LcvsI1rQgDgA02wjWtCAOBParCNa0IA4JuHsI1rQgDg56SwjWtCAOAzwrCNa0IA4H/fsI1rQgDgy/ywjWtCAOAXGrGNa0IA4GM3sY1rQgDgr1SxjWtCAOD7cbGNa0IA4EePsY1rQgDgk6yxjWtCAODfybGNa0IA4CvnsY1rQgDgdwSyjWtCAODDIbKNa0IA4A8/so1rQgDgW1yyjWtCAOCnebKNa0IA4POWso1rQgDgP7SyjWtCAOCL0bKNa0IA4Nfuso1rQgDgIwyzjWtCAOBvKbONa0IA4LtGs41rQgDgB2SzjWtCAOBTgbONa0IA4J+es41rQgDg67uzjWtCAOA32bONa0IA4IP2s41rQgDgzxO0jWtCAOAbMbSNa0IA4GdOtI1rQgDgs2u0jWtCAOD/iLSNa0IA4EumtI1rQgDgl8O0jWtCAODj4LSNa0IA4C/+tI1rQgDgexu1jWtCAODHOLWNa0IA4BNWtY1rQgDgX3O1jWtCAOCrkLWNa0IA4PettY1rQgDgQ8u1jWtCAOCP6LWNa0IA4NsFto1rQgDgJyO2jWtCAOBzQLaNa0IA4L9dto1rQgDgC3u2jWtCAOBXmLaNa0IA4KO1to1rQgDg79K2jWtCAOA78LaNa0IA4IcNt41rQgDg0yq3jWtCAOAfSLeNa0IA4Gtlt41rQgDgt4K3jWtCAOADoLeNa0IA4E+9t41rQgDgm9q3jWtCAODn97eNa0IA4DMVuI1rQgDgfzK4jWtCAODLT7iNa0IA4BdtuI1rQgDgY4q4jWtCAOCvp7iNa0IA4PvEuI1rQgDgR+K4jWtCAOCT/7iNa0IA4N8cuY1rQgDgKzq5jWtCAOB3V7mNa0IA4MN0uY1rQgDgD5K5jWtCAOBbr7mNa0IA4KfMuY1rQgDg8+m5jWtCAOA/B7qNa0IA4Iskuo1rQgDg10G6jWtCAOAjX7qNa0IA4G98uo1rQgDgu5m6jWtCAOAHt7qNa0IA4FPUuo1rQgDgn/G6jWtCAODrDruNa0IA4Dcsu41rQgDgg0m7jWtCAODPZruNa0IA4BuEu41rQgDgZ6G7jWtCAOCzvruNa0IA4P/bu41rQgDgS/m7jWtCAOCXFryNa0IA4OMzvI1rQgDgL1G8jWtCAOB7bryNa0IA4MeLvI1rQgDgE6m8jWtCAOBfxryNa0IA4KvjvI1rQgDg9wC9jWtCAOBDHr2Na0IA4I87vY1rQgDg21i9jWtCAOAndr2Na0IA4HOTvY1rQgDgv7C9jWtCAOALzr2Na0IA4FfrvY1rQgDgowi+jWtCAODvJb6Na0IA4DtDvo1rQgDgh2C+jWtCAODTfb6Na0IA4B+bvo1rQgDga7i+jWtCAOC31b6Na0IA4APzvo1rQgDgTxC/jWtCAOCbLb+Na0IA4OdKv41rQgDgM2i/jWtCAOB/hb+Na0IA4Muiv41rQgDgF8C/jWtCAOBj3b+Na0IA4K/6v41rQgDg+xfAjWtCAOBHNcCNa0IA4JNSwI1rQgDg32/AjWtCAOArjcCNa0IA4HeqwI1rQgDgw8fAjWtCAOAP5cCNa0IA4FsCwY1rQgDgpx/BjWtCAODzPMGNa0IA4D9awY1rQgDgi3fBjWtCAODXlMGNa0IA4COywY1rQgDgb8/BjWtCAOC77MGNa0IA4AcKwo1rQgDgUyfCjWtCAOCfRMKNa0IA4Othwo1rQgDgN3/CjWtCAOCDnMKNa0IA4M+5wo1rQgDgG9fCjWtCAOBn9MKNa0IA4LMRw41rQgDg/y7DjWtC\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}],[\"Sun_Probe_Earth_angle_left_parenthesis_deg_right_parenthesis\",{\"type\":\"ndarray\",\"array\":{\"type\":\"bytes\",\"data\":\"AqM+4PAHWEBJ99DcUTBXQO3HgyFHWVZAoN7p396CVUBYe/iIJq1UQIcL9lMr2FNA4dMQyfoDU0BTtLFXozBSQLbCzwA1XlFAPDlgH8KMUEAXaDi6wHhPQKw9WslT2k1A6Of01X0+TECqTzZkj6VKQIZxBG/uD0lAslMnrB1+R0APiAGNxvBFQHe6FTTHaERAGgAeMkbnQkDs/2C3zm1BQPM6ay/y/D9AZkQy0kk4PUB420oClpU6QD176szXHzhAB8AHgynmNUAHdlh7qPwzQCEwO0NjfDJAXkJ1bbqAMUCqLDmk5iAxQHrUTXllZzFA+SUZhTVNMkDVAfNqMb0zQE5SmvtqnDVAATLE0UvRN0DtHuWL30Y6QDIVUhBA7TxAa0uAKsi4P0D/F+3lhFBBQJbQcG70z0JAyw8QO3dYRED7ZzjMZuhFQIFKV4KGfkdArFooouUZSUDK1qhbyrlKQBrdLfqiXUxAl4ShTPsETkAS3Bz3dK9PQMAIKeVgrlBAkT29w0+GUUDkEtZSal9SQLfRIeeWOVNAEav57b0UVED7ftMayfBUQKY2RLSizVVAgQvs9DSrVkBfwYB3aYlXQGQ3qaQoaFhAPNE3GllHWUBFJQ8D3yZaQPxR8VObBltAQFFl32rmW0Cp+RMuJcZcQJAE7QCbpV1AuGiRWZSEXkAzQH7SzWJfQC1KZ3z6H2BA58rxmNGNYECjuSY9q/pgQA8x6HUzZmFAA8rRsvvPYUCFyklpbzdiQCeLHCfDm2JAjbX7gNv7YkDcoAIEKVZjQGV1LWJ4qGNA7guqob/vY0DxHKGfCyhkQLozUiLeTGRARmLOaFRaZEB7xqisz05kQGW/mZLWK2RA98PEo0X1Y0DYCH8lpq9jQCUz6JL8XmNAqTvxhWIGY0DOJE2UFqhiQKtvjFKvRWJAIhKZH0zgYUDZiDsfunhhQFNkgvuND2FAiUYiSzWlYEARV+E/AjpgQDaWphJnnF9AfT8cb/PDXkAuzTDt9epdQAmx/V2rEV1AlwgPz0Q4XEAoYnxI6l5bQG15Jta8hVpANIeXEtisWUCTQdJYU9RYQDEDardC/FdAmryht7ckV0CUzYUGwk1WQMCYzApwd1VAhsT4b8+hVECDWpmu7cxTQJDv3ZjY+FJAxZv98p4lUkAYbZAgUVNRQKvjy/ABglBAwpZHMI9jT0DBc1/SecVNQPDJP80FKkxA9sQTo4WRSkAM5BjPYfxIQH4MtTQga0dAl4rDWm7eRUD/8ZiyL1dEQF5VL8SR1kJA3YSe9iheQUB0iyKzM+A/QEsNTV+oHj1AGfVhmMt/OkBnd99j0g44QNax9LMQ2zVAXKizq9P4M0DRBtYlLYEyQEvQOOchjzFAJpRH/BM5MUCp7/WGaYgxQElOPwFNdTJA6iIUm13qM0CDMXfd7cw1QDbR3b7WAzhA6DjOEYx6OkDNM51qdiE9QACOImkm7T9AdHidlqhqQUDAJuqX+OlCQFEtEvhOckRA3eWd0AkCRkANTmx075dHQIx1PQwRM0lAbEsd/rXSSkACKuNZTXZMQMe4/2djHU5AUDdqE5rHT0DG7ZioUbpQQHmiGnceklFAkah8rRZrUkCWM/OVIEVTQOgBJI0kIFRAeLQrMAz8VEByyEipwdhVQAez0RAvtlZArC6k1z2UV0BTTMQz1nJYQGFSEIbeUVlA5ko9rzoxWkAY12BJyxBbQPFWV7ds8FtASSn79vXPXEABvtobN69dQNA7TEz3jV5AmRbJCvJrX0BLXrC9aSRgQPe4PpYZkmBA0JdvVsb+YEBZdjlsGmphQHnUixel02FAkpi41M46YkBqO4MkyJ5iQA2o2SNw/mJAWJU7PDBYY0DX1IORzKljQGHxNvsy8GNAY39Zh20nZEArfbQwCUtkQI3d+HpCV2RA6SsYm6RKZECjYVSZ0yZkQNRdy/qv72NAAX9PrrWpY0CBJyf511hjQMPmDWwiAGNA7AwTB8qhYkDFYW1SXz9iQJLnT/z92WFA2Zpp73ByYUC6s6iASwlhQDVpTHv6nmBAuqsrmc8zYEDobGmKEpBfQAbwftWvt15Abnb2ScPeXUDtOfOwiQVdQPhCiyA0LFxAkrKotOpSW0BuL9CUznlaQB4Gonz7oFlA\"},\"shape\":[201],\"dtype\":\"float64\",\"order\":\"little\"}]]}}},\"view\":{\"type\":\"object\",\"name\":\"CDSView\",\"id\":\"p2600\",\"attributes\":{\"filter\":{\"type\":\"object\",\"name\":\"AllIndices\",\"id\":\"p2601\"}}},\"glyph\":{\"type\":\"object\",\"name\":\"Scatter\",\"id\":\"p2596\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Longitude (deg)\"},\"y\":{\"type\":\"field\",\"field\":\"Latitude (deg)\"},\"size\":{\"type\":\"value\",\"value\":5.477225575051661},\"line_color\":{\"type\":\"value\",\"value\":\"red\"},\"fill_color\":{\"type\":\"value\",\"value\":\"red\"},\"hatch_color\":{\"type\":\"value\",\"value\":\"red\"}}},\"selection_glyph\":{\"type\":\"object\",\"name\":\"Scatter\",\"id\":\"p2604\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Longitude (deg)\"},\"y\":{\"type\":\"field\",\"field\":\"Latitude (deg)\"},\"size\":{\"type\":\"value\",\"value\":5.477225575051661},\"angle\":{\"type\":\"value\",\"value\":0.0},\"line_color\":{\"type\":\"value\",\"value\":\"red\"},\"line_alpha\":{\"type\":\"value\",\"value\":1.0},\"line_width\":{\"type\":\"value\",\"value\":1},\"line_join\":{\"type\":\"value\",\"value\":\"bevel\"},\"line_cap\":{\"type\":\"value\",\"value\":\"butt\"},\"line_dash\":{\"type\":\"value\",\"value\":[]},\"line_dash_offset\":{\"type\":\"value\",\"value\":0},\"fill_color\":{\"type\":\"value\",\"value\":\"red\"},\"fill_alpha\":{\"type\":\"value\",\"value\":1.0},\"hatch_color\":{\"type\":\"value\",\"value\":\"red\"},\"hatch_alpha\":{\"type\":\"value\",\"value\":1.0},\"hatch_scale\":{\"type\":\"value\",\"value\":12.0},\"hatch_pattern\":{\"type\":\"value\",\"value\":null},\"hatch_weight\":{\"type\":\"value\",\"value\":1.0},\"marker\":{\"type\":\"value\",\"value\":\"circle\"}}},\"nonselection_glyph\":{\"type\":\"object\",\"name\":\"Scatter\",\"id\":\"p2597\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Longitude (deg)\"},\"y\":{\"type\":\"field\",\"field\":\"Latitude (deg)\"},\"size\":{\"type\":\"value\",\"value\":5.477225575051661},\"line_color\":{\"type\":\"value\",\"value\":\"red\"},\"line_alpha\":{\"type\":\"value\",\"value\":0.1},\"fill_color\":{\"type\":\"value\",\"value\":\"red\"},\"fill_alpha\":{\"type\":\"value\",\"value\":0.1},\"hatch_color\":{\"type\":\"value\",\"value\":\"red\"},\"hatch_alpha\":{\"type\":\"value\",\"value\":0.1}}},\"muted_glyph\":{\"type\":\"object\",\"name\":\"Scatter\",\"id\":\"p2598\",\"attributes\":{\"tags\":[\"apply_ranges\"],\"x\":{\"type\":\"field\",\"field\":\"Longitude (deg)\"},\"y\":{\"type\":\"field\",\"field\":\"Latitude (deg)\"},\"size\":{\"type\":\"value\",\"value\":5.477225575051661},\"line_color\":{\"type\":\"value\",\"value\":\"red\"},\"line_alpha\":{\"type\":\"value\",\"value\":0.2},\"fill_color\":{\"type\":\"value\",\"value\":\"red\"},\"fill_alpha\":{\"type\":\"value\",\"value\":0.2},\"hatch_color\":{\"type\":\"value\",\"value\":\"red\"},\"hatch_alpha\":{\"type\":\"value\",\"value\":0.2}}}}}],\"toolbar\":{\"type\":\"object\",\"name\":\"Toolbar\",\"id\":\"p2562\",\"attributes\":{\"tools\":[{\"type\":\"object\",\"name\":\"WheelZoomTool\",\"id\":\"p2538\",\"attributes\":{\"renderers\":\"auto\",\"zoom_on_axis\":false}},{\"type\":\"object\",\"name\":\"BoxZoomTool\",\"id\":\"p2539\",\"attributes\":{\"overlay\":{\"type\":\"object\",\"name\":\"BoxAnnotation\",\"id\":\"p1083\",\"attributes\":{\"syncable\":false,\"level\":\"overlay\",\"visible\":false,\"left\":{\"type\":\"number\",\"value\":\"nan\"},\"right\":{\"type\":\"number\",\"value\":\"nan\"},\"top\":{\"type\":\"number\",\"value\":\"nan\"},\"bottom\":{\"type\":\"number\",\"value\":\"nan\"},\"left_units\":\"canvas\",\"right_units\":\"canvas\",\"top_units\":\"canvas\",\"bottom_units\":\"canvas\",\"line_color\":\"black\",\"line_alpha\":1.0,\"line_width\":2,\"line_dash\":[4,4],\"fill_color\":\"lightgrey\",\"fill_alpha\":0.5}},\"match_aspect\":true}},{\"type\":\"object\",\"name\":\"HoverTool\",\"id\":\"p2552\",\"attributes\":{\"tags\":[\"hv_created\"],\"renderers\":[{\"id\":\"p2599\"}],\"tooltips\":[[\"Longitude (deg)\",\"$x{custom}\"],[\"Latitude (deg)\",\"$y{custom}\"],[\"Epoch\",\"@{Epoch}{%F %T}\"],[\"Sun Probe Earth angle (deg)\",\"@{Sun_Probe_Earth_angle_left_parenthesis_deg_right_parenthesis}\"]],\"formatters\":{\"type\":\"map\",\"entries\":[[\"@{Epoch}\",\"datetime\"],[\"$x\",{\"type\":\"object\",\"name\":\"CustomJSHover\",\"id\":\"p2602\",\"attributes\":{\"code\":\"\\n        const projections = Bokeh.require(\\\"core/util/projections\\\");\\n        const {snap_x, snap_y} = special_vars\\n        const coords = projections.wgs84_mercator.invert(snap_x, snap_y)\\n        return \\\"\\\" + (coords[0]).toFixed(4)\\n    \"}}],[\"$y\",{\"type\":\"object\",\"name\":\"CustomJSHover\",\"id\":\"p2603\",\"attributes\":{\"code\":\"\\n        const projections = Bokeh.require(\\\"core/util/projections\\\");\\n        const {snap_x, snap_y} = special_vars\\n        const coords = projections.wgs84_mercator.invert(snap_x, snap_y)\\n        return \\\"\\\" + (coords[1]).toFixed(4)\\n    \"}}]]}}},{\"type\":\"object\",\"name\":\"PanTool\",\"id\":\"p2576\"},{\"type\":\"object\",\"name\":\"ResetTool\",\"id\":\"p2577\"}],\"active_drag\":{\"id\":\"p2576\"}}},\"left\":[{\"type\":\"object\",\"name\":\"LinearAxis\",\"id\":\"p2570\",\"attributes\":{\"ticker\":{\"type\":\"object\",\"name\":\"MercatorTicker\",\"id\":\"p2580\",\"attributes\":{\"mantissas\":[1,2,5],\"dimension\":\"lat\"}},\"formatter\":{\"type\":\"object\",\"name\":\"MercatorTickFormatter\",\"id\":\"p2581\",\"attributes\":{\"dimension\":\"lat\"}},\"axis_label\":\"Latitude\",\"major_label_policy\":{\"type\":\"object\",\"name\":\"AllLabels\",\"id\":\"p2573\"}}}],\"below\":[{\"type\":\"object\",\"name\":\"LinearAxis\",\"id\":\"p2565\",\"attributes\":{\"ticker\":{\"type\":\"object\",\"name\":\"MercatorTicker\",\"id\":\"p2578\",\"attributes\":{\"mantissas\":[1,2,5],\"dimension\":\"lon\"}},\"formatter\":{\"type\":\"object\",\"name\":\"MercatorTickFormatter\",\"id\":\"p2579\",\"attributes\":{\"dimension\":\"lon\"}},\"axis_label\":\"Longitude\",\"major_label_policy\":{\"type\":\"object\",\"name\":\"AllLabels\",\"id\":\"p2568\"}}}],\"center\":[{\"type\":\"object\",\"name\":\"Grid\",\"id\":\"p2569\",\"attributes\":{\"axis\":{\"id\":\"p2565\"},\"grid_line_color\":null}},{\"type\":\"object\",\"name\":\"Grid\",\"id\":\"p2574\",\"attributes\":{\"dimension\":1,\"axis\":{\"id\":\"p2570\"},\"grid_line_color\":null}}],\"frame_width\":713,\"frame_height\":300,\"min_border_top\":10,\"min_border_bottom\":10,\"min_border_left\":10,\"min_border_right\":10,\"output_backend\":\"webgl\",\"match_aspect\":true}},{\"type\":\"object\",\"name\":\"Spacer\",\"id\":\"p2606\",\"attributes\":{\"name\":\"HSpacer03742\",\"stylesheets\":[\"\\n:host(.pn-loading.pn-arc):before, .pn-loading.pn-arc:before {\\n  background-image: url(\\\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJtYXJnaW46IGF1dG87IGJhY2tncm91bmQ6IG5vbmU7IGRpc3BsYXk6IGJsb2NrOyBzaGFwZS1yZW5kZXJpbmc6IGF1dG87IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjYzNjM2MzIiBzdHJva2Utd2lkdGg9IjEwIiByPSIzNSIgc3Ryb2tlLWRhc2hhcnJheT0iMTY0LjkzMzYxNDMxMzQ2NDE1IDU2Ljk3Nzg3MTQzNzgyMTM4Ij4gICAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIiBkdXI9IjFzIiB2YWx1ZXM9IjAgNTAgNTA7MzYwIDUwIDUwIiBrZXlUaW1lcz0iMDsxIj48L2FuaW1hdGVUcmFuc2Zvcm0+ICA8L2NpcmNsZT48L3N2Zz4=\\\");\\n  background-size: auto calc(min(50%, 400px));\\n}\",{\"id\":\"p2523\"},{\"id\":\"p2521\"},{\"id\":\"p2522\"}],\"margin\":0,\"sizing_mode\":\"stretch_width\",\"align\":\"start\"}}]}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"copy_to_clipboard1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"24340461-f171-489f-80b9-24867c79915b\",\"roots\":{\"p2520\":\"b83cf433-199e-4405-83c3-69b1578a0d1d\"},\"root_ids\":[\"p2520\"]}];\n",
+       "  var docs = Object.values(docs_json)\n",
+       "  if (!docs) {\n",
+       "    return\n",
+       "  }\n",
+       "  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')\n",
+       "  function embed_document(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "    for (const render_item of render_items) {\n",
+       "      for (const root_id of render_item.root_ids) {\n",
+       "\tconst id_el = document.getElementById(root_id)\n",
+       "\tif (id_el.children.length && (id_el.children[0].className === 'bk-root')) {\n",
+       "\t  const root_el = id_el.children[0]\n",
+       "\t  root_el.id = root_el.id + '-rendered'\n",
+       "\t}\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "  function get_bokeh(root) {\n",
+       "    if (root.Bokeh === undefined) {\n",
+       "      return null\n",
+       "    } else if (root.Bokeh.version !== py_version) {\n",
+       "      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {\n",
+       "\treturn null\n",
+       "      }\n",
+       "      return root.Bokeh.versions.get(py_version);\n",
+       "    } else if (root.Bokeh.version === py_version) {\n",
+       "      return root.Bokeh\n",
+       "    }\n",
+       "    return null\n",
+       "  }\n",
+       "  function is_loaded(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    return (Bokeh != null && Bokeh.Panel !== undefined)\n",
+       "  }\n",
+       "  if (is_loaded(root)) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    var attempts = 0;\n",
+       "    var timer = setInterval(function(root) {\n",
+       "      if (is_loaded(root)) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else if (document.readyState == \"complete\") {\n",
+       "        attempts++;\n",
+       "        if (attempts > 200) {\n",
+       "          clearInterval(timer);\n",
+       "\t  var Bokeh = get_bokeh(root)\n",
+       "\t  if (Bokeh == null || Bokeh.Panel == null) {\n",
+       "            console.warn(\"Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing\");\n",
+       "\t  } else {\n",
+       "\t    console.warn(\"Panel: WARNING: Attempting to render but not all required libraries could be resolved.\")\n",
+       "\t    embed_document(root)\n",
+       "\t  }\n",
+       "        }\n",
+       "      }\n",
+       "    }, 25, root)\n",
+       "  }\n",
+       "})(window);</script>"
+      ],
+      "text/plain": [
+       ":Overlay\n",
+       "   .WMTS.I   :WMTS   [Longitude,Latitude]\n",
+       "   .Points.I :Points   [Longitude (deg),Latitude (deg)]   (Epoch,Sun Probe Earth angle (deg))"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {
+      "application/vnd.holoviews_exec.v0+json": {
+       "id": "p2520"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.hvplot.points('Longitude (deg)', 'Latitude (deg)', geo=True, color='red', tiles='ESRI', xlim=(0, 360), ylim=(-60, 60), hover_cols=[\"Epoch\", \"Sun Probe Earth angle (deg)\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e64369b-ae0e-4977-aec7-a0722e9a06a5",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "The goal of this exercise is to show that the SPE is essentially the Sun elevation angle from the position exactly nadir of the vehicle plus 90 degrees (or so, since the Earth isn't a perfect sphere). It also shows you how to combine the different functionality you've seen with the other tutorials to solve similar problem.\n",
+    "\n",
+    "_Note:_ this is the `verify_geometry` Rust test, but rebuilt in Python.\n",
+    "\n",
+    "1. For the whole spacecraft trajectory, build the locality exactly nadir of it at each epoch (remember that a `TimeSeries` instance can only be used once, so you'll need to rebuild a new one). For this step, initialize a new `Orbit` instance from the latitude and longitude constructor using the position of the spacecraft in the IAU Earth frame as we did above.\n",
+    "2. At each epoch, grab the state of the Sun as seen from the Earth (both can be in the J2000 frame since the AER computation will transform the states into the correct frames anyway).\n",
+    "3. Call the azimuth, elevtion, and range function of your loaded Almanac, and store the elevation of the Sun as seen from the point exactly nadir of the spacecraft.\n",
+    "4. Plot the elevation data in degrees compared to the SPE angle calculated above."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": ".venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/anise/src/almanac/bpc.rs
+++ b/anise/src/almanac/bpc.rs
@@ -10,10 +10,14 @@
 
 use hifitime::Epoch;
 
-use crate::naif::daf::DAFError;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+use crate::naif::daf::NAIFSummaryRecord;
 use crate::naif::pck::BPCSummaryRecord;
 use crate::naif::BPC;
 use crate::orientations::OrientationError;
+use crate::{naif::daf::DAFError, NaifId};
 
 use super::{Almanac, MAX_LOADED_BPCS};
 
@@ -169,6 +173,52 @@ impl Almanac {
             action: "searching for BPC summary",
             source: DAFError::SummaryIdError { kind: "BPC", id },
         })
+    }
+}
+
+#[cfg_attr(feature = "python", pymethods)]
+impl Almanac {
+    /// Returns a vector of the summaries whose ID matches the desired `id`, in the order in which they will be used, i.e. in reverse loading order.
+    pub fn bpc_summaries(&self, id: NaifId) -> Result<Vec<BPCSummaryRecord>, OrientationError> {
+        let mut summaries = vec![];
+
+        for maybe_bpc in self.bpc_data.iter().take(self.num_loaded_bpc()).rev() {
+            let bpc = maybe_bpc.as_ref().unwrap();
+            if let Ok((summary, _)) = bpc.summary_from_id(id) {
+                // NOTE: We're iterating backward, so the correct BPC number is "total loaded" minus "current iteration".
+                summaries.push(*summary);
+            }
+        }
+
+        if summaries.is_empty() {
+            // If we're reached this point, there is no relevant summary
+            Err(OrientationError::BPC {
+                action: "searching for BPC summary",
+                source: DAFError::SummaryIdError { kind: "BPC", id },
+            })
+        } else {
+            Ok(summaries)
+        }
+    }
+
+    /// Returns the applicable domain of the request id, i.e. start and end epoch that the provided id has loaded data.
+    pub fn bpc_domain(&self, id: NaifId) -> Result<(Epoch, Epoch), OrientationError> {
+        let summaries = self.bpc_summaries(id)?;
+
+        // We know that the summaries is non-empty because if it is, the previous function call returns an error.
+        let start = summaries
+            .iter()
+            .min_by_key(|summary| summary.start_epoch())
+            .unwrap()
+            .start_epoch();
+
+        let end = summaries
+            .iter()
+            .max_by_key(|summary| summary.end_epoch())
+            .unwrap()
+            .end_epoch();
+
+        Ok((start, end))
     }
 }
 

--- a/anise/src/almanac/bpc.rs
+++ b/anise/src/almanac/bpc.rs
@@ -13,6 +13,7 @@ use hifitime::Epoch;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+#[cfg(not(feature = "python"))]
 use crate::naif::daf::NAIFSummaryRecord;
 use crate::naif::pck::BPCSummaryRecord;
 use crate::naif::BPC;

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -38,6 +38,7 @@ pub const MAX_PLANETARY_DATA: usize = 64;
 pub mod aer;
 pub mod bpc;
 pub mod planetary;
+pub mod solar;
 pub mod spk;
 pub mod transform;
 

--- a/anise/src/almanac/solar.rs
+++ b/anise/src/almanac/solar.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 #[cfg_attr(feature = "python", pymethods)]
 impl Almanac {
     /// Returns the angle (between 0 and 180 degrees) between the observer and the Sun, and the observer and the target body ID.
-    /// This computes the Sun Probe Earth angle (SPE) if the probe is in a loaded, its ID is the "observer_id", and the target is set to its central body.
+    /// This computes the Sun Probe Earth angle (SPE) if the probe is in a loaded SPK, its ID is the "observer_id", and the target is set to its central body.
     ///
     /// # Geometry
     /// If the SPE is greater than 90 degrees, then the celestial object below the probe is in sunlight.

--- a/anise/src/almanac/solar.rs
+++ b/anise/src/almanac/solar.rs
@@ -1,0 +1,91 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use crate::{constants::frames::SUN_J2000, ephemerides::EphemerisError, prelude::Frame, NaifId};
+
+use super::Almanac;
+
+use hifitime::Epoch;
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg_attr(feature = "python", pymethods)]
+impl Almanac {
+    /// Returns the angle (between 0 and 180 degrees) between the observer and the Sun, and the observer and the target body ID.
+    /// This computes the Sun Probe Earth angle (SPE) if the probe is in a loaded, its ID is the "observer_id", and the target is set to its central body.
+    ///
+    /// # Geometry
+    /// If the SPE is greater than 90 degrees, then the celestial object below the probe is in sunlight.
+    ///
+    /// ## Sunrise at nadir
+    /// ```text
+    /// Sun
+    ///  |  \      
+    ///  |   \
+    ///  |    \
+    ///  Obs. -- Target
+    /// ```
+    /// ## Sun high at nadir
+    /// ```text
+    /// Sun
+    ///  \        
+    ///   \  __ θ > 90
+    ///    \     \
+    ///     Obs. ---------- Target
+    /// ```
+    ///
+    /// ## Sunset at nadir
+    /// ```text
+    ///          Sun
+    ///        /  
+    ///       /  __ θ < 90
+    ///      /    /
+    ///  Obs. -- Target
+    /// ```
+    ///
+    /// # Algorithm
+    /// 1. Compute the position of the Sun as seen from the observer
+    /// 2. Compute the position of the target as seen from the observer
+    /// 3. Return the arccosine of the dot product of the norms of these vectors.
+    pub fn sun_angle_deg(
+        &self,
+        target_id: NaifId,
+        observer_id: NaifId,
+        epoch: Epoch,
+    ) -> Result<f64, EphemerisError> {
+        let obs_to_sun =
+            self.translate_geometric(SUN_J2000, Frame::from_ephem_j2000(observer_id), epoch)?;
+        let obs_to_target = self.translate_geometric(
+            Frame::from_ephem_j2000(observer_id),
+            Frame::from_ephem_j2000(target_id),
+            epoch,
+        )?;
+
+        Ok(obs_to_sun
+            .r_hat()
+            .dot(&obs_to_target.r_hat())
+            .acos()
+            .to_degrees())
+    }
+
+    /// Convenience function that calls `sun_angle_deg` with the provided frames instead of the ephemeris ID.
+    pub fn sun_angle_deg_from_frame(
+        &self,
+        target: Frame,
+        observer: Frame,
+        epoch: Epoch,
+    ) -> Result<f64, EphemerisError> {
+        self.sun_angle_deg(target.ephemeris_id, observer.ephemeris_id, epoch)
+    }
+}
+
+#[cfg(test)]
+mod ut_solar {}

--- a/anise/src/almanac/solar.rs
+++ b/anise/src/almanac/solar.rs
@@ -64,8 +64,8 @@ impl Almanac {
         let obs_to_sun =
             self.translate_geometric(SUN_J2000, Frame::from_ephem_j2000(observer_id), epoch)?;
         let obs_to_target = self.translate_geometric(
-            Frame::from_ephem_j2000(observer_id),
             Frame::from_ephem_j2000(target_id),
+            Frame::from_ephem_j2000(observer_id),
             epoch,
         )?;
 
@@ -88,4 +88,86 @@ impl Almanac {
 }
 
 #[cfg(test)]
-mod ut_solar {}
+mod ut_solar {
+    use crate::{
+        constants::{
+            celestial_objects::EARTH,
+            frames::{EARTH_J2000, IAU_EARTH_FRAME, SUN_J2000},
+            usual_planetary_constants::MEAN_EARTH_ANGULAR_VELOCITY_DEG_S,
+        },
+        prelude::*,
+    };
+
+    /// Load a BSP of a spacecraft trajectory, compute the sun elevation at different points on the surface below that spacecraft
+    /// and ensure that it matches with the SPE calculation.
+    #[test]
+    fn verify_geometry() {
+        let ctx = Almanac::default()
+            .load("../data/de440s.bsp")
+            .and_then(|ctx| ctx.load("../data/gmat-hermite.bsp"))
+            .and_then(|ctx| ctx.load("../data/pck11.pca"))
+            .unwrap();
+
+        let epoch = Epoch::from_gregorian_hms(2000, 1, 1, 12, 0, 0, TimeScale::UTC);
+
+        let sc_id = -10000001;
+
+        let my_sc_j2k = Frame::from_ephem_j2000(sc_id);
+
+        // Grab the state in the J2000 frame
+        let state = ctx.transform(my_sc_j2k, EARTH_J2000, epoch, None).unwrap();
+
+        // We'll check at four different points in the orbit
+        for epoch in TimeSeries::inclusive(
+            epoch,
+            epoch + state.period().unwrap(),
+            0.05 * state.period().unwrap(),
+        ) {
+            let spe_deg = ctx.sun_angle_deg(EARTH, sc_id, epoch).unwrap();
+            assert_eq!(
+                spe_deg,
+                ctx.sun_angle_deg_from_frame(EARTH_J2000, my_sc_j2k, epoch)
+                    .unwrap()
+            );
+
+            let iau_earth = ctx.frame_from_uid(IAU_EARTH_FRAME).unwrap();
+
+            // Compute this state in the body fixed frame.
+            let state_bf = ctx
+                .transform(my_sc_j2k, IAU_EARTH_FRAME, epoch, None)
+                .unwrap();
+            // Build a local point on the surface below this spacecraft
+            let nadir_surface_point = Orbit::try_latlongalt(
+                state_bf.latitude_deg().unwrap(),
+                state_bf.longitude_deg(),
+                0.0,
+                MEAN_EARTH_ANGULAR_VELOCITY_DEG_S,
+                epoch,
+                iau_earth,
+            )
+            .unwrap();
+            // Fetch the state of the sun at this time.
+            let sun_state = ctx
+                .transform(SUN_J2000, IAU_EARTH_FRAME, epoch, None)
+                .unwrap();
+
+            // Compute the Sun elevation from that point.
+            let sun_elevation_deg = ctx
+                .azimuth_elevation_range_sez(sun_state, nadir_surface_point)
+                .unwrap()
+                .elevation_deg;
+
+            println!(
+                "{epoch}\tsun el = {sun_elevation_deg:.3} deg\tlat = {:.3} deg\tlong = {:.3} deg\t-->\tSPE = {spe_deg:.3} deg",
+                nadir_surface_point.latitude_deg().unwrap(),
+                nadir_surface_point.longitude_deg()
+            );
+
+            // Test: the sun elevation from the ground should be about 90 degrees _less_ than the SPE
+            // The "about" is because the SPE effectively assumes a spherical celestial object, but the frame
+            // from the Almanac accounts for the flattening when computing the exact location below the vehicle.
+            // Hence, there is a small difference (we accept up to 0.05 degrees of difference).
+            assert!((sun_elevation_deg + 90.0 - spe_deg).abs() < 5e-2)
+        }
+    }
+}

--- a/anise/src/almanac/spk.rs
+++ b/anise/src/almanac/spk.rs
@@ -10,10 +10,14 @@
 
 use hifitime::Epoch;
 
-use crate::ephemerides::EphemerisError;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use crate::naif::daf::DAFError;
+use crate::naif::daf::NAIFSummaryRecord;
 use crate::naif::spk::summary::SPKSummaryRecord;
 use crate::naif::SPK;
+use crate::{ephemerides::EphemerisError, NaifId};
 use log::error;
 
 use super::{Almanac, MAX_LOADED_SPKS};
@@ -45,7 +49,9 @@ impl Almanac {
         me.spk_data[data_idx] = Some(spk);
         Ok(me)
     }
+}
 
+impl Almanac {
     pub fn num_loaded_spk(&self) -> usize {
         let mut count = 0;
         for maybe in &self.spk_data {
@@ -122,7 +128,7 @@ impl Almanac {
         })
     }
 
-    /// Returns the summary given the name of the summary record.
+    /// Returns the most recently loaded summary by its name, if any with that ID are available
     pub fn spk_summary_from_name(
         &self,
         name: &str,
@@ -152,7 +158,7 @@ impl Almanac {
         })
     }
 
-    /// Returns the summary given the name of the summary record if that summary has data defined at the requested epoch
+    /// Returns the most recently loaded summary by its ID, if any with that ID are available
     pub fn spk_summary(
         &self,
         id: i32,
@@ -177,6 +183,52 @@ impl Almanac {
             action: "searching for SPK summary",
             source: DAFError::SummaryIdError { kind: "SPK", id },
         })
+    }
+}
+
+#[cfg_attr(feature = "python", pymethods)]
+impl Almanac {
+    /// Returns a vector of the summaries whose ID matches the desired `id`, in the order in which they will be used, i.e. in reverse loading order.
+    pub fn spk_summaries(&self, id: NaifId) -> Result<Vec<SPKSummaryRecord>, EphemerisError> {
+        let mut summaries = vec![];
+        for maybe_spk in self.spk_data.iter().take(self.num_loaded_spk()).rev() {
+            let spk = maybe_spk.as_ref().unwrap();
+            if let Ok((summary, _)) = spk.summary_from_id(id) {
+                // NOTE: We're iterating backward, so the correct SPK number is "total loaded" minus "current iteration".
+                summaries.push(*summary);
+            }
+        }
+
+        if summaries.is_empty() {
+            error!("Almanac: No summary {id} valid");
+            // If we're reached this point, there is no relevant summary
+            Err(EphemerisError::SPK {
+                action: "searching for SPK summary",
+                source: DAFError::SummaryIdError { kind: "SPK", id },
+            })
+        } else {
+            Ok(summaries)
+        }
+    }
+
+    /// Returns the applicable domain of the request id, i.e. start and end epoch that the provided id has loaded data.
+    pub fn spk_domain(&self, id: NaifId) -> Result<(Epoch, Epoch), EphemerisError> {
+        let summaries = self.spk_summaries(id)?;
+
+        // We know that the summaries is non-empty because if it is, the previous function call returns an error.
+        let start = summaries
+            .iter()
+            .min_by_key(|summary| summary.start_epoch())
+            .unwrap()
+            .start_epoch();
+
+        let end = summaries
+            .iter()
+            .max_by_key(|summary| summary.end_epoch())
+            .unwrap()
+            .end_epoch();
+
+        Ok((start, end))
     }
 }
 

--- a/anise/src/almanac/spk.rs
+++ b/anise/src/almanac/spk.rs
@@ -14,6 +14,7 @@ use hifitime::Epoch;
 use pyo3::prelude::*;
 
 use crate::naif::daf::DAFError;
+#[cfg(not(feature = "python"))]
 use crate::naif::daf::NAIFSummaryRecord;
 use crate::naif::spk::summary::SPKSummaryRecord;
 use crate::naif::SPK;

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -675,7 +675,7 @@ impl Orbit {
     /// Returns the true anomaly in degrees between 0 and 360.0
     ///
     /// NOTE: This function will emit a warning stating that the TA should be avoided if in a very near circular orbit
-    /// Code from https://github.com/ChristopherRabotin/GMAT/blob/80bde040e12946a61dae90d9fc3538f16df34190/src/gmatutil/util/StateConversionUtil.cpp#L6835
+    /// Code from <https://github.com/ChristopherRabotin/GMAT/blob/80bde040e12946a61dae90d9fc3538f16df34190/src/gmatutil/util/StateConversionUtil.cpp#L6835>
     ///
     /// LIMITATION: For an orbit whose true anomaly is (very nearly) 0.0 or 180.0, this function may return either 0.0 or 180.0 with a very small time increment.
     /// This is due to the precision of the cosine calculation: if the arccosine calculation is out of bounds, the sign of the cosine of the true anomaly is used

--- a/anise/src/constants.rs
+++ b/anise/src/constants.rs
@@ -89,7 +89,7 @@ pub mod orientations {
     /// The rotation from B1950 to J2000 is
     /// \[ -z \]  \[ theta \]  \[ -zeta \]
     ///         3            2            3
-    /// The values for z, theta, and zeta are computed from the formulas given in table 5 of [5].
+    /// The values for z, theta, and zeta are computed from the formulas given in table 5 of \[5\].
     /// z     =  1153.04066200330"
     /// theta =  1002.26108439117"
     /// zeta  =  1152.84248596724"
@@ -105,7 +105,7 @@ pub mod orientations {
     ///  \[ 0.53155" \]
     ///                3
     ///
-    /// In [2], Standish uses two separate rotations,
+    /// In \[2\], Standish uses two separate rotations,
     ///
     ///   \[ 0.00073" \]  P \[ 0.5316" \]
     ///                 3                3
@@ -204,7 +204,7 @@ pub mod orientations {
     pub const IAU_NEPTUNE: NaifId = 799;
     pub const IAU_URANUS: NaifId = 899;
 
-    /// Angle between J2000 to solar system ecliptic J2000 ([ECLIPJ2000]), in radians (about 23.43929 degrees). Apply this rotation about the X axis ([r1])
+    /// Angle between J2000 to solar system ecliptic J2000 ([ECLIPJ2000]), in radians (about 23.43929 degrees). Apply this rotation about the X axis (R1)
     pub const J2000_TO_ECLIPJ2000_ANGLE_RAD: f64 = 0.40909280422232897;
 
     /// Given the frame ID, try to return a human name
@@ -280,7 +280,7 @@ pub mod frames {
 /// Typical planetary constants that aren't found in SPICE input files.
 pub mod usual_planetary_constants {
     /// Mean angular velocity of the Earth in deg/s
-    /// Source: G. Xu and Y. Xu, "GPS", DOI 10.1007/978-3-662-50367-6_2, 2016 (confirmed by https://hpiers.obspm.fr/eop-pc/models/constants.html)
+    /// Source: G. Xu and Y. Xu, "GPS", DOI 10.1007/978-3-662-50367-6_2, 2016 (confirmed by <https://hpiers.obspm.fr/eop-pc/models/constants.html>)
     pub const MEAN_EARTH_ANGULAR_VELOCITY_DEG_S: f64 = 0.004178079012116429;
     /// Mean angular velocity of the Moon in deg/s, computed from hifitime:
     /// ```py
@@ -288,7 +288,7 @@ pub mod usual_planetary_constants {
     /// >>> tau/moon_period.to_seconds()
     /// 2.661698975163682e-06
     /// ```
-    /// Source: https://www.britannica.com/science/month#ref225844 via https://en.wikipedia.org/w/index.php?title=Lunar_day&oldid=1180701337
+    /// Source: <https://www.britannica.com/science/month#ref225844> via <https://en.wikipedia.org/w/index.php?title=Lunar_day&oldid=1180701337>
     pub const MEAN_MOON_ANGULAR_VELOCITY_DEG_S: f64 = 2.661_698_975_163_682e-6;
 }
 

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -188,7 +188,7 @@ impl Almanac {
 
     /// Translates the provided Cartesian state into the requested observer frame
     ///
-    /// **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the [transform_to] function instead to include rotations.
+    /// **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_to` function instead to include rotations.
     #[allow(clippy::too_many_arguments)]
     pub fn translate_to(
         &self,
@@ -205,7 +205,7 @@ impl Almanac {
 impl Almanac {
     /// Translates a state with its origin (`to_frame`) and given its units (distance_unit, time_unit), returns that state with respect to the requested frame
     ///
-    /// **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the [transform_state_to] function instead to include rotations.
+    /// **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_state_to` function instead to include rotations.
     #[allow(clippy::too_many_arguments)]
     pub fn translate_state_to(
         &self,

--- a/anise/src/math/rotation/quaternion.rs
+++ b/anise/src/math/rotation/quaternion.rs
@@ -20,7 +20,7 @@ use snafu::ensure;
 
 use super::EPSILON_RAD;
 
-/// Quaternion will always be a unit quaternion in ANISE, cf. [EulerParameter].
+/// Quaternion will always be a unit quaternion in ANISE, cf. EulerParameter.
 ///
 /// In ANISE, Quaternions use exclusively the Hamiltonian convenstion.
 pub type Quaternion = EulerParameter;

--- a/anise/src/naif/daf/data_types.rs
+++ b/anise/src/naif/daf/data_types.rs
@@ -16,8 +16,13 @@ use crate::naif::daf::DatatypeSnafu;
 
 use super::DAFError;
 
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
+
 pub enum DataType {
     Type1ModifiedDifferenceArray = 1,
     Type2ChebyshevTriplet = 2,

--- a/anise/src/naif/pck/mod.rs
+++ b/anise/src/naif/pck/mod.rs
@@ -15,8 +15,13 @@ use crate::{
 use hifitime::Epoch;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use super::daf::DafDataType;
 
+#[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "anise.internals"))]
 #[derive(Clone, Copy, Debug, Default, AsBytes, FromZeroes, FromBytes)]
 #[repr(C)]
 pub struct BPCSummaryRecord {
@@ -36,6 +41,21 @@ impl BPCSummaryRecord {
             action: "converting data type from i32",
             source,
         })
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl BPCSummaryRecord {
+    /// Returns the start epoch of this BPC Summary
+    pub fn start_epoch(&self) -> Epoch {
+        <Self as NAIFSummaryRecord>::start_epoch(self)
+    }
+
+    /// Returns the start epoch of this BPC Summary
+
+    pub fn end_epoch(&self) -> Epoch {
+        <Self as NAIFSummaryRecord>::end_epoch(self)
     }
 }
 

--- a/anise/src/orientations/rotations.rs
+++ b/anise/src/orientations/rotations.rs
@@ -28,7 +28,7 @@ impl Almanac {
     /// This function only performs the rotation and no translation whatsoever. Use the `transform_from_to` function instead to include rotations.
     ///
     /// # Note
-    /// This function performs a recursion of no more than twice the [MAX_TREE_DEPTH].
+    /// This function performs a recursion of no more than twice the MAX_TREE_DEPTH.
     pub fn rotate_from_to(
         &self,
         from_frame: Frame,

--- a/anise/src/structure/planetocentric/mod.rs
+++ b/anise/src/structure/planetocentric/mod.rs
@@ -234,7 +234,7 @@ impl PlanetaryData {
 
     /// Computes the rotation to the parent frame, including its time derivative.
     ///
-    /// Source: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/rotation.html#Working%20with%20RA,%20Dec%20and%20Twist
+    /// Source: <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/rotation.html#Working%20with%20RA,%20Dec%20and%20Twist>
     pub fn rotation_to_parent(&self, epoch: Epoch, system: &Self) -> PhysicsResult<DCM> {
         if self.pole_declination.is_none()
             && self.prime_meridian.is_none()

--- a/anise/tests/ephemerides/parent_translation_verif.rs
+++ b/anise/tests/ephemerides/parent_translation_verif.rs
@@ -15,11 +15,23 @@ use anise::file2heap;
 use anise::math::Vector3;
 use anise::prelude::*;
 
-const ZEROS: &[u8] = &[0; 2048];
-/// Test that we can load data from a static pointer to it.
+const ZEROS: &[u8] = &[0; 256];
+/// Test that we can load data from a static pointer to it, even if there is less than one record length
 #[test]
 fn invalid_load_from_static() {
     assert!(SPK::from_static(&ZEROS).is_err());
+}
+
+#[test]
+fn de400_domain() {
+    let almanac = Almanac::new("../data/de440s.bsp").unwrap();
+
+    assert!(almanac.spk_domain(-1012).is_err());
+    assert!(almanac.spk_domain(399).is_ok());
+
+    // No BPC loaded, so it should error.
+    assert!(almanac.bpc_domain(-1).is_err());
+    assert!(almanac.bpc_domain(399).is_err());
 }
 
 #[test]


### PR DESCRIPTION
# Summary

New feature: computation of the sun angle between an observer (e.g. a probe) and another celestial object (e.g. the primary body that probe orbits). This allows the computation of the Sun-probe-Earth angle, for example, if the observer is the probe and the target is the primary body it orbits.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

+ Add sun_angle_deg and `sun_angle_deg_from_frames` function signatures

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

+ Test that with the `gmat-hermite.bsp` file, which contains ~ 3 hours of Earth centered propagation, the computation of the SPE is (almost) exactly 90 degrees greater than the Sun elevation at the point exactly nadir of the spacecraft at a geodetic height of zero kilometers. An error of 0.05 degrees is acceptable because the SPE does _not_ account for the flattening of the Earth but the elevation does since it's computed from the latitude and longitude in the IAU Earth frame, which accounts for that flattening ratio.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->