### PR TITLE
Add domain validity map for SPK and BPC

### DIFF
--- a/anise/src/ephemerides/translate_to_parent.rs
+++ b/anise/src/ephemerides/translate_to_parent.rs
@@ -21,6 +21,9 @@ use crate::naif::daf::datatypes::{HermiteSetType13, LagrangeSetType9, Type2Cheby
 use crate::naif::daf::{DAFError, DafDataType, NAIFDataSet};
 use crate::prelude::Frame;
 
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 impl Almanac {
     /// Returns the position vector and velocity vector of the `source` with respect to its parent in the ephemeris at the provided epoch,
     /// Units are those used in the SPK, typically distances are in kilometers and velocities in kilometers per second.
@@ -91,7 +94,10 @@ impl Almanac {
 
         Ok((pos_km, vel_km_s, new_frame))
     }
+}
 
+#[cfg_attr(feature = "python", pymethods)]
+impl Almanac {
     /// Performs the GEOMETRIC translation to the parent. Use translate_from_to for aberration.
     pub fn translate_to_parent(
         &self,

--- a/anise/tests/ephemerides/parent_translation_verif.rs
+++ b/anise/tests/ephemerides/parent_translation_verif.rs
@@ -28,10 +28,13 @@ fn de400_domain() {
 
     assert!(almanac.spk_domain(-1012).is_err());
     assert!(almanac.spk_domain(399).is_ok());
+    assert!(almanac.spk_domains().is_ok());
 
     // No BPC loaded, so it should error.
     assert!(almanac.bpc_domain(-1).is_err());
     assert!(almanac.bpc_domain(399).is_err());
+
+    assert!(almanac.bpc_domains().is_err());
 }
 
 #[test]


### PR DESCRIPTION
# Summary

As a user of ANISE, I'm interested in programmatically knowing what NAIF IDs are currently loaded for SPK and BPC files, along with their validity. This allows me to query it off the bat without any manual step.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

+ `translate_to_parent` is now exposed to Python
+ `spk_domains` and `bpc_domains` are new functions, available in Rust and Python.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

**Detail the changes in tests, including new tests and validations**

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->