### PR TITLE
Download assets in build.rs for the embed_ephem feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,12 @@ jobs:
         env:
           LAGRANGE_BSP: ${{ secrets.LAGRANGE_BSP }}
         run: cargo test --release --workspace --exclude anise-gui --exclude anise-py
+      
+      - name: Test rust_embed build
+        run: |
+          rm -rf data # Not available on crates.io
+          cargo build --features embed_ephem
+          cargo build --features embed_ephem --release
 
   lints:
     name: Lints

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Test rust_embed build
         run: |
           rm -rf data # Not available on crates.io
+          cd anise # Build only the Rust library
           cargo build --features embed_ephem
           cargo build --features embed_ephem --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."

--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -37,7 +37,7 @@ rust-embed = { version = "8.4.0", features = [
     "interpolate-folder-path",
     "include-exclude",
 ], optional = true }
-regex = {version = "1.10.5" , optional = true}
+regex = { version = "1.10.5", optional = true }
 
 [dev-dependencies]
 rust-spice = "0.7.6"
@@ -48,6 +48,9 @@ iai = "0.1"
 polars = { version = "0.41.1", features = ["lazy", "parquet"] }
 rayon = "1.7"
 serde_yaml = "0.9.30"
+
+[build-dependencies]
+reqwest = { version = "0.11", features = ["blocking"], optional = true }
 
 [features]
 default = ["metaload"]

--- a/anise/build.rs
+++ b/anise/build.rs
@@ -1,0 +1,42 @@
+#[cfg(feature = "embed_ephem")]
+fn main() {
+    // Download the files to embed at build time.
+    use std::{fs::File, io::Write, time::Duration};
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    let embedded_files = [
+        (
+            "http://public-data.nyxspace.com/anise/v0.4/pck11.pca",
+            format!("{}/../data/pck11.pca", env!("CARGO_MANIFEST_DIR")),
+        ),
+        (
+            "http://public-data.nyxspace.com/anise/de440s.bsp",
+            format!("{}/../data/de440s.bsp", env!("CARGO_MANIFEST_DIR")),
+        ),
+    ];
+
+    for (url, dest_path) in embedded_files {
+        let resp = client
+            .get(url)
+            .send()
+            .expect(&format!("could not download {url}"));
+
+        let bytes = resp
+            .bytes()
+            .expect(&format!("could not read bytes from {url}"));
+
+        let mut file =
+            File::create(&dest_path).expect(&format!("could not create the data path {dest_path}"));
+        file.write_all(&bytes)
+            .expect(&format!("could not write asset data to {dest_path}"));
+    }
+}
+
+#[cfg(not(feature = "embed_ephem"))]
+fn main() {
+    // Nothing to do if we aren't embedded files.
+}

--- a/anise/build.rs
+++ b/anise/build.rs
@@ -1,7 +1,12 @@
 #[cfg(feature = "embed_ephem")]
 fn main() {
     // Download the files to embed at build time.
-    use std::{fs::File, io::Write, time::Duration};
+    use std::{
+        fs::{self, File},
+        io::Write,
+        path::Path,
+        time::Duration,
+    };
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
         .timeout(Duration::from_secs(30))
@@ -18,6 +23,13 @@ fn main() {
             format!("{}/../data/de440s.bsp", env!("CARGO_MANIFEST_DIR")),
         ),
     ];
+
+    let data_path = Path::new(&env!("CARGO_MANIFEST_DIR")).join("../data");
+
+    // Create the directory if it doesn't exist
+    if !data_path.exists() {
+        fs::create_dir_all(&data_path).expect(&format!("failed to create directory {data_path:?}"));
+    }
 
     for (url, dest_path) in embedded_files {
         let resp = client


### PR DESCRIPTION
# Summary

Hot fix for version 0.4.0 with the `embed_ephem` feature. The crate does not embed any of the data files, so this change downloads them if needed.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

The building step is checked in CI to ensure that the build is successful.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->