### PR TITLE
Change serde_dhall to be under the metaload feature

### DIFF
--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -58,7 +58,7 @@ default = ["metaload"]
 spkezr_validation = []
 python = ["pyo3", "pyo3-log"]
 metaload = ["url", "reqwest/blocking", "platform-dirs", "regex", "serde_dhall"]
-embed_ephem = ["rust-embed"]
+embed_ephem = ["rust-embed", "reqwest/blocking"]
 
 [[bench]]
 name = "iai_jpl_ephemerides"

--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -29,7 +29,7 @@ pyo3-log = { workspace = true, optional = true }
 url = { version = "2.5.0", optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-serde_dhall = { workspace = true }
+serde_dhall = { version = "0.12", optional = true }
 reqwest = { version = "0.12.0", optional = true, features = ["blocking"] }
 platform-dirs = { version = "0.3.0", optional = true }
 tabled = { workspace = true }
@@ -57,7 +57,7 @@ default = ["metaload"]
 # Enabling this flag significantly increases compilation times due to Arrow and Polars.
 spkezr_validation = []
 python = ["pyo3", "pyo3-log"]
-metaload = ["url", "reqwest/blocking", "platform-dirs", "regex"]
+metaload = ["url", "reqwest/blocking", "platform-dirs", "regex", "serde_dhall"]
 embed_ephem = ["rust-embed"]
 
 [[bench]]


### PR DESCRIPTION
# Summary

Previously serde_dhall was getting included as part of the default features even tho it was only necessary for the metaload feature.