### PR TITLE
Support SPK Type 9: Lagrange unequal time steps + Support env vars in MetaFile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-        
+
       - name: Download data
         run: |
           wget -O data/de421.bsp http://public-data.nyxspace.com/anise/de421.bsp
@@ -115,12 +115,17 @@ jobs:
 
       - name: Rust-SPICE hermite validation
         run: RUST_BACKTRACE=1 cargo test validate_hermite_type13_ --features spkezr_validation --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --include-ignored --test-threads 1
-      
+
+      - name: Rust-SPICE Lagrange validation
+        env:
+          LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
+        run: RUST_BACKTRACE=1 cargo test validate_lagrange_type9_with_varying_segment_sizes --features spkezr_validation --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --include-ignored --test-threads 1
+
       - name: Rust-SPICE PCK validation
         run: RUST_BACKTRACE=1 cargo test validate_iau_rotation_to_parent --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --ignored
-      
+
       - name: Rust-SPICE BPC validation
-        run: | 
+        run: |
           RUST_BACKTRACE=1 cargo test validate_bpc_ --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --include-ignored --test-threads 1
           RUST_BACKTRACE=1 cargo test de440s_translation_verif_venus2emb --release --workspace --exclude anise-gui --exclude anise-py -- --nocapture --include-ignored --test-threads 1
 
@@ -148,7 +153,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Download data
         run: |
           wget -O data/de421.bsp http://public-data.nyxspace.com/anise/de421.bsp
@@ -173,6 +178,8 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage report
+        env:
+            LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
         run: |
           cd anise # Prevent the workspace flag
           cargo llvm-cov clean --workspace
@@ -183,6 +190,7 @@ jobs:
           cargo llvm-cov test --no-report validate_jplde_de440s_no_aberration --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_jplde_de440s_aberration_lt --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_hermite_type13_from_gmat --features spkezr_validation -- --nocapture --ignored
+          cargo llvm-cov test --no-report validate_lagrange_type9_with_varying_segment_sizes --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report ut_embed --features embed_ephem
           cargo llvm-cov report --lcov > ../lcov.txt
         env:
@@ -217,4 +225,3 @@ jobs:
           cd anise # Jump into the package
           cargo login $TOKEN
           cargo publish
-        

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,9 +55,13 @@ jobs:
         run: sh dev-env-setup.sh && cd .. # Return to root
 
       - name: Test debug
+        env:
+          LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
         run: cargo test --workspace --exclude anise-gui --exclude anise-py
 
       - name: Test release
+        env:
+          LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
         run: cargo test --release --workspace --exclude anise-gui --exclude anise-py
 
   lints:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -179,7 +179,8 @@ jobs:
 
       - name: Generate coverage report
         env:
-            LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
+          LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
+          RUSTFLAGS: --cfg __ui_tests
         run: |
           cd anise # Prevent the workspace flag
           cargo llvm-cov clean --workspace
@@ -193,8 +194,6 @@ jobs:
           cargo llvm-cov test --no-report validate_lagrange_type9_with_varying_segment_sizes --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report ut_embed --features embed_ephem
           cargo llvm-cov report --lcov > ../lcov.txt
-        env:
-          RUSTFLAGS: --cfg __ui_tests
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -37,7 +37,7 @@ rust-embed = { version = "8.4.0", features = [
     "interpolate-folder-path",
     "include-exclude",
 ], optional = true }
-regex = "1.10.5"
+regex = {version = "1.10.5" , optional = true}
 
 [dev-dependencies]
 rust-spice = "0.7.6"
@@ -54,7 +54,7 @@ default = ["metaload"]
 # Enabling this flag significantly increases compilation times due to Arrow and Polars.
 spkezr_validation = []
 python = ["pyo3", "pyo3-log"]
-metaload = ["url", "reqwest/blocking", "platform-dirs"]
+metaload = ["url", "reqwest/blocking", "platform-dirs", "regex"]
 embed_ephem = ["rust-embed"]
 
 [[bench]]

--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -37,6 +37,7 @@ rust-embed = { version = "8.4.0", features = [
     "interpolate-folder-path",
     "include-exclude",
 ], optional = true }
+regex = "1.10.5"
 
 [dev-dependencies]
 rust-spice = "0.7.6"

--- a/anise/src/math/interpolation/hermite.rs
+++ b/anise/src/math/interpolation/hermite.rs
@@ -16,7 +16,6 @@
    2. The relevant comments (including authors) from hrmint are kept.
    3. The tests are not part of the original SPICE code.
    4. The transliteration in itself justifies the change of license from unrestricted to MPL.
-
 */
 /* hrmint.f -- translated by f2c (version 19980913).
    You must link the resulting object file with the libraries:
@@ -93,7 +92,7 @@ pub fn hermite_eval(
 
     // At this point, we know that the lengths of items is correct, so we can directly address them without worry for overflowing the array.
 
-    let work: &mut [f64] = &mut [0.0; 256];
+    let work: &mut [f64] = &mut [0.0; 8 * MAX_SAMPLES];
     let n: usize = xs.len();
 
     /*     Copy the input array into WORK.  After this, the first column */
@@ -181,10 +180,10 @@ pub fn hermite_eval(
             let denom = xs[xij - 1] - xs[xi - 1];
             if denom.abs() < f64::EPSILON {
                 return Err(InterpolationError::InterpMath {
-                    source:MathError::DivisionByZero {
-                    action:
-                        "hermite data contains likely duplicate abcissa, remove duplicate states",
-                }});
+                    source: MathError::DivisionByZero {
+                        action: "hermite data contains duplicate states",
+                    },
+                });
             }
 
             /*           Compute the interpolated derivative at X for the Ith */

--- a/anise/src/math/interpolation/hermite.rs
+++ b/anise/src/math/interpolation/hermite.rs
@@ -24,37 +24,37 @@
 
 /* $ Restrictions */
 
-/*     None. */
+/*  None. */
 
 /* $ Literature_References */
 
-/*     [1]  "Numerical Recipes---The Art of Scientific Computing" by */
-/*           William H. Press, Brian P. Flannery, Saul A. Teukolsky, */
-/*           William T. Vetterling (see sections 3.0 and 3.1). */
+/*  [1]  "Numerical Recipes---The Art of Scientific Computing" by */
+/*  William H. Press, Brian P. Flannery, Saul A. Teukolsky, */
+/*  William T. Vetterling (see sections 3.0 and 3.1). */
 
-/*     [2]  "Elementary Numerical Analysis---An Algorithmic Approach" */
-/*           by S. D. Conte and Carl de Boor.  See p. 64. */
+/*  [2]  "Elementary Numerical Analysis---An Algorithmic Approach" */
+/*  by S. D. Conte and Carl de Boor.  See p. 64. */
 
 /* $ Author_and_Institution */
 
-/*     N.J. Bachman   (JPL) */
+/*  N.J. Bachman   (JPL) */
 
 /* $ Version */
 
 /* -    SPICELIB Version 1.2.1, 28-JAN-2014 (NJB) */
 
-/*        Fixed a few comment typos. */
+/*  Fixed a few comment typos. */
 
 /* -    SPICELIB Version 1.2.0, 01-FEB-2002 (NJB) (EDW) */
 
-/*        Bug fix:  declarations of local variables XI and XIJ */
-/*        were changed from DOUBLE PRECISION to INTEGER. */
-/*        Note:  bug had no effect on behavior of this routine. */
+/*  Bug fix:  declarations of local variables XI and XIJ */
+/*  were changed from DOUBLE PRECISION to INTEGER. */
+/*  Note:  bug had no effect on behavior of this routine. */
 
 /* -    SPICELIB Version 1.1.0, 28-DEC-2001 (NJB) */
 
-/*        Blanks following final newline were truncated to */
-/*        suppress compilation warnings on the SGI-N32 platform. */
+/*  Blanks following final newline were truncated to */
+/*  suppress compilation warnings on the SGI-N32 platform. */
 
 /* -    SPICELIB Version 1.0.0, 01-MAR-2000 (NJB) */
 
@@ -95,24 +95,24 @@ pub fn hermite_eval(
     let work: &mut [f64] = &mut [0.0; 8 * MAX_SAMPLES];
     let n: usize = xs.len();
 
-    /*     Copy the input array into WORK.  After this, the first column */
-    /*     of WORK represents the first column of our triangular */
-    /*     interpolation table. */
+    /*  Copy the input array into WORK.  After this, the first column */
+    /*  of WORK represents the first column of our triangular */
+    /*  interpolation table. */
 
     for i in 0..n {
         work[2 * i] = ys[i];
         work[2 * i + 1] = ydots[i];
     }
 
-    /*     Compute the second column of the interpolation table: this */
-    /*     consists of the N-1 values obtained by evaluating the */
-    /*     first-degree interpolants at X. We'll also evaluate the */
-    /*     derivatives of these interpolants at X and save the results in */
-    /*     the second column of WORK. Because the derivative computations */
-    /*     depend on the function computations from the previous column in */
-    /*     the interpolation table, and because the function interpolation */
-    /*     overwrites the previous column of interpolated function values, */
-    /*     we must evaluate the derivatives first. */
+    /*  Compute the second column of the interpolation table: this */
+    /*  consists of the N-1 values obtained by evaluating the */
+    /*  first-degree interpolants at X. We'll also evaluate the */
+    /*  derivatives of these interpolants at X and save the results in */
+    /*  the second column of WORK. Because the derivative computations */
+    /*  depend on the function computations from the previous column in */
+    /*  the interpolation table, and because the function interpolation */
+    /*  overwrites the previous column of interpolated function values, */
+    /*  we must evaluate the derivatives first. */
 
     for i in 1..=n - 1 {
         let c1 = xs[i] - x_eval;
@@ -127,51 +127,50 @@ pub fn hermite_eval(
             });
         }
 
-        /*        The second column of WORK contains interpolated derivative */
-        /*        values. */
+        /*  The second column of WORK contains interpolated derivative */
+        /*  values. */
 
-        /*        The odd-indexed interpolated derivatives are simply the input */
-        /*        derivatives. */
+        /*  The odd-indexed interpolated derivatives are simply the input */
+        /*  derivatives. */
 
         let prev = 2 * i - 1;
         let curr = 2 * i;
         work[prev + 2 * n - 1] = work[prev];
 
-        /*        The even-indexed interpolated derivatives are the slopes of */
-        /*        the linear interpolating polynomials for adjacent input */
-        /*        abscissa/ordinate pairs. */
+        /*  The even-indexed interpolated derivatives are the slopes of */
+        /*  the linear interpolating polynomials for adjacent input */
+        /*  abscissa/ordinate pairs. */
 
         work[prev + 2 * n] = (work[curr] - work[prev - 1]) / denom;
 
-        /*        The first column of WORK contains interpolated function values. */
-        /*        The odd-indexed entries are the linear Taylor polynomials, */
-        /*        for each input abscissa value, evaluated at X. */
+        /*  The first column of WORK contains interpolated function values. */
+        /*  The odd-indexed entries are the linear Taylor polynomials, */
+        /*  for each input abscissa value, evaluated at X. */
 
         let temp = work[prev] * (x_eval - xs[i - 1]) + work[prev - 1];
         work[prev] = (c1 * work[prev - 1] + c2 * work[curr]) / denom;
         work[prev - 1] = temp;
     }
 
-    /*     The last column entries were not computed by the preceding loop; */
-    /*     compute them now. */
+    /*  The last column entries were not computed by the preceding loop; */
+    /*  compute them now. */
 
     work[4 * n - 2] = work[(2 * n) - 1];
     work[2 * (n - 1)] += work[(2 * n) - 1] * (x_eval - xs[n - 1]);
 
-    /*     Compute columns 3 through 2*N of the table. */
+    /*  Compute columns 3 through 2*N of the table. */
 
     for j in 2..=(2 * n) - 1 {
         for i in 1..=(2 * n) - j {
-            /*           In the theoretical construction of the interpolation table,
-             */
-            /*           there are 2*N abscissa values, since each input abcissa */
-            /*           value occurs with multiplicity two. In this theoretical */
-            /*           construction, the Jth column of the interpolation table */
-            /*           contains results of evaluating interpolants that span J+1 */
-            /*           consecutive abscissa values.  The indices XI and XIJ below */
-            /*           are used to pick the correct abscissa values out of the */
-            /*           physical XVALS array, in which the abscissa values are not */
-            /*           repeated. */
+            /*  In the theoretical construction of the interpolation table, */
+            /*  there are 2*N abscissa values, since each input abcissa */
+            /*  value occurs with multiplicity two. In this theoretical */
+            /*  construction, the Jth column of the interpolation table */
+            /*  contains results of evaluating interpolants that span J+1 */
+            /*  consecutive abscissa values.  The indices XI and XIJ below */
+            /*  are used to pick the correct abscissa values out of the */
+            /*  physical XVALS array, in which the abscissa values are not */
+            /*  repeated. */
 
             let xi = (i + 1) / 2;
             let xij = (i + j + 1) / 2;
@@ -186,30 +185,29 @@ pub fn hermite_eval(
                 });
             }
 
-            /*           Compute the interpolated derivative at X for the Ith */
-            /*           interpolant. This is the derivative with respect to X of */
-            /*           the expression for the interpolated function value, which */
-            /*           is the second expression below. This derivative computation
-             */
-            /*           is done first because it relies on the interpolated */
-            /*           function values from the previous column of the */
-            /*           interpolation table. */
+            /*  Compute the interpolated derivative at X for the Ith */
+            /*  interpolant. This is the derivative with respect to X of */
+            /*  the expression for the interpolated function value, which */
+            /*  is the second expression below. This derivative computation */
+            /*  is done first because it relies on the interpolated */
+            /*  function values from the previous column of the */
+            /*  interpolation table. */
 
-            /*           The derivative expression here corresponds to equation */
-            /*           2.35 on page 64 in reference [2]. */
+            /*  The derivative expression here corresponds to equation */
+            /*  2.35 on page 64 in reference [2]. */
 
             work[i + 2 * n - 1] =
                 (c1 * work[i + 2 * n - 1] + c2 * work[i + 2 * n] + (work[i] - work[i - 1])) / denom;
 
-            /*           Compute the interpolated function value at X for the Ith */
-            /*           interpolant. */
+            /*  Compute the interpolated function value at X for the Ith */
+            /*  interpolant. */
 
             work[i - 1] = (c1 * work[i - 1] + c2 * work[i]) / denom;
         }
     }
 
-    /*     Our interpolated function value is sitting in WORK(1,1) at this */
-    /*     point.  The interpolated derivative is located in WORK(1,2). */
+    /*  Our interpolated function value is sitting in WORK(1,1) at this */
+    /*  point. The interpolated derivative is located in WORK(1,2). */
 
     let f = work[0];
     let df = work[2 * n];

--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -10,7 +10,7 @@
 
 use crate::errors::MathError;
 
-use super::InterpolationError;
+use super::{InterpolationError, MAX_SAMPLES};
 
 pub fn lagrange_eval(
     xs: &[f64],
@@ -29,8 +29,11 @@ pub fn lagrange_eval(
 
     // At this point, we know that the lengths of items is correct, so we can directly address them without worry for overflowing the array.
 
-    let mut work = ys.to_vec();
-    let mut dwork = vec![0.0; ys.len()];
+    let work: &mut [f64] = &mut [0.0; MAX_SAMPLES];
+    let dwork: &mut [f64] = &mut [0.0; MAX_SAMPLES];
+    for (ii, y) in ys.iter().enumerate() {
+        work[ii] = *y;
+    }
 
     let n = xs.len();
 
@@ -41,8 +44,6 @@ pub fn lagrange_eval(
 
             let denom = xi - xij;
             if denom.abs() < f64::EPSILON {
-                dbg!(&xs);
-                dbg!(&ys);
                 return Err(InterpolationError::InterpMath {
                     source: MathError::DivisionByZero {
                         action: "lagrange data contains duplicate states",

--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -1,0 +1,174 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+/*
+   NOTES:
+   1. This code is manually transliterated from CSPICE's `lgrint.c`.
+   2. The relevant comments (including authors) from lgrint are kept.
+   3. The tests are not part of the original SPICE code.
+   4. The transliteration in itself justifies the change of license from unrestricted to MPL.
+*/
+/* lgrint.f -- translated by f2c (version 19980913).
+   You must link the resulting object file with the libraries:
+    -lf2c -lm   (in that order)
+*/
+
+/* $ Restrictions */
+
+/*     None. */
+
+/* $ Literature_References */
+
+/*     [1]  "Numerical Recipes---The Art of Scientific Computing" by */
+/*           William H. Press, Brian P. Flannery, Saul A. Teukolsky, */
+/*           William T. Vetterling (see sections 3.0 and 3.1). */
+
+/* $ Author_and_Institution */
+
+/*     N.J. Bachman   (JPL) */
+
+/* $ Version */
+
+/* -    SPICELIB Version 1.0.0, 16-AUG-1993 (NJB) */
+
+use crate::errors::MathError;
+
+use super::InterpolationError;
+
+pub fn lagrange_eval(xs: &[f64], ys: &[f64], x_eval: f64) -> Result<f64, InterpolationError> {
+    if xs.len() != ys.len() {
+        return Err(InterpolationError::CorruptedData {
+            what: "lengths of abscissas (xs), ordinates (ys), and first derivatives (ydots) differ",
+        });
+    } else if xs.is_empty() {
+        return Err(InterpolationError::CorruptedData {
+            what: "list of abscissas (xs) is empty",
+        });
+    }
+
+    // At this point, we know that the lengths of items is correct, so we can directly address them without worry for overflowing the array.
+
+    /*     We're going to compute the value of our interpolating polynomial */
+    /*     at X by taking advantage of a recursion relation between */
+    /*     Lagrange polynomials of order n+1 and order n.  The method works */
+    /*     as follows: */
+
+    /*        Define */
+
+    /*           P               (x) */
+    /*            i(i+1)...(i+j) */
+
+    /*        to be the unique Lagrange polynomial that interpolates our */
+    /*        input function at the abscissa values */
+
+    /*           x ,  x   , ... x   . */
+    /*            i    i+1       i+j */
+
+    /*        Then we have the recursion relation */
+
+    /*           P              (x)  = */
+    /*            i(i+1)...(i+j) */
+
+    /*                                  x - x */
+    /*                                   i */
+    /*                                 -----------  *  P                (x) */
+    /*                                  x - x           (i+1)...(i+j) */
+    /*                                   i   i+j */
+
+    /*                                  x  -  x */
+    /*                                         i+j */
+    /*                               + -----------  *  P                (x) */
+    /*                                  x  -  x         i(i+1)...(i+j-1) */
+    /*                                   i     i+j */
+
+    /*        Repeated application of this relation allows us to build */
+    /*        successive columns, in left-to-right order, of the */
+    /*        triangular table */
+
+    /*           P (x) */
+    /*            1 */
+    /*                    P  (x) */
+    /*                     12 */
+    /*           P (x)             P   (x) */
+    /*            2                 123 */
+    /*                    P  (x) */
+    /*                     23               . */
+    /*                             P   (x) */
+    /*           .                  234            . */
+    /*           . */
+    /*           .        .                               . */
+    /*                    . */
+    /*                    .        .                           P      (x) */
+    /*                             .                      .     12...N */
+    /*                             . */
+    /*                                             . */
+
+    /*                                      . */
+
+    /*                             P           (x) */
+    /*                              (N-2)(N-1)N */
+    /*                    P     (x) */
+    /*                     (N-1)N */
+    /*           P (x) */
+    /*            N */
+
+    /*        and after N-1 steps arrive at our desired result, */
+
+    /*           P       (x). */
+    /*            12...N */
+
+    /*     The computation is easier to do than to describe. */
+
+    /*     We'll use the scratch array WORK to contain the current column of */
+    /*     our interpolation table.  To start out with, WORK(I) will contain */
+
+    /*        P (x). */
+    /*         I */
+
+    let mut work = ys.to_vec();
+
+    let n = xs.len();
+
+    for j in 1..n {
+        for i in 0..(n - j) {
+            let denom = xs[i] - xs[i + j];
+            if denom.abs() < f64::EPSILON {
+                return Err(InterpolationError::InterpMath {
+                    source: MathError::DivisionByZero {
+                        action: "lagrange data contains duplicate states",
+                    },
+                });
+            }
+
+            work[i] = ((x_eval - xs[i + j]) * work[i] + (xs[i] - x_eval) * work[i + 1])
+                / (xs[i] - xs[i + j]);
+        }
+    }
+    Ok(work[0])
+}
+
+#[test]
+fn lagrange_spice_docs_example() {
+    let ts = [-1.0, 0.0, 3.0, 5.0];
+    let yvals = [-2.0, -7.0, -8.0, 26.0];
+
+    // Check that we can interpolate the values exactly.
+    for (i, t) in ts.iter().enumerate() {
+        let eval = lagrange_eval(&ts, &yvals, *t).unwrap();
+        let eval_err = (eval - yvals[i]).abs();
+        assert!(eval_err < f64::EPSILON, "f(x) error is {eval_err:e}");
+    }
+
+    // Check the interpolation from the SPICE documentation
+    let x = lagrange_eval(&ts, &yvals, 2.0).unwrap();
+
+    // WARNING: The documentation data is wrong! Evaluation at 2.0 returns -12.2999... in spiceypy.
+    let expected_x = -12.299999999999999;
+    assert!((x - expected_x).abs() < f64::EPSILON, "X error");
+}

--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -57,6 +57,7 @@ pub fn lagrange_eval(
             dwork[i] = ((x_eval - xij) * dwork[i] + (xi - x_eval) * dwork[i + 1]) / denom + deriv;
         }
     }
+
     let f = work[0];
     let df = dwork[0];
     Ok((f, df))

--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -41,6 +41,8 @@ pub fn lagrange_eval(
 
             let denom = xi - xij;
             if denom.abs() < f64::EPSILON {
+                dbg!(&xs);
+                dbg!(&ys);
                 return Err(InterpolationError::InterpMath {
                     source: MathError::DivisionByZero {
                         action: "lagrange data contains duplicate states",

--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -7,41 +7,16 @@
  *
  * Documentation: https://nyxspace.com/
  */
-/*
-   NOTES:
-   1. This code is manually transliterated from CSPICE's `lgrint.c`.
-   2. The relevant comments (including authors) from lgrint are kept.
-   3. The tests are not part of the original SPICE code.
-   4. The transliteration in itself justifies the change of license from unrestricted to MPL.
-*/
-/* lgrint.f -- translated by f2c (version 19980913).
-   You must link the resulting object file with the libraries:
-    -lf2c -lm   (in that order)
-*/
-
-/* $ Restrictions */
-
-/*     None. */
-
-/* $ Literature_References */
-
-/*     [1]  "Numerical Recipes---The Art of Scientific Computing" by */
-/*           William H. Press, Brian P. Flannery, Saul A. Teukolsky, */
-/*           William T. Vetterling (see sections 3.0 and 3.1). */
-
-/* $ Author_and_Institution */
-
-/*     N.J. Bachman   (JPL) */
-
-/* $ Version */
-
-/* -    SPICELIB Version 1.0.0, 16-AUG-1993 (NJB) */
 
 use crate::errors::MathError;
 
 use super::InterpolationError;
 
-pub fn lagrange_eval(xs: &[f64], ys: &[f64], x_eval: f64) -> Result<f64, InterpolationError> {
+pub fn lagrange_eval(
+    xs: &[f64],
+    ys: &[f64],
+    x_eval: f64,
+) -> Result<(f64, f64), InterpolationError> {
     if xs.len() != ys.len() {
         return Err(InterpolationError::CorruptedData {
             what: "lengths of abscissas (xs), ordinates (ys), and first derivatives (ydots) differ",
@@ -54,90 +29,17 @@ pub fn lagrange_eval(xs: &[f64], ys: &[f64], x_eval: f64) -> Result<f64, Interpo
 
     // At this point, we know that the lengths of items is correct, so we can directly address them without worry for overflowing the array.
 
-    /*     We're going to compute the value of our interpolating polynomial */
-    /*     at X by taking advantage of a recursion relation between */
-    /*     Lagrange polynomials of order n+1 and order n.  The method works */
-    /*     as follows: */
-
-    /*        Define */
-
-    /*           P               (x) */
-    /*            i(i+1)...(i+j) */
-
-    /*        to be the unique Lagrange polynomial that interpolates our */
-    /*        input function at the abscissa values */
-
-    /*           x ,  x   , ... x   . */
-    /*            i    i+1       i+j */
-
-    /*        Then we have the recursion relation */
-
-    /*           P              (x)  = */
-    /*            i(i+1)...(i+j) */
-
-    /*                                  x - x */
-    /*                                   i */
-    /*                                 -----------  *  P                (x) */
-    /*                                  x - x           (i+1)...(i+j) */
-    /*                                   i   i+j */
-
-    /*                                  x  -  x */
-    /*                                         i+j */
-    /*                               + -----------  *  P                (x) */
-    /*                                  x  -  x         i(i+1)...(i+j-1) */
-    /*                                   i     i+j */
-
-    /*        Repeated application of this relation allows us to build */
-    /*        successive columns, in left-to-right order, of the */
-    /*        triangular table */
-
-    /*           P (x) */
-    /*            1 */
-    /*                    P  (x) */
-    /*                     12 */
-    /*           P (x)             P   (x) */
-    /*            2                 123 */
-    /*                    P  (x) */
-    /*                     23               . */
-    /*                             P   (x) */
-    /*           .                  234            . */
-    /*           . */
-    /*           .        .                               . */
-    /*                    . */
-    /*                    .        .                           P      (x) */
-    /*                             .                      .     12...N */
-    /*                             . */
-    /*                                             . */
-
-    /*                                      . */
-
-    /*                             P           (x) */
-    /*                              (N-2)(N-1)N */
-    /*                    P     (x) */
-    /*                     (N-1)N */
-    /*           P (x) */
-    /*            N */
-
-    /*        and after N-1 steps arrive at our desired result, */
-
-    /*           P       (x). */
-    /*            12...N */
-
-    /*     The computation is easier to do than to describe. */
-
-    /*     We'll use the scratch array WORK to contain the current column of */
-    /*     our interpolation table.  To start out with, WORK(I) will contain */
-
-    /*        P (x). */
-    /*         I */
-
     let mut work = ys.to_vec();
+    let mut dwork = vec![0.0; ys.len()];
 
     let n = xs.len();
 
     for j in 1..n {
         for i in 0..(n - j) {
-            let denom = xs[i] - xs[i + j];
+            let xi = xs[i];
+            let xij = xs[i + j];
+
+            let denom = xi - xij;
             if denom.abs() < f64::EPSILON {
                 return Err(InterpolationError::InterpMath {
                     source: MathError::DivisionByZero {
@@ -146,29 +48,51 @@ pub fn lagrange_eval(xs: &[f64], ys: &[f64], x_eval: f64) -> Result<f64, Interpo
                 });
             }
 
-            work[i] = ((x_eval - xs[i + j]) * work[i] + (xs[i] - x_eval) * work[i + 1])
-                / (xs[i] - xs[i + j]);
+            let work_i = work[i];
+            let work_ip1 = work[i + 1];
+
+            work[i] = ((x_eval - xij) * work_i + (xi - x_eval) * work_ip1) / denom;
+
+            let deriv = (work_i - work_ip1) / denom;
+            dwork[i] = ((x_eval - xij) * dwork[i] + (xi - x_eval) * dwork[i + 1]) / denom + deriv;
         }
     }
-    Ok(work[0])
+    let f = work[0];
+    let df = dwork[0];
+    Ok((f, df))
 }
 
 #[test]
 fn lagrange_spice_docs_example() {
     let ts = [-1.0, 0.0, 3.0, 5.0];
     let yvals = [-2.0, -7.0, -8.0, 26.0];
+    let dyvals = [
+        -4.6333333333333334,
+        -4.9833333333333333,
+        7.76666666666666666,
+        27.7666666666666662,
+    ];
 
     // Check that we can interpolate the values exactly.
     for (i, t) in ts.iter().enumerate() {
-        let eval = lagrange_eval(&ts, &yvals, *t).unwrap();
+        let (eval, deval) = lagrange_eval(&ts, &yvals, *t).unwrap();
         let eval_err = (eval - yvals[i]).abs();
         assert!(eval_err < f64::EPSILON, "f(x) error is {eval_err:e}");
+
+        let deval_err = (deval - dyvals[i]).abs();
+        assert!(
+            deval_err < f64::EPSILON,
+            "#{i}: f'(x) error is {deval_err:e}"
+        );
     }
 
     // Check the interpolation from the SPICE documentation
-    let x = lagrange_eval(&ts, &yvals, 2.0).unwrap();
+    let (x, dx) = lagrange_eval(&ts, &yvals, 2.0).unwrap();
 
     // WARNING: The documentation data is wrong! Evaluation at 2.0 returns -12.2999... in spiceypy.
     let expected_x = -12.299999999999999;
+    let expected_dx = 1.2166666666666666;
+    dbg!(x, dx);
     assert!((x - expected_x).abs() < f64::EPSILON, "X error");
+    assert!((dx - expected_dx).abs() < f64::EPSILON, "dX error");
 }

--- a/anise/src/math/interpolation/mod.rs
+++ b/anise/src/math/interpolation/mod.rs
@@ -15,6 +15,7 @@ mod lagrange;
 pub use chebyshev::chebyshev_eval;
 pub use hermite::hermite_eval;
 use hifitime::Epoch;
+pub use lagrange::lagrange_eval;
 use snafu::Snafu;
 
 use crate::errors::{DecodingError, MathError};

--- a/anise/src/math/interpolation/mod.rs
+++ b/anise/src/math/interpolation/mod.rs
@@ -10,6 +10,7 @@
 
 mod chebyshev;
 mod hermite;
+mod lagrange;
 
 pub use chebyshev::chebyshev_eval;
 pub use hermite::hermite_eval;
@@ -50,4 +51,8 @@ pub enum InterpolationError {
         kind: &'static str,
         op: &'static str,
     },
+    #[snafu(display(
+        "{dataset} is not yet supported -- https://github.com/nyx-space/anise/issues/{issue}"
+    ))]
+    UnimplementedType { issue: u32, dataset: &'static str },
 }

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -115,7 +115,10 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
         _epoch: Epoch,
         _: &S,
     ) -> Result<CartesianState, InterpolationError> {
-        todo!("https://github.com/anise-toolkit/anise.rs/issues/14")
+        Err(InterpolationError::UnimplementedType {
+            dataset: Self::DATASET_NAME,
+            issue: 14,
+        })
     }
 
     fn check_integrity(&self) -> Result<(), IntegrityError> {

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -112,7 +112,10 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
         _epoch: Epoch,
         _: &S,
     ) -> Result<CartesianState, InterpolationError> {
-        todo!("https://github.com/anise-toolkit/anise.rs/issues/12")
+        Err(InterpolationError::UnimplementedType {
+            dataset: Self::DATASET_NAME,
+            issue: 12,
+        })
     }
 
     fn check_integrity(&self) -> Result<(), IntegrityError> {
@@ -205,7 +208,10 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
         _epoch: Epoch,
         _: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
-        todo!("https://github.com/anise-toolkit/anise.rs/issues/13")
+        Err(InterpolationError::UnimplementedType {
+            dataset: Self::DATASET_NAME,
+            issue: 12,
+        })
     }
 
     fn check_integrity(&self) -> Result<(), IntegrityError> {

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -244,10 +244,10 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
 
                 // Ensure that we aren't fetching out of the window
                 let mut first_idx = idx.saturating_sub(num_left);
-                let last_idx = group_size.min(first_idx + group_size);
+                let last_idx = self.num_records.min(first_idx + group_size);
 
                 // Check that we have enough samples
-                if last_idx == group_size {
+                if last_idx == self.num_records {
                     first_idx = last_idx - 2 * num_left;
                 }
 

--- a/anise/tests/ephemerides/translation.rs
+++ b/anise/tests/ephemerides/translation.rs
@@ -657,12 +657,33 @@ fn type9_lagrange_query() {
 
     // Query in the middle to the parent, since we don't have anything else loaded.
     let state = almanac
-        .translate(obj_frame, EARTH_J2000, start, Aberration::NONE)
+        .translate(
+            obj_frame,
+            EARTH_J2000,
+            start + 1.159_f64.seconds(),
+            Aberration::NONE,
+        )
         .unwrap();
 
-    let expected_pos_km = Vector3::new(-7330.07448072, 3165.86736474, 765.52615102);
-    let expected_vel_km_s = Vector3::new(-7.224378, -5.265514, -4.125131);
+    let expected_pos_km = Vector3::new(-7338.44373643, 3159.7629953, 760.74472775);
+    let expected_vel_km_s = Vector3::new(-7.21781188, -5.26834555, -4.12581558);
 
     dbg!(state.radius_km - expected_pos_km);
     dbg!(state.velocity_km_s - expected_vel_km_s);
+
+    assert!(
+        relative_eq!(state.radius_km, expected_pos_km, epsilon = 5e-6),
+        "got {} but want {} => err = {:.3e} km",
+        state.radius_km,
+        expected_pos_km,
+        (state.radius_km - expected_pos_km).norm()
+    );
+
+    assert!(
+        relative_eq!(state.velocity_km_s, expected_vel_km_s, epsilon = 5e-9),
+        "got {} but want {} => err = {:.3e} km/s",
+        state.velocity_km_s,
+        expected_vel_km_s,
+        (state.velocity_km_s - expected_vel_km_s).norm()
+    );
 }

--- a/anise/tests/ephemerides/translation.rs
+++ b/anise/tests/ephemerides/translation.rs
@@ -633,3 +633,33 @@ fn de440s_translation_verif_aberrations() {
         );
     }
 }
+
+#[cfg(feature = "metaload")]
+#[test]
+fn type9_lagrange_query() {
+    use anise::almanac::metaload::MetaFile;
+    use anise::constants::frames::EARTH_J2000;
+    use anise::prelude::Frame;
+
+    let lagrange_meta = MetaFile {
+        uri: "http://public-data.nyxspace.com/anise/ci/env:LAGRANGE_BSP".to_string(),
+        crc32: None,
+    };
+
+    let almanac = Almanac::default()
+        .load_from_metafile(lagrange_meta)
+        .unwrap();
+
+    let obj_id = -10;
+    let obj_frame = Frame::from_ephem_j2000(obj_id);
+
+    let (start, _) = almanac.spk_domain(obj_id).unwrap();
+
+    // Query in the middle to the parent, since we don't have anything else loaded.
+    let state = almanac
+        .translate(obj_frame, EARTH_J2000, start, Aberration::NONE)
+        .unwrap();
+
+    // This tests that we've loaded the frame info from the Almanac, otherwise we cannot compute the orbital elements.
+    assert_eq!(format!("{state:x}"), "[Earth J2000] 2000-01-01T13:40:32.183929398 ET\tsma = 7192.041350 km\tecc = 0.024628\tinc = 12.851841 deg\traan = 306.170038 deg\taop = 315.085528 deg\tta = 96.135384 deg");
+}

--- a/anise/tests/ephemerides/translation.rs
+++ b/anise/tests/ephemerides/translation.rs
@@ -660,6 +660,9 @@ fn type9_lagrange_query() {
         .translate(obj_frame, EARTH_J2000, start, Aberration::NONE)
         .unwrap();
 
-    // This tests that we've loaded the frame info from the Almanac, otherwise we cannot compute the orbital elements.
-    assert_eq!(format!("{state:x}"), "[Earth J2000] 2000-01-01T13:40:32.183929398 ET\tsma = 7192.041350 km\tecc = 0.024628\tinc = 12.851841 deg\traan = 306.170038 deg\taop = 315.085528 deg\tta = 96.135384 deg");
+    let expected_pos_km = Vector3::new(-7330.07448072, 3165.86736474, 765.52615102);
+    let expected_vel_km_s = Vector3::new(-7.224378, -5.265514, -4.125131);
+
+    dbg!(state.radius_km - expected_pos_km);
+    dbg!(state.velocity_km_s - expected_vel_km_s);
 }

--- a/anise/tests/ephemerides/translation.rs
+++ b/anise/tests/ephemerides/translation.rs
@@ -299,19 +299,6 @@ fn de438s_translation_verif_emb2moon() {
 fn spk_hermite_type13_verif() {
     let _ = pretty_env_logger::try_init().is_err();
 
-    // "Load" the file via a memory map (avoids allocations)
-    // let path = "../data/de440s.bsp";
-    // let buf = file2heap!(path).unwrap();
-    // let spk = SPK::parse(buf).unwrap();
-
-    // let buf = file2heap!("../data/gmat-hermite.bsp").unwrap();
-    // let spacecraft = SPK::parse(buf).unwrap();
-
-    // let ctx = Almanac::from_spk(spk)
-    //     .unwrap()
-    //     .with_spk(spacecraft)
-    //     .unwrap();
-
     let ctx = Almanac::default()
         .load("../data/de440s.bsp")
         .and_then(|ctx| ctx.load("../data/gmat-hermite.bsp"))

--- a/anise/tests/ephemerides/validation/compare.rs
+++ b/anise/tests/ephemerides/validation/compare.rs
@@ -68,7 +68,6 @@ impl EphemValData {
 /// An ephemeris comparison tool that writes the differences between ephemerides to a Parquet file.
 pub struct CompareEphem {
     pub input_file_names: Vec<String>,
-    pub output_file_name: String,
     pub num_queries_per_pair: usize,
     pub dry_run: bool,
     pub aberration: Option<Aberration>,
@@ -109,7 +108,6 @@ impl CompareEphem {
         let writer = ArrowWriter::try_new(file, Arc::new(schema), Some(props)).unwrap();
 
         Self {
-            output_file_name,
             input_file_names,
             num_queries_per_pair,
             aberration,
@@ -313,8 +311,8 @@ impl CompareEphem {
                         0 => (data.spice_val_x_km, data.anise_val_x_km),
                         1 => (data.spice_val_y_km, data.anise_val_y_km),
                         2 => (data.spice_val_z_km, data.anise_val_z_km),
-                        3 => (data.spice_val_vy_km_s, data.anise_val_vy_km_s),
-                        4 => (data.spice_val_vz_km_s, data.anise_val_vz_km_s),
+                        3 => (data.spice_val_vx_km_s, data.anise_val_vx_km_s),
+                        4 => (data.spice_val_vy_km_s, data.anise_val_vy_km_s),
                         5 => (data.spice_val_vz_km_s, data.anise_val_vz_km_s),
                         _ => unreachable!(),
                     };

--- a/anise/tests/ephemerides/validation/mod.rs
+++ b/anise/tests/ephemerides/validation/mod.rs
@@ -9,6 +9,7 @@
  */
 
 mod type02_chebyshev_jpl_de;
+mod type09_lagrange;
 mod type13_hermite;
 
 mod compare;

--- a/anise/tests/ephemerides/validation/type09_lagrange.rs
+++ b/anise/tests/ephemerides/validation/type09_lagrange.rs
@@ -1,0 +1,38 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use super::{compare::*, validate::Validation};
+use anise::almanac::metaload::MetaFile;
+
+#[ignore = "Requires Rust SPICE -- must be executed serially"]
+#[test]
+fn validate_lagrange_type9_with_varying_segment_sizes() {
+    let mut lagrange_meta = MetaFile {
+        uri: "http://public-data.nyxspace.com/anise/ci/env:LAGRANGE_BSP".to_string(),
+        crc32: None,
+    };
+    lagrange_meta.process().unwrap();
+
+    let file_name = "spk-type9-validation-variable-seg-size".to_string();
+    let comparator = CompareEphem::new(vec![lagrange_meta.uri], file_name.clone(), 10_000, None);
+
+    let err_count = comparator.run();
+
+    assert_eq!(err_count, 0, "None of the queries should fail!");
+
+    let validator = Validation {
+        file_name,
+        max_q75_err: 5e-9,
+        max_q99_err: 2e-7,
+        max_abs_err: 0.05,
+    };
+
+    validator.validate();
+}

--- a/anise/tests/ephemerides/validation/type13_hermite.rs
+++ b/anise/tests/ephemerides/validation/type13_hermite.rs
@@ -36,6 +36,7 @@ fn validate_hermite_type13_from_gmat() {
 #[ignore = "Requires Rust SPICE -- must be executed serially"]
 #[test]
 fn validate_hermite_type13_with_varying_segment_sizes() {
+    // ISSUE: This file is corrupt, cf. https://github.com/nyx-space/anise/issues/262
     let file_name = "spk-type13-validation-variable-seg-size".to_string();
     let comparator = CompareEphem::new(
         vec!["../data/variable-seg-size-hermite.bsp".to_string()],

--- a/anise/tests/ephemerides/validation/type13_hermite.rs
+++ b/anise/tests/ephemerides/validation/type13_hermite.rs
@@ -36,7 +36,6 @@ fn validate_hermite_type13_from_gmat() {
 #[ignore = "Requires Rust SPICE -- must be executed serially"]
 #[test]
 fn validate_hermite_type13_with_varying_segment_sizes() {
-    // ISSUE: This file is corrupt. I messed up the rewrite.
     let file_name = "spk-type13-validation-variable-seg-size".to_string();
     let comparator = CompareEphem::new(
         vec!["../data/variable-seg-size-hermite.bsp".to_string()],


### PR DESCRIPTION
# Summary

- **Add support for SPK Type 09!** Closes #13 
- **Add support for environment variables in MetaFile**: in the URI of a `MetaFile`, you can now specify, e.g. `env:USER` to automatically expand the `USER` environment variable when the MetaFile is processed. This syntax is identical to the Dhall language syntax.

This algorithm is _not_ the SPICE algorithm from spke09.f, but it performs superbly well while remaining clear to read.

Validation results:
```
 INFO  lib::ephemerides::validation::compare > Pairs in comparator: {(-10, 399): (Frame { ephemeris_id: -10, orientation_id: 1, mu_km3_s2: None, shape: None }, Frame { ephemeris_id: 399, orientation_id: 1, mu_km3_s2: None, shape: None }, 2024-08-20T11:22:31.269000133 UTC, 2024-08-21T11:22:31.269000086 UTC)}
 INFO  lib::ephemerides::validation::compare > TimeSeries [2024-08-20T11:23:40.451823499 ET : 2024-08-21T11:23:23.171803769 ET : 8 s 639 ms 999 μs 998 ns] for body -10 J2000 -> Earth J2000
 INFO  lib::ephemerides::validation::compare > Done with all 10000 comparisons
shape: (1, 7)
┌─────────────┬─────────────┬──────────────┬────────────────┬─────────────┬─────────────┬─────────────┐
│ min abs err ┆ q25 abs err ┆ mean abs err ┆ median abs err ┆ q75 abs err ┆ q99 abs err ┆ max abs err │
│ ---         ┆ ---         ┆ ---          ┆ ---            ┆ ---         ┆ ---         ┆ ---         │
│ f64         ┆ f64         ┆ f64          ┆ f64            ┆ f64         ┆ f64         ┆ f64         │
╞═════════════╪═════════════╪══════════════╪════════════════╪═════════════╪═════════════╪═════════════╡
│ 0.0         ┆ 0.0         ┆ 1.5158e-17   ┆ 0.0            ┆ 0.0         ┆ 0.0         ┆ 9.0949e-13  │
└─────────────┴─────────────┴──────────────┴────────────────┴─────────────┴─────────────┴─────────────┘
test ephemerides::validation::type09_lagrange::validate_lagrange_type9_with_varying_segment_sizes ... ok
```

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Provided a Lagrange Type 9 SPK on the Nyx cloud which is used both in unit testing with two tests, one near the start and one near the end of the interpolation data, and run the usual validator that checks 10,000 entries between the start and end of summaries.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

Add documentation for `MetaFile` since it was missing it.

<!-- Thank you for contributing to ANISE! -->