### PR TITLE
Modify and truncate DAF files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 # Bug report
-_Bug reports will lead to a stakeholder need report, and will need to be linked to this issue_
 
 ## Describe the bug
 A clear and concise description of what the bug is.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo bench --bench "crit_bpc_rotation" --workspace --exclude anise-py
 
       - name: Save benchmark artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jpl-development-ephemerides-benchmark
           path: target/criterion/**/report/*

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo bench --bench "crit_bpc_rotation" --workspace --exclude anise-py
 
       - name: Save benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: jpl-development-ephemerides-benchmark
           path: target/criterion/**/report/*

--- a/.github/workflows/gui.yaml
+++ b/.github/workflows/gui.yaml
@@ -33,7 +33,7 @@ jobs:
               run: cargo build --release --bin anise-gui --workspace --exclude anise-py
             
             - name: Save executable
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                 name: anise-gui-linux
                 path: target/release/anise-gui
@@ -53,7 +53,7 @@ jobs:
               run: cargo build --release --bin anise-gui --workspace --exclude anise-py
 
             - name: Save executable
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                 name: anise-gui-windows
                 path: target\release\anise-gui.exe

--- a/.github/workflows/gui.yaml
+++ b/.github/workflows/gui.yaml
@@ -33,7 +33,7 @@ jobs:
               run: cargo build --release --bin anise-gui --workspace --exclude anise-py
             
             - name: Save executable
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: anise-gui-linux
                 path: target/release/anise-gui
@@ -53,7 +53,7 @@ jobs:
               run: cargo build --release --bin anise-gui --workspace --exclude anise-py
 
             - name: Save executable
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: anise-gui-windows
                 path: target\release\anise-gui.exe

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        continue-on-error: ${{ matrix.target == 's390x' }}
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,7 +36,7 @@ jobs:
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.3/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.3/pck11.pca
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -65,7 +65,7 @@ jobs:
             fi
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: anise-py/dist
@@ -118,7 +118,7 @@ jobs:
         with:
           lfs: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: ${{ matrix.target }}
@@ -132,7 +132,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: anise-py/dist
@@ -157,7 +157,7 @@ jobs:
         with:
           lfs: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -170,7 +170,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: anise-py/dist
@@ -208,7 +208,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: anise-py/dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,7 +65,7 @@ jobs:
             fi
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: anise-py/dist
@@ -132,7 +132,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: anise-py/dist
@@ -170,7 +170,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: anise-py/dist
@@ -208,7 +208,7 @@ jobs:
           working-directory: anise-py
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: anise-py/dist

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,7 +123,7 @@ jobs:
           RUST_BACKTRACE=1 cargo test de440s_translation_verif_venus2emb --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --include-ignored --test-threads 1
 
       # Now analyze the results and create pretty plots
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -134,7 +134,7 @@ jobs:
           python spk_validation_plots.py
 
       - name: Save validation artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: validation-artifacts
           path: target/*.html

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,7 +134,7 @@ jobs:
           python spk_validation_plots.py
 
       - name: Save validation artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: validation-artifacts
           path: target/*.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py"]
 
 [workspace.package]
-version = "0.3.2-alpha"
+version = "0.3.2"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."
@@ -50,7 +50,7 @@ serde = "1"
 serde_derive = "1"
 serde_dhall = "0.12"
 
-anise = { version = "0.3.2-alpha", path = "anise", default-features = false }
+anise = { version = "0.3.2", path = "anise", default-features = false }
 
 [profile.bench]
 debug = true

--- a/anise-cli/src/args.rs
+++ b/anise-cli/src/args.rs
@@ -55,15 +55,14 @@ pub enum Actions {
         /// New end epoch of the segment
         end: Option<Epoch>,
     },
-    /// Rename the segment with the provided "old name" to the "new name" in any DAF file (SPK or BPC).
-    RenameDAFSegment {
+    /// Remove the segment of the provided ID of the input NAIF DAF file.
+    /// Limitation: this may not work correctly if there are several segments with the same ID.
+    RmDAFById {
         /// Input DAF file, SPK or BPC
         input: PathBuf,
         /// Output DAF file path
         output: PathBuf,
-        /// Old segment name
-        old_name: String,
-        /// New segment name
-        new_name: String,
+        /// ID of the segment to truncate
+        id: i32,
     },
 }

--- a/anise-cli/src/args.rs
+++ b/anise-cli/src/args.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use hifitime::Epoch;
 
 #[derive(Parser, Debug)]
 #[clap(name="ANISE", author="Rabotin and ANISE contributors", version, about, long_about = None)]
@@ -38,5 +39,31 @@ pub enum Actions {
         fkfile: PathBuf,
         /// Output ANISE binary file
         outfile: PathBuf,
+    },
+    /// Truncate the segment of the provided ID of the input NAIF DAF file to the provided start and end epochs
+    /// Limitation: this may not work correctly if there are several segments with the same ID.
+    /// Only works with Chebyshev Type 2 data types (i.e. planetary ephemerides).
+    TruncDAFById {
+        /// Input DAF file, SPK or BPC
+        input: PathBuf,
+        /// Output DAF file path
+        output: PathBuf,
+        /// ID of the segment to truncate
+        id: i32,
+        /// New start epoch of the segment
+        start: Option<Epoch>,
+        /// New end epoch of the segment
+        end: Option<Epoch>,
+    },
+    /// Rename the segment with the provided "old name" to the "new name" in any DAF file (SPK or BPC).
+    RenameDAFSegment {
+        /// Input DAF file, SPK or BPC
+        input: PathBuf,
+        /// Output DAF file path
+        output: PathBuf,
+        /// Old segment name
+        old_name: String,
+        /// New segment name
+        new_name: String,
     },
 }

--- a/anise-py/src/astro.rs
+++ b/anise-py/src/astro.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise-py/src/constants.rs
+++ b/anise-py/src/constants.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise-py/src/lib.rs
+++ b/anise-py/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise-py/src/utils.rs
+++ b/anise-py/src/utils.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/aer.rs
+++ b/anise/src/almanac/aer.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/bpc.rs
+++ b/anise/src/almanac/bpc.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/metaload/metaalmanac.rs
+++ b/anise/src/almanac/metaload/metaalmanac.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/metaload/metafile.rs
+++ b/anise/src/almanac/metaload/metafile.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/metaload/mod.rs
+++ b/anise/src/almanac/metaload/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/planetary.rs
+++ b/anise/src/almanac/planetary.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/python.rs
+++ b/anise/src/almanac/python.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/solar.rs
+++ b/anise/src/almanac/solar.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/spk.rs
+++ b/anise/src/almanac/spk.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/almanac/transform.rs
+++ b/anise/src/almanac/transform.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/astro/aberration.rs
+++ b/anise/src/astro/aberration.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/astro/mod.rs
+++ b/anise/src/astro/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/astro/orbit_geodetic.rs
+++ b/anise/src/astro/orbit_geodetic.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/astro/utils.rs
+++ b/anise/src/astro/utils.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/constants.rs
+++ b/anise/src/constants.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christop&her.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christop&her.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/ephemerides/mod.rs
+++ b/anise/src/ephemerides/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/ephemerides/translate_to_parent.rs
+++ b/anise/src/ephemerides/translate_to_parent.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/errors.rs
+++ b/anise/src/errors.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/frames/frame.rs
+++ b/anise/src/frames/frame.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/frames/frameuid.rs
+++ b/anise/src/frames/frameuid.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/frames/mod.rs
+++ b/anise/src/frames/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/lib.rs
+++ b/anise/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/angles.rs
+++ b/anise/src/math/angles.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/cartesian.rs
+++ b/anise/src/math/cartesian.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/cartesian_py.rs
+++ b/anise/src/math/cartesian_py.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/interpolation/chebyshev.rs
+++ b/anise/src/math/interpolation/chebyshev.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/interpolation/hermite.rs
+++ b/anise/src/math/interpolation/hermite.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/interpolation/mod.rs
+++ b/anise/src/math/interpolation/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/interpolation/mod.rs
+++ b/anise/src/math/interpolation/mod.rs
@@ -45,4 +45,9 @@ pub enum InterpolationError {
     MissingInterpolationData { epoch: Epoch },
     #[snafu(display("interpolation data corrupted: {what}"))]
     CorruptedData { what: &'static str },
+    #[snafu(display("{op} is unsupported for {kind}"))]
+    UnsupportedOperation {
+        kind: &'static str,
+        op: &'static str,
+    },
 }

--- a/anise/src/math/mod.rs
+++ b/anise/src/math/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/rotation/dcm.rs
+++ b/anise/src/math/rotation/dcm.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/rotation/mod.rs
+++ b/anise/src/math/rotation/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/rotation/mrp.rs
+++ b/anise/src/math/rotation/mrp.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/rotation/quaternion.rs
+++ b/anise/src/math/rotation/quaternion.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/math/units.rs
+++ b/anise/src/math/units.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -418,10 +418,8 @@ impl<R: NAIFSummaryRecord> DAF<R> {
 
     /// Copies the underlying bytes of this DAF into a MutDAF, enabling modification of the DAF.
     pub fn to_mutable(&self) -> MutDAF<R> {
-        let mut bytes = BytesMut::with_capacity(0);
-        bytes.extend_from_slice(&self.bytes);
         MutDAF {
-            bytes,
+            bytes: BytesMut::from_iter(&self.bytes),
             crc32_checksum: self.crc32_checksum,
             _daf_type: PhantomData,
         }

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -18,19 +18,17 @@ use crate::errors::{DecodingError, InputOutputError};
 use crate::file2heap;
 use crate::naif::daf::DecodingDataSnafu;
 use crate::{errors::IntegrityError, DBL_SIZE};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
+use core::fmt::Debug;
 use core::hash::Hash;
+use core::marker::PhantomData;
 use core::ops::Deref;
 use hifitime::Epoch;
 use log::{debug, error, trace};
 use snafu::ResultExt;
-use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use zerocopy::AsBytes;
 use zerocopy::{FromBytes, Ref};
-
-// Thanks ChatGPT for the idea !
 
 macro_rules! io_imports {
     () => {
@@ -45,13 +43,20 @@ io_imports!();
 
 pub(crate) const RCRD_LEN: usize = 1024;
 #[derive(Clone, Default, Debug, PartialEq)]
-pub struct DAF<R: NAIFSummaryRecord> {
-    pub bytes: Bytes,
+pub struct GenericDAF<R: NAIFSummaryRecord, W: MutKind> {
+    pub bytes: W,
     pub crc32_checksum: u32,
     pub _daf_type: PhantomData<R>,
 }
 
-impl<R: NAIFSummaryRecord> DAF<R> {
+pub type DAF<R> = GenericDAF<R, Bytes>;
+pub type MutDAF<R> = GenericDAF<R, BytesMut>;
+
+pub trait MutKind: Deref<Target = [u8]> {}
+impl MutKind for Bytes {}
+impl MutKind for BytesMut {}
+
+impl<R: NAIFSummaryRecord, W: MutKind> GenericDAF<R, W> {
     /// Compute the CRC32 of the underlying bytes
     pub fn crc32(&self) -> u32 {
         crc32fast::hash(&self.bytes)
@@ -68,48 +73,6 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                 computed: self.crc32(),
             })
         }
-    }
-
-    /// Parse the DAF only if the CRC32 checksum of the data is valid
-    pub fn check_then_parse<B: Deref<Target = [u8]>>(
-        bytes: B,
-        expected: u32,
-    ) -> Result<Self, DAFError> {
-        let computed = crc32fast::hash(&bytes);
-        if computed != expected {
-            return Err(DAFError::DAFIntegrity {
-                source: IntegrityError::ChecksumInvalid { expected, computed },
-            });
-        }
-
-        Self::parse(bytes)
-    }
-
-    pub fn load(path: &str) -> Result<Self, DAFError> {
-        let bytes = file2heap!(path).with_context(|_| IOSnafu {
-            action: format!("loading {path:?}"),
-        })?;
-
-        Self::parse(bytes)
-    }
-
-    /// Parse the provided static byte array as a SPICE Double Array File
-    pub fn from_static<B: Deref<Target = [u8]>>(bytes: &'static B) -> Result<Self, DAFError> {
-        Self::parse(Bytes::from_static(bytes))
-    }
-
-    /// Parse the provided bytes as a SPICE Double Array File
-    pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
-        let crc32_checksum = crc32fast::hash(&bytes);
-        let me = Self {
-            bytes: Bytes::copy_from_slice(&bytes),
-            crc32_checksum,
-            _daf_type: PhantomData,
-        };
-        // Check that these calls will succeed.
-        me.file_record()?;
-        me.name_record()?;
-        Ok(me)
     }
 
     pub fn file_record(&self) -> Result<FileRecord, DAFError> {
@@ -323,7 +286,6 @@ impl<R: NAIFSummaryRecord> DAF<R> {
 
         // Convert it
         S::from_slice_f64(data).with_context(|_| DecodingDataSnafu { kind: R::NAME, idx })
-        // S::from_slice_f64(data)
     }
 
     pub fn comments(&self) -> Result<Option<String>, DAFError> {
@@ -398,10 +360,65 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     }
 }
 
-impl<R: NAIFSummaryRecord> Hash for DAF<R> {
+impl<R: NAIFSummaryRecord, W: MutKind> Hash for GenericDAF<R, W> {
     /// Hash will only hash the bytes, nothing else (since these are derived from the bytes anyway).
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.bytes.hash(state);
+    }
+}
+
+impl<R: NAIFSummaryRecord> DAF<R> {
+    /// Parse the provided bytes as a SPICE Double Array File
+    pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
+        let crc32_checksum = crc32fast::hash(&bytes);
+        let me = Self {
+            bytes: Bytes::copy_from_slice(&bytes),
+            crc32_checksum,
+            _daf_type: PhantomData,
+        };
+        // Check that these calls will succeed.
+        me.file_record()?;
+        me.name_record()?;
+        Ok(me)
+    }
+
+    /// Parse the DAF only if the CRC32 checksum of the data is valid
+    pub fn check_then_parse<B: Deref<Target = [u8]>>(
+        bytes: B,
+        expected: u32,
+    ) -> Result<Self, DAFError> {
+        let computed = crc32fast::hash(&bytes);
+        if computed != expected {
+            return Err(DAFError::DAFIntegrity {
+                source: IntegrityError::ChecksumInvalid { expected, computed },
+            });
+        }
+
+        Self::parse(bytes)
+    }
+
+    pub fn load(path: &str) -> Result<Self, DAFError> {
+        let bytes = file2heap!(path).with_context(|_| IOSnafu {
+            action: format!("loading {path:?}"),
+        })?;
+
+        Self::parse(bytes)
+    }
+
+    /// Parse the provided static byte array as a SPICE Double Array File
+    pub fn from_static<B: Deref<Target = [u8]>>(bytes: &'static B) -> Result<Self, DAFError> {
+        Self::parse(Bytes::from_static(bytes))
+    }
+
+    /// Copies the underlying bytes of this DAF into a MutDAF, enabling modification of the DAF.
+    pub fn to_mutable(&self) -> MutDAF<R> {
+        let mut bytes = BytesMut::with_capacity(0);
+        bytes.extend_from_slice(&self.bytes);
+        MutDAF {
+            bytes,
+            crc32_checksum: self.crc32_checksum,
+            _daf_type: PhantomData,
+        }
     }
 }
 

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -250,13 +250,13 @@ impl<R: NAIFSummaryRecord, W: MutKind> GenericDAF<R, W> {
 
     /// Provided a name that is in the summary, return its full data, if name is available.
     pub fn nth_data<'a, S: NAIFDataSet<'a>>(&'a self, idx: usize) -> Result<S, DAFError> {
-        let this_summary =
-            self.data_summaries()?
-                .get(idx)
-                .ok_or_else(|| DAFError::InvalidIndex {
-                    idx,
-                    kind: S::DATASET_NAME,
-                })?;
+        let this_summary = self
+            .data_summaries()?
+            .get(idx)
+            .ok_or(DAFError::InvalidIndex {
+                idx,
+                kind: S::DATASET_NAME,
+            })?;
         // Grab the data in native endianness (TODO: How to support both big and little endian?)
         trace!("{idx} -> {this_summary:?}");
         if self.file_record()?.is_empty() {

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -250,7 +250,13 @@ impl<R: NAIFSummaryRecord, W: MutKind> GenericDAF<R, W> {
 
     /// Provided a name that is in the summary, return its full data, if name is available.
     pub fn nth_data<'a, S: NAIFDataSet<'a>>(&'a self, idx: usize) -> Result<S, DAFError> {
-        let this_summary = &self.data_summaries()?[idx];
+        let this_summary =
+            self.data_summaries()?
+                .get(idx)
+                .ok_or_else(|| DAFError::InvalidIndex {
+                    idx,
+                    kind: S::DATASET_NAME,
+                })?;
         // Grab the data in native endianness (TODO: How to support both big and little endian?)
         trace!("{idx} -> {this_summary:?}");
         if self.file_record()?.is_empty() {

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -291,7 +291,7 @@ impl<R: NAIFSummaryRecord, W: MutKind> GenericDAF<R, W> {
         .into_slice();
 
         // Convert it
-        S::from_slice_f64(data).with_context(|_| DecodingDataSnafu { kind: R::NAME, idx })
+        S::from_f64_slice(data).with_context(|_| DecodingDataSnafu { kind: R::NAME, idx })
     }
 
     pub fn comments(&self) -> Result<Option<String>, DAFError> {

--- a/anise/src/naif/daf/data_types.rs
+++ b/anise/src/naif/daf/data_types.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -34,6 +34,27 @@ impl<'a> Type2ChebyshevSet<'a> {
     pub fn degree(&self) -> usize {
         (self.rsize - 2) / 3 - 1
     }
+
+    fn spline_idx<S: NAIFSummaryRecord>(
+        &self,
+        epoch: Epoch,
+        summary: &S,
+    ) -> Result<usize, InterpolationError> {
+        if epoch < summary.start_epoch() || epoch > summary.end_epoch() {
+            // No need to go any further.
+            return Err(InterpolationError::NoInterpolationData {
+                req: epoch,
+                start: summary.start_epoch(),
+                end: summary.end_epoch(),
+            });
+        }
+
+        let window_duration_s = self.interval_length.to_seconds();
+
+        let ephem_start_delta_s = epoch.to_et_seconds() - summary.start_epoch_et_s();
+
+        Ok(((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records))
+    }
 }
 
 impl<'a> fmt::Display for Type2ChebyshevSet<'a> {
@@ -126,46 +147,10 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         epoch: Epoch,
         summary: &S,
     ) -> Result<(Vector3, Vector3), InterpolationError> {
-        if epoch < summary.start_epoch() || epoch > summary.end_epoch() {
-            // No need to go any further.
-            return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
-                start: summary.start_epoch(),
-                end: summary.end_epoch(),
-            });
-        }
+        let spline_idx = self.spline_idx(epoch, summary)?;
 
         let window_duration_s = self.interval_length.to_seconds();
-
         let radius_s = window_duration_s / 2.0;
-        let ephem_start_delta_s = epoch.to_et_seconds() - summary.start_epoch_et_s();
-
-        /*
-                CSPICE CODE
-                https://github.com/ChristopherRabotin/cspice/blob/26c72936fb7ff6f366803a1419b7cc3c61e0b6e5/src/cspice/spkr02.c#L272
-
-            i__1 = end - 3;
-            dafgda_(handle, &i__1, &end, record);
-            init = record[0];
-            intlen = record[1];
-            recsiz = (integer) record[2];
-            nrec = (integer) record[3];
-            recno = (integer) ((*et - init) / intlen) + 1;
-            recno = min(recno,nrec);
-
-        /*     Compute the address of the desired record. */
-
-            recadr = (recno - 1) * recsiz + begin;
-
-        /*     Along with the record, return the size of the record. */
-
-            record[0] = record[2];
-            i__1 = recadr + recsiz - 1;
-            dafgda_(handle, &recadr, &i__1, &record[1]);
-                */
-
-        let spline_idx =
-            ((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records);
 
         // Now, build the X, Y, Z data from the record data.
         let record = self
@@ -202,6 +187,31 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         }
 
         Ok(())
+    }
+
+    fn truncate<S: NAIFSummaryRecord>(
+        mut self,
+        summary: &S,
+        new_start: Option<Epoch>,
+        new_end: Option<Epoch>,
+    ) -> Result<Self, InterpolationError> {
+        let start_idx = if let Some(start) = new_start {
+            self.spline_idx(start, summary)? - 1
+        } else {
+            0
+        };
+
+        let end_idx = if let Some(end) = new_end {
+            self.spline_idx(end, summary)? - 1
+        } else {
+            self.num_records - 1
+        };
+
+        self.record_data = &self.record_data[start_idx * self.rsize..(end_idx + 1) * self.rsize];
+        self.num_records = (self.record_data.len() / self.rsize) - 1;
+        self.init_epoch = self.nth_record(0).unwrap().midpoint_epoch() - 0.5 * self.interval_length;
+
+        Ok(self)
     }
 }
 

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -202,7 +202,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         };
 
         let end_idx = if let Some(end) = new_end {
-            self.spline_idx(end, summary)? - 1
+            self.spline_idx(end, summary)?
         } else {
             self.num_records - 1
         };

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -213,6 +213,17 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
 
         Ok(self)
     }
+
+    /// Builds the DAF array representing a Chebyshev Type 2 interpolation set.
+    fn to_f64_daf_vec(&self) -> Result<Vec<f64>, InterpolationError> {
+        let mut data = self.record_data.to_vec();
+        data.push(self.init_epoch.to_et_seconds());
+        data.push(self.interval_length.to_seconds());
+        data.push(self.rsize as f64);
+        data.push(self.num_records as f64);
+
+        Ok(data)
+    }
 }
 
 pub struct Type2ChebyshevRecord<'a> {

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -76,7 +76,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
     type RecordKind = Type2ChebyshevRecord<'a>;
     const DATASET_NAME: &'static str = "Chebyshev Type 2";
 
-    fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError> {
+    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
         ensure!(
             slice.len() >= 5,
             TooFewDoublesSnafu {
@@ -314,7 +314,7 @@ mod chebyshev_ut {
 
     #[test]
     fn too_small() {
-        if Type2ChebyshevSet::from_slice_f64(&[0.1, 0.2, 0.3, 0.4])
+        if Type2ChebyshevSet::from_f64_slice(&[0.1, 0.2, 0.3, 0.4])
             != Err(DecodingError::TooFewDoubles {
                 dataset: "Chebyshev Type 2",
                 got: 4,
@@ -327,7 +327,7 @@ mod chebyshev_ut {
 
     #[test]
     fn subnormal() {
-        match Type2ChebyshevSet::from_slice_f64(&[0.0, f64::INFINITY, 0.0, 0.0, 0.0]) {
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, f64::INFINITY, 0.0, 0.0, 0.0]) {
             Ok(_) => panic!("test failed on invalid init_epoch"),
             Err(e) => {
                 assert_eq!(
@@ -342,7 +342,7 @@ mod chebyshev_ut {
             }
         }
 
-        match Type2ChebyshevSet::from_slice_f64(&[0.0, 0.0, f64::INFINITY, 0.0, 0.0]) {
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, 0.0, f64::INFINITY, 0.0, 0.0]) {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {
                 assert_eq!(
@@ -357,7 +357,7 @@ mod chebyshev_ut {
             }
         }
 
-        match Type2ChebyshevSet::from_slice_f64(&[0.0, 0.0, -1e-16, 0.0, 0.0]) {
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, 0.0, -1e-16, 0.0, 0.0]) {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {
                 assert_eq!(
@@ -376,7 +376,7 @@ mod chebyshev_ut {
 
         // Load a slice whose metadata is OK but the record data is not
         let dataset =
-            Type2ChebyshevSet::from_slice_f64(&[f64::INFINITY, 0.0, 2e-16, 0.0, 0.0]).unwrap();
+            Type2ChebyshevSet::from_f64_slice(&[f64::INFINITY, 0.0, 2e-16, 0.0, 0.0]).unwrap();
         match dataset.check_integrity() {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -53,7 +53,7 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
     type RecordKind = PositionVelocityRecord;
     const DATASET_NAME: &'static str = "Hermite Type 12";
 
-    fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError> {
+    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
         ensure!(
             slice.len() >= 5,
             TooFewDoublesSnafu {
@@ -171,7 +171,7 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
     type RecordKind = PositionVelocityRecord;
     const DATASET_NAME: &'static str = "Hermite Type 13";
 
-    fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError> {
+    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
         ensure!(
             slice.len() >= 3,
             TooFewDoublesSnafu {
@@ -398,7 +398,7 @@ mod hermite_ut {
 
     #[test]
     fn too_small() {
-        if HermiteSetType13::from_slice_f64(&[0.1, 0.2])
+        if HermiteSetType13::from_f64_slice(&[0.1, 0.2])
             != Err(DecodingError::TooFewDoubles {
                 dataset: "Hermite Type 13",
                 got: 2,
@@ -416,7 +416,7 @@ mod hermite_ut {
 
         let mut invalid_num_records = zeros;
         invalid_num_records[zeros.len() - 1] = f64::INFINITY;
-        match HermiteSetType13::from_slice_f64(&invalid_num_records) {
+        match HermiteSetType13::from_f64_slice(&invalid_num_records) {
             Ok(_) => panic!("test failed on invalid num records"),
             Err(e) => {
                 assert_eq!(
@@ -435,7 +435,7 @@ mod hermite_ut {
 
         let mut invalid_num_samples = zeros;
         invalid_num_samples[zeros.len() - 2] = f64::INFINITY;
-        match HermiteSetType13::from_slice_f64(&invalid_num_samples) {
+        match HermiteSetType13::from_f64_slice(&invalid_num_samples) {
             Ok(_) => panic!("test failed on invalid num samples"),
             Err(e) => {
                 assert_eq!(
@@ -455,7 +455,7 @@ mod hermite_ut {
         let mut invalid_epoch = zeros;
         invalid_epoch[zeros.len() - 3] = f64::INFINITY;
 
-        let dataset = HermiteSetType13::from_slice_f64(&invalid_epoch).unwrap();
+        let dataset = HermiteSetType13::from_f64_slice(&invalid_epoch).unwrap();
         match dataset.check_integrity() {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {
@@ -474,7 +474,7 @@ mod hermite_ut {
         // Force the number of records to be one, otherwise everything is considered the epoch registry
         invalid_record[zeros.len() - 1] = 1.0;
 
-        let dataset = HermiteSetType13::from_slice_f64(&invalid_record).unwrap();
+        let dataset = HermiteSetType13::from_f64_slice(&invalid_record).unwrap();
         match dataset.check_integrity() {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -49,7 +49,7 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
     type RecordKind = PositionVelocityRecord;
     const DATASET_NAME: &'static str = "Lagrange Type 8";
 
-    fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError> {
+    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
         ensure!(
             slice.len() >= 5,
             TooFewDoublesSnafu {
@@ -157,7 +157,7 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
     type RecordKind = PositionVelocityRecord;
     const DATASET_NAME: &'static str = "Lagrange Type 9";
 
-    fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError> {
+    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
         ensure!(
             slice.len() >= 3,
             TooFewDoublesSnafu {

--- a/anise/src/naif/daf/datatypes/mod.rs
+++ b/anise/src/naif/daf/datatypes/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/datatypes/posvel.rs
+++ b/anise/src/naif/daf/datatypes/posvel.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -86,6 +86,29 @@ pub trait NAIFDataSet<'a>: Sized + Display + PartialEq {
 
     /// Checks the integrity of this data set, returns an error if the data has issues.
     fn check_integrity(&self) -> Result<(), IntegrityError>;
+
+    /// Returns a copy of Self where the data corresponds to the start and end times provided.
+    /// If either is set to None, then that data will not be modified.
+    ///
+    /// # Rounding of truncation
+    /// The exact new start and new end times may not match the exact data. This function only truncates
+    /// the available data and does not make any modifications to it (i.e. it does not recompute the interpolation coefficients).
+    ///
+    /// # Error
+    /// This function will return an error if the new start is before the current start or if the new end is after the current end of the data.
+    /// That's because it can't make up new data.
+    fn truncate<S: NAIFSummaryRecord>(
+        self,
+        summary: &S,
+        new_start: Option<Epoch>,
+        new_end: Option<Epoch>,
+    ) -> Result<Self, InterpolationError> {
+        /*
+        IDEA:
+        # Chebyshev: grab the spline index for the provided start time and stop time.
+         */
+        unimplemented!("truncation is not available yet")
+    }
 }
 
 pub trait NAIFDataRecord<'a>: Display {

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -223,12 +223,8 @@ pub enum DAFError {
     },
     #[snafu(display("DAF/{kind}: data index {idx} is invalid"))]
     InvalidIndex { kind: &'static str, idx: usize },
-    #[snafu(display("DAF/{kind}: encountered {source} when {action}"))]
-    MutInterpolationError {
-        kind: &'static str,
-        action: &'static str,
-        source: InterpolationError,
-    },
+    #[snafu(display("could not build data vector of type DAF/{kind}"))]
+    DataBuildError { kind: &'static str },
 }
 
 // Manual implementation of PartialEq because IOError does not derive it, sadly.

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -59,6 +59,10 @@ pub trait NAIFSummaryRecord: NAIFRecord + Copy {
     fn is_empty(&self) -> bool {
         self.start_index() == self.end_index()
     }
+    /// Updates the indexes of this summary (used when modifying a DAF).
+    fn update_indexes(&mut self, start: usize, end: usize);
+    /// Updates the epochs of this summary (used when modifying a DAF).
+    fn update_epochs(&mut self, start_epoch: Epoch, end_epoch: Epoch);
     /// Name of this NAIF type
     const NAME: &'static str;
 }

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -76,6 +76,11 @@ pub trait NAIFDataSet<'a>: Sized + Display + PartialEq {
     /// Builds this dataset given a slice of f64 data
     fn from_slice_f64(slice: &'a [f64]) -> Result<Self, DecodingError>;
 
+    /// Builds the DAF array representing this data
+    fn to_f64_daf_array(&self) -> Vec<f64> {
+        unimplemented!("this dataset cannot yet be converted to a new DAF array")
+    }
+
     fn nth_record(&self, n: usize) -> Result<Self::RecordKind, DecodingError>;
 
     fn evaluate<S: NAIFSummaryRecord>(
@@ -103,10 +108,6 @@ pub trait NAIFDataSet<'a>: Sized + Display + PartialEq {
         new_start: Option<Epoch>,
         new_end: Option<Epoch>,
     ) -> Result<Self, InterpolationError> {
-        /*
-        IDEA:
-        # Chebyshev: grab the spline index for the provided start time and stop time.
-         */
         unimplemented!("truncation is not available yet")
     }
 }
@@ -210,6 +211,8 @@ pub enum DAFError {
         dtype: DafDataType,
         kind: &'static str,
     },
+    #[snafu(display("DAF/{kind}: data index {idx} is invalid"))]
+    InvalidIndex { kind: &'static str, idx: usize },
 }
 
 // Manual implementation of PartialEq because IOError does not derive it, sadly.

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -21,6 +21,7 @@ pub(crate) const RCRD_LEN: usize = 1024;
 #[allow(clippy::module_inception)]
 pub mod daf;
 mod data_types;
+pub mod mut_daf;
 pub use data_types::DataType as DafDataType;
 pub mod file_record;
 pub mod name_record;

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -18,7 +18,7 @@ use zerocopy::AsBytes;
 use crate::{
     errors::{DecodingError, InputOutputError},
     file2heap,
-    naif::daf::file_record::FileRecordError,
+    naif::daf::{file_record::FileRecordError, MutInterpolationSnafu},
     DBL_SIZE,
 };
 
@@ -104,7 +104,12 @@ impl<R: NAIFSummaryRecord> MutDAF<R> {
 
         // let original_size = (end - start) as isize;
 
-        let new_data_bytes = new_data.to_f64_daf_array();
+        let new_data_bytes = new_data
+            .to_f64_daf_vec()
+            .with_context(|_| MutInterpolationSnafu {
+                kind: R::NAME,
+                action: "building new DAF vector",
+            })?;
         // let new_size = new_data_bytes.len() as isize;
 
         // Update the bytes

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -1,0 +1,75 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use core::{marker::PhantomData, ops::Deref};
+
+use bytes::BytesMut;
+use snafu::ResultExt;
+use zerocopy::AsBytes;
+
+use crate::{
+    errors::{DecodingError, InputOutputError},
+    file2heap,
+};
+
+use super::{
+    daf::MutDAF, DAFError, DecodingNameSnafu, IOSnafu, NAIFSummaryRecord, NameRecord, RCRD_LEN,
+};
+
+macro_rules! io_imports {
+    () => {
+        use std::fs::File;
+    };
+}
+
+io_imports!();
+
+impl<R: NAIFSummaryRecord> MutDAF<R> {
+    /// Parse the provided bytes as a SPICE Double Array File
+    pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
+        let crc32_checksum = crc32fast::hash(&bytes);
+        let mut buf = BytesMut::with_capacity(0);
+        buf.extend(bytes.iter());
+        let me = Self {
+            bytes: buf,
+            crc32_checksum,
+            _daf_type: PhantomData,
+        };
+        // Check that these calls will succeed.
+        me.file_record()?;
+        me.name_record()?;
+        Ok(me)
+    }
+
+    pub fn load(path: &str) -> Result<Self, DAFError> {
+        let bytes = file2heap!(path).with_context(|_| IOSnafu {
+            action: format!("loading {path:?}"),
+        })?;
+
+        Self::parse(bytes)
+    }
+
+    /// Sets the name record of this mutable DAF file to the one provided as a parameter.
+    pub fn set_name_record(&mut self, new_name_record: NameRecord) -> Result<(), DAFError> {
+        let rcrd_idx = self.file_record()?.fwrd_idx() * RCRD_LEN;
+        let size = self.bytes.len();
+        let rcrd_bytes = self
+            .bytes
+            .get_mut(rcrd_idx..rcrd_idx + RCRD_LEN)
+            .ok_or_else(|| DecodingError::InaccessibleBytes {
+                start: rcrd_idx,
+                end: rcrd_idx + RCRD_LEN,
+                size,
+            })
+            .with_context(|_| DecodingNameSnafu { kind: R::NAME })?;
+        rcrd_bytes.copy_from_slice(new_name_record.as_bytes());
+        Ok(())
+    }
+}

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -10,30 +10,21 @@
 
 use core::{marker::PhantomData, ops::Deref};
 
-use bytes::BytesMut;
-use hifitime::Epoch;
-use snafu::ResultExt;
-use zerocopy::AsBytes;
-
-use crate::{
-    errors::{DecodingError, InputOutputError},
-    file2heap,
-    naif::daf::{file_record::FileRecordError, MutInterpolationSnafu, NAIFRecord, SummaryRecord},
-    DBL_SIZE,
-};
-
 use super::{
     daf::MutDAF, DAFError, DecodingNameSnafu, IOSnafu, NAIFDataSet, NAIFSummaryRecord, NameRecord,
     RCRD_LEN,
 };
-
-macro_rules! io_imports {
-    () => {
-        use std::fs::File;
-    };
-}
-
-io_imports!();
+use crate::{
+    errors::{DecodingError, InputOutputError},
+    file2heap,
+    naif::daf::{file_record::FileRecordError, NAIFRecord, SummaryRecord},
+    DBL_SIZE,
+};
+use bytes::BytesMut;
+use hifitime::Epoch;
+use snafu::ResultExt;
+use std::fs::File;
+use zerocopy::AsBytes;
 
 impl<R: NAIFSummaryRecord> MutDAF<R> {
     /// Parse the provided bytes as a SPICE Double Array File
@@ -106,10 +97,7 @@ impl<R: NAIFSummaryRecord> MutDAF<R> {
 
         let new_data_bytes = new_data
             .to_f64_daf_vec()
-            .with_context(|_| MutInterpolationSnafu {
-                kind: R::NAME,
-                action: "building new DAF vector",
-            })?;
+            .or(Err(DAFError::DataBuildError { kind: R::NAME }))?;
 
         let new_size = new_data_bytes.len() as isize;
 

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -55,21 +55,9 @@ impl NameRecord {
     }
 
     /// Changes the name of the n-th record
-    ///
-    /// # Safety
-    ///
-    /// This function uses an `unsafe` call to mutate the underlying `&[u8]` even though it isn't declared as mutable.
-    /// This will _only_ change the name record and will, at worst, change the full name.
-    ///
-    /// In terms of concurrency, this means that if the Context is borrowed while this function is called, between two separate calls,
-    /// the name of a record may no longer be available.
-    pub fn set_nth_name(&self, n: usize, summary_size: usize, new_name: &str) {
+    pub fn set_nth_name(&mut self, n: usize, summary_size: usize, new_name: &str) {
         let this_name =
-            &self.raw_names[n * summary_size * DBL_SIZE..(n + 1) * summary_size * DBL_SIZE];
-
-        let this_name = unsafe {
-            core::slice::from_raw_parts_mut(this_name.as_ptr() as *mut u8, this_name.len())
-        };
+            &mut self.raw_names[n * summary_size * DBL_SIZE..(n + 1) * summary_size * DBL_SIZE];
 
         // Copy the name (thanks Clippy)
         let cur_len = this_name.len();

--- a/anise/src/naif/daf/summary_record.rs
+++ b/anise/src/naif/daf/summary_record.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/kpl/fk.rs
+++ b/anise/src/naif/kpl/fk.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/kpl/mod.rs
+++ b/anise/src/naif/kpl/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/kpl/parser.rs
+++ b/anise/src/naif/kpl/parser.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/kpl/tpc.rs
+++ b/anise/src/naif/kpl/tpc.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/mod.rs
+++ b/anise/src/naif/mod.rs
@@ -16,10 +16,20 @@ pub mod spk;
 
 pub mod pretty_print;
 
-use self::{daf::DAF, pck::BPCSummaryRecord, spk::summary::SPKSummaryRecord};
+use self::{
+    daf::{daf::MutDAF, DAF},
+    pck::BPCSummaryRecord,
+    spk::summary::SPKSummaryRecord,
+};
 
+/// Spacecraft Planetary Kernel
 pub type SPK = DAF<SPKSummaryRecord>;
+/// Spacecraft Planetary Kernel, mutable, for editing DAF/SPK files
+pub type MutSPK = MutDAF<SPKSummaryRecord>;
+/// Binary Planetary Constant
 pub type BPC = DAF<BPCSummaryRecord>;
+/// Binary Planetary Constant, mutable, for editing DAF/PCK files
+pub type MutBPC = MutDAF<BPCSummaryRecord>;
 
 #[macro_export]
 macro_rules! parse_bytes_as {

--- a/anise/src/naif/mod.rs
+++ b/anise/src/naif/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/pck/mod.rs
+++ b/anise/src/naif/pck/mod.rs
@@ -91,4 +91,14 @@ impl NAIFSummaryRecord for BPCSummaryRecord {
     fn end_epoch_et_s(&self) -> f64 {
         self.end_epoch_et_s
     }
+
+    fn update_indexes(&mut self, start: usize, end: usize) {
+        self.start_idx = start as i32;
+        self.end_idx = end as i32;
+    }
+
+    fn update_epochs(&mut self, start_epoch: Epoch, end_epoch: Epoch) {
+        self.start_epoch_et_s = start_epoch.to_et_seconds();
+        self.end_epoch_et_s = end_epoch.to_et_seconds();
+    }
 }

--- a/anise/src/naif/pck/mod.rs
+++ b/anise/src/naif/pck/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/spk/mod.rs
+++ b/anise/src/naif/spk/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/spk/summary.rs
+++ b/anise/src/naif/spk/summary.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/naif/spk/summary.rs
+++ b/anise/src/naif/spk/summary.rs
@@ -187,6 +187,16 @@ impl NAIFSummaryRecord for SPKSummaryRecord {
     fn end_epoch_et_s(&self) -> f64 {
         self.end_epoch_et_s
     }
+
+    fn update_indexes(&mut self, start: usize, end: usize) {
+        self.start_idx = start as i32;
+        self.end_idx = end as i32;
+    }
+
+    fn update_epochs(&mut self, start_epoch: Epoch, end_epoch: Epoch) {
+        self.start_epoch_et_s = start_epoch.to_et_seconds();
+        self.end_epoch_et_s = end_epoch.to_et_seconds();
+    }
 }
 
 impl fmt::Display for SPKSummaryRecord {

--- a/anise/src/orientations/mod.rs
+++ b/anise/src/orientations/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/orientations/paths.rs
+++ b/anise/src/orientations/paths.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/orientations/rotate_to_parent.rs
+++ b/anise/src/orientations/rotate_to_parent.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/orientations/rotations.rs
+++ b/anise/src/orientations/rotations.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/py_errors.rs
+++ b/anise/src/py_errors.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/dataset/builder.rs
+++ b/anise/src/structure/dataset/builder.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/dataset/datatype.rs
+++ b/anise/src/structure/dataset/datatype.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/lookuptable.rs
+++ b/anise/src/structure/lookuptable.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/metadata.rs
+++ b/anise/src/structure/metadata.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/mod.rs
+++ b/anise/src/structure/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/planetocentric/ellipsoid.rs
+++ b/anise/src/structure/planetocentric/ellipsoid.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/planetocentric/mod.rs
+++ b/anise/src/structure/planetocentric/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/planetocentric/phaseangle.rs
+++ b/anise/src/structure/planetocentric/phaseangle.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/semver.rs
+++ b/anise/src/structure/semver.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/spacecraft/drag.rs
+++ b/anise/src/structure/spacecraft/drag.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/spacecraft/inertia.rs
+++ b/anise/src/structure/spacecraft/inertia.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/spacecraft/mass.rs
+++ b/anise/src/structure/spacecraft/mass.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/spacecraft/mod.rs
+++ b/anise/src/structure/spacecraft/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/src/structure/spacecraft/srp.rs
+++ b/anise/src/structure/spacecraft/srp.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/mod.rs
+++ b/anise/tests/ephemerides/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/parent_translation_verif.rs
+++ b/anise/tests/ephemerides/parent_translation_verif.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/paths.rs
+++ b/anise/tests/ephemerides/paths.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/translation.rs
+++ b/anise/tests/ephemerides/translation.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/validation/compare.rs
+++ b/anise/tests/ephemerides/validation/compare.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/validation/mod.rs
+++ b/anise/tests/ephemerides/validation/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/validation/type02_chebyshev_jpl_de.rs
+++ b/anise/tests/ephemerides/validation/type02_chebyshev_jpl_de.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/validation/type13_hermite.rs
+++ b/anise/tests/ephemerides/validation/type13_hermite.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/ephemerides/validation/validate.rs
+++ b/anise/tests/ephemerides/validation/validate.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/frames/format.rs
+++ b/anise/tests/frames/format.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/frames/mod.rs
+++ b/anise/tests/frames/mod.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/lib.rs
+++ b/anise/tests/lib.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -208,7 +208,7 @@ fn test_spk_truncate_cheby() {
 
     let path = "../data/de440s.bsp";
 
-    let mut my_spk = SPK::load(path).unwrap().to_mutable();
+    let my_spk = SPK::load(path).unwrap();
 
     // Check that we correctly throw an error if the nth data does not exist.
     assert!(my_spk.nth_data::<Type2ChebyshevSet>(100).is_err());
@@ -221,8 +221,13 @@ fn test_spk_truncate_cheby() {
     let updated_segment = segment
         .truncate(&summary, Some(summary.start_epoch() + Unit::Day * 16), None)
         .unwrap();
+
     assert!(
         updated_segment.init_epoch - orig_init_epoch <= Unit::Day * 16,
         "truncated too much data"
     );
+
+    // Now we can grab a mutable version of the SPK and modify it.
+    let mut my_spk_mut = my_spk.to_mutable();
+    assert!(my_spk_mut.set_nth_data(0, updated_segment).is_ok());
 }

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -13,7 +13,7 @@ use std::mem::size_of_val;
 use anise::{
     file2heap,
     naif::{
-        daf::{datatypes::Type2ChebyshevSet, DAF},
+        daf::{datatypes::Type2ChebyshevSet, NAIFDataSet, DAF},
         pck::BPCSummaryRecord,
         spk::summary::SPKSummaryRecord,
         Endian,
@@ -200,4 +200,21 @@ fn test_spk_mut_summary_name() {
         reloaded.name_record().unwrap().nth_name(0, summary_size),
         "Renamed #0 (ANISE by Nyx Space)"
     );
+}
+
+#[test]
+fn test_spk_truncate_cheby() {
+    let _ = pretty_env_logger::try_init();
+
+    let path = "../data/de440s.bsp";
+
+    let mut my_spk = SPK::load(path).unwrap().to_mutable();
+
+    let summary = my_spk.data_summaries().unwrap()[0];
+    let segment = my_spk.nth_data::<Type2ChebyshevSet>(0).unwrap();
+    println!("{segment}");
+    let updated_segment = segment
+        .truncate(&summary, Some(summary.start_epoch() + Unit::Day * 15), None)
+        .unwrap();
+    println!("{updated_segment}");
 }

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -213,8 +213,10 @@ fn test_spk_truncate_cheby() {
     // Check that we correctly throw an error if the nth data does not exist.
     assert!(my_spk.nth_data::<Type2ChebyshevSet>(100).is_err());
 
-    let summary = my_spk.data_summaries().unwrap()[0];
-    let segment = my_spk.nth_data::<Type2ChebyshevSet>(0).unwrap();
+    let idx = 10;
+
+    let summary = my_spk.data_summaries().unwrap()[idx];
+    let segment = my_spk.nth_data::<Type2ChebyshevSet>(idx).unwrap();
 
     let orig_init_epoch = segment.init_epoch;
 
@@ -235,14 +237,14 @@ fn test_spk_truncate_cheby() {
     // Now we can grab a mutable version of the SPK and modify it.
     let mut my_spk_mut = my_spk.to_mutable();
     assert!(my_spk_mut
-        .set_nth_data(0, updated_segment, new_start, summary.end_epoch())
+        .set_nth_data(idx, updated_segment, new_start, summary.end_epoch())
         .is_ok());
 
     // Serialize the data into a new BSP and confirm that we've updated everything.
     let output_path = "../target/truncated-de440s.bsp";
     my_spk_mut.persist(output_path).unwrap();
-    let reloaded = SPK::load(output_path).unwrap();
 
-    let summary = reloaded.data_summaries().unwrap()[0];
+    let reloaded = SPK::load(output_path).unwrap();
+    let summary = reloaded.data_summaries().unwrap()[idx];
     assert_eq!(summary.start_epoch(), new_start);
 }

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -210,11 +210,19 @@ fn test_spk_truncate_cheby() {
 
     let mut my_spk = SPK::load(path).unwrap().to_mutable();
 
+    // Check that we correctly throw an error if the nth data does not exist.
+    assert!(my_spk.nth_data::<Type2ChebyshevSet>(100).is_err());
+
     let summary = my_spk.data_summaries().unwrap()[0];
     let segment = my_spk.nth_data::<Type2ChebyshevSet>(0).unwrap();
-    println!("{segment}");
+
+    let orig_init_epoch = segment.init_epoch;
+
     let updated_segment = segment
-        .truncate(&summary, Some(summary.start_epoch() + Unit::Day * 15), None)
+        .truncate(&summary, Some(summary.start_epoch() + Unit::Day * 16), None)
         .unwrap();
-    println!("{updated_segment}");
+    assert!(
+        updated_segment.init_epoch - orig_init_epoch <= Unit::Day * 16,
+        "truncated too much data"
+    );
 }

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -235,16 +235,30 @@ fn test_spk_truncate_cheby() {
     );
 
     // Now we can grab a mutable version of the SPK and modify it.
-    let mut my_spk_mut = my_spk.to_mutable();
-    assert!(my_spk_mut
+    let mut my_spk_trunc = my_spk.to_mutable();
+    assert!(my_spk_trunc
         .set_nth_data(idx, updated_segment, new_start, summary.end_epoch())
         .is_ok());
 
     // Serialize the data into a new BSP and confirm that we've updated everything.
     let output_path = "../target/truncated-de440s.bsp";
-    my_spk_mut.persist(output_path).unwrap();
+    my_spk_trunc.persist(output_path).unwrap();
 
     let reloaded = SPK::load(output_path).unwrap();
     let summary = reloaded.data_summaries().unwrap()[idx];
     assert_eq!(summary.start_epoch(), new_start);
+
+    // Test that we can remove segments all togethet
+    let mut my_spk_rm = my_spk.to_mutable();
+    assert!(my_spk_rm.delete_nth_data(idx).is_ok());
+
+    // Serialize the data into a new BSP and confirm that we've updated everything.
+    let output_path = "../target/rm-de440s.bsp";
+    my_spk_rm.persist(output_path).unwrap();
+
+    let reloaded = SPK::load(output_path).unwrap();
+    assert!(
+        reloaded.summary_from_id(301).is_err(),
+        "summary 301 not removed"
+    );
 }

--- a/anise/tests/naif.rs
+++ b/anise/tests/naif.rs
@@ -174,26 +174,30 @@ fn test_spk_mut_summary_name() {
     let _ = pretty_env_logger::try_init();
 
     let path = "../data/variable-seg-size-hermite.bsp";
+    let output_path = "../data/rename-test.bsp";
 
-    let mut example_data = SPK::load(path).unwrap().to_mutable();
+    let mut my_spk = SPK::load(path).unwrap().to_mutable();
 
-    let summary_size = example_data.file_record().unwrap().summary_size();
+    let summary_size = my_spk.file_record().unwrap().summary_size();
 
-    let mut name_rcrd = example_data.name_record().unwrap();
-    name_rcrd.set_nth_name(0, summary_size, "BLAH BLAH");
-    example_data.set_name_record(name_rcrd).unwrap();
+    let mut name_rcrd = my_spk.name_record().unwrap();
 
-    dbg!(example_data
-        .name_record()
-        .unwrap()
-        .nth_name(0, summary_size));
+    // Rename all summaries
+    for sno in 0..my_spk.data_summaries().unwrap().len() {
+        name_rcrd.set_nth_name(
+            sno,
+            summary_size,
+            &format!("Renamed #{sno} (ANISE by Nyx Space)"),
+        );
+    }
+    my_spk.set_name_record(name_rcrd).unwrap();
 
-    // example_data.persist(path).unwrap();
+    my_spk.persist(&output_path).unwrap();
 
     // Check that the written file is correct.
-    let reloaded = SPK::load(path).unwrap();
+    let reloaded = SPK::load(output_path).unwrap();
     assert_eq!(
         reloaded.name_record().unwrap().nth_name(0, summary_size),
-        "BLAH BLAH"
+        "Renamed #0 (ANISE by Nyx Space)"
     );
 }

--- a/anise/tests/orientations/validation.rs
+++ b/anise/tests/orientations/validation.rs
@@ -1,6 +1,6 @@
 /*
  * ANISE Toolkit
- * Copyright (C) 2021-2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/data/rename-test.bsp
+++ b/data/rename-test.bsp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78071e80977338bacfa867e867fc8b53bbd59ffd07addf12f84ae11e98790952
-size 82944
+oid sha256:62e4ce41a6aa17910b5c0c41845cbca2f81884ba8f63fa66b975dcd059a33737
+size 80896

--- a/data/variable-seg-size-hermite.bsp
+++ b/data/variable-seg-size-hermite.bsp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92d8789c09ddff7f774715fe1f5ac2284c3ebd92120c3554f7945ba06b799378
-size 84992
+oid sha256:995ad203359e3acd7ceca2c883d16553b9d43af8fb45adbc3c9f3c2c921c33df
+size 82944


### PR DESCRIPTION
# Summary

+ Provides the ability to truncate segments or remove segments from any DAF file, available via API and CLI
+ Provides the ability, via the API only, to rename segments in DAF files

## Architectural Changes

Most of the `DAF` functionality has been moved to a `GenericDAF<W>`, where `W` is either `Bytes` or `BytesMut` (of course, only the latter enables modification of the underlying bytes).

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

+ Truncate existing DAF segments
+ Remove existing DAF segments
+ Rename DAF segments (modifying the `name record`)

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

1. Renaming test renames a segment, saves the new DAF/SPK, reloads it, and ensures that the name was changed
2. Modification test truncates a segment that isn't at the start of the file, saves it, and reloads it, checking that the start time was modified and the end time was not modified. A manual test was also done here via the CLI for both the truncation and inspection of the changes
3. Modification test includes removing the Moon (301) from the DE440s.bsp file, and checks that after saving, that entry is indeed removed.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->