### PR TITLE
Clone and modify data sets of all kind

### DIFF
--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -243,7 +243,7 @@ impl<T: DataSetT, const ENTRIES: usize> DataSet<T, ENTRIES> {
             // Search the names for that same entry.
             for (name, name_entry) in &self.lut.by_name.clone() {
                 if name_entry == &entry {
-                    self.lut.rmname(&name).with_context(|_| DataSetLutSnafu {
+                    self.lut.rmname(name).with_context(|_| DataSetLutSnafu {
                         action: "removing by ID",
                     })?;
                     break;

--- a/anise/src/structure/lookuptable.rs
+++ b/anise/src/structure/lookuptable.rs
@@ -143,6 +143,60 @@ impl<const ENTRIES: usize> LookUpTable<ENTRIES> {
         rtn
     }
 
+    /// Change the ID of a given entry to the new ID
+    ///
+    /// This will return an error if the current ID is not in the LUT, or if the new ID is already in the LUT.
+    pub fn reid(&mut self, current_id: i32, new_id: i32) -> Result<(), LutError> {
+        if let Some(entry) = self.by_id.swap_remove(&current_id) {
+            // We can unwrap the insertion because we just removed something.
+            self.by_id.insert(new_id, entry).unwrap();
+            Ok(())
+        } else {
+            Err(LutError::UnknownId { id: current_id })
+        }
+    }
+
+    /// Removes this ID from the LUT if it's present.
+    ///
+    /// If this item was inserted with a name, it will rename accessible by the name.
+    pub fn rmid(&mut self, id: i32) -> Result<(), LutError> {
+        if self.by_id.remove(&id).is_none() {
+            Err(LutError::UnknownId { id })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Change the ID of a given entry to the new ID
+    ///
+    /// This will return an error if the current ID is not in the LUT, or if the new ID is already in the LUT.
+    pub fn rename(&mut self, current_name: &str, new_name: &str) -> Result<(), LutError> {
+        if let Some(entry) = self.by_name.swap_remove(&current_name.try_into().unwrap()) {
+            // We can unwrap the insertion because we just removed something.
+            self.by_name
+                .insert(new_name.try_into().unwrap(), entry)
+                .unwrap();
+            Ok(())
+        } else {
+            Err(LutError::UnknownName {
+                name: current_name.try_into().unwrap(),
+            })
+        }
+    }
+
+    /// Removes this ID from the LUT if it's present.
+    ///
+    /// If this item was inserted with a name, it will rename accessible by the name.
+    pub fn rmname(&mut self, name: &str) -> Result<(), LutError> {
+        if self.by_name.remove(&name.try_into().unwrap()).is_none() {
+            Err(LutError::UnknownName {
+                name: name.try_into().unwrap(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     pub(crate) fn check_integrity(&self) -> bool {
         if self.by_id.is_empty() || self.by_name.is_empty() {
             // If either map is empty, the LUT is integral because there cannot be


### PR DESCRIPTION
# Summary

Allows in-place modification, renaming, removal, and partial removal of dataset entries from ID or name.

Closes #200 

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

`DataSetT`, i.e. the entries to a `DataSet`, must now implement `Default`. This is requires so we can "zero out" the underlying bytes that represent the data to be removed.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Test renaming, removing, accessibility of the renamed and removed data, using both ID and name.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->