### PR TITLE
Fix azimuth computation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
           wget -O data/de440.bsp http://public-data.nyxspace.com/anise/de440.bsp
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.3/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.3/pck11.pca
+          wget -O data/moon_fk.epa http://public-data.nyxspace.com/anise/v0.3/moon_fk.epa
+          wget -O data/moon_pa_de440_200625.bpc http://public-data.nyxspace.com/anise/moon_pa_de440_200625.bpc
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc

--- a/anise/src/almanac/aer.rs
+++ b/anise/src/almanac/aer.rs
@@ -95,7 +95,7 @@ impl Almanac {
             warn!("object nearly overhead (el = {elevation_deg:.6} deg), azimuth may be incorrect");
         }
         // For the elevation, we need to perform a quadrant check because it's measured from 0 to 360 degrees.
-        let azimuth_deg = between_0_360((-rho_sez.y.atan2(rho_sez.x)).to_degrees());
+        let azimuth_deg = between_0_360((rho_sez.y.atan2(-rho_sez.x)).to_degrees());
 
         Ok(AzElRange {
             epoch: tx.epoch,
@@ -240,7 +240,7 @@ mod ut_aer {
                 assert_eq!(
                     format!("{aer}"),
                     format!(
-                        "{}: az.: 313.599990 deg    el.: 7.237568 deg    range: 91457.271742 km    range-rate: -12.396849 km/s",
+                        "{}: az.: 133.599990 deg    el.: 7.237568 deg    range: 91457.271742 km    range-rate: -12.396849 km/s",
                         state.epoch
                     )
                 );


### PR DESCRIPTION
# Summary

The computation of the azimuth was off by 180 degrees. The algorithm is from the same source: Vallado, section 4.4.3.

## How did this bug come to be?

Vallado specifies that the azimuth needs to be computed by accounting for the quadrant check, and provides the sine and cosine of the azimuth angles as follows:

+ \sin \beta = \rho_y / norm(\rho)
+ \cos \beta = -\rho_x / norm(\rho)

Given the quadrant check, I rewrote this as:

+ \tan \beta = \sin \beta / \cos \beta = \rho_y / (-\rho_x) = -\rho_y / \rho_x

This is mathematically correct. _However_, when using the `atan2` function, [the sign of each component matters](https://doc.rust-lang.org/std/primitive.f64.html#method.atan2). The code was using `atan2` incorrectly because I had moved the negative sign from the denominator to the numerator.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

+ Azimuth computation was wrong by 180 degrees.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

There isn't yet any public validation tests for azimuth and elevation, but it's been checked against proprietary data, which uncovered the error in azimuth. Elevation and range matched the proprietary data with high precision.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->