### PR TITLE
Version bump for `bytes` 1.6.1 versioning bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."
@@ -50,7 +50,7 @@ serde = "1"
 serde_derive = "1"
 serde_dhall = "0.12"
 
-anise = { version = "0.4.1", path = "anise", default-features = false }
+anise = { version = "0.4.2", path = "anise", default-features = false }
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,19 @@ exclude = [
 
 [workspace.dependencies]
 hifitime = "4.0.0-alpha"
-memmap2 = "=0.9.4"
-crc32fast = "=1.4.2"
+memmap2 = "0.9.4"
+crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }
-log = "=0.4"
-pretty_env_logger = "=0.5"
+log = "0.4"
+pretty_env_logger = "0.5"
 tabled = "=0.15"
 const_format = "0.2"
 nalgebra = { version = "0.32", default-features = true, features = [
     "serde-serialize",
 ] }
-approx = "=0.5.1"
+approx = "0.5.1"
 zerocopy = { version = "0.7.26", features = ["derive"] }
-bytes = "=1.6.0"
+bytes = "1.6.0"
 snafu = { version = "0.8.0", features = ["backtrace"] }
 lexical-core = "0.8.5"
 heapless = "0.8.0"
@@ -50,7 +50,7 @@ serde = "1"
 serde_derive = "1"
 serde_dhall = "0.12"
 
-anise = { version = "0.4.0", path = "anise", default-features = false }
+anise = { version = "0.4.1", path = "anise", default-features = false }
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
# Summary

Bytes won't adhere to the Cargo book on yanking version crates, so I'm forced to make _a new release_ of ANISE to fix this since versions < 0.4.2 are locked to bytes 1.6.0.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

**Detail the changes in tests, including new tests and validations**

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->