### PR TITLE
Convert PathBufRef to PathRef

### DIFF
--- a/anise/src/naif/kpl/tpc.rs
+++ b/anise/src/naif/kpl/tpc.rs
@@ -157,7 +157,7 @@ fn test_anise_conversion() {
     let path = "../target/gm_pck_08.anise";
 
     // Test saving
-    dataset.save_as(&PathBuf::from(path), true).unwrap();
+    dataset.save_as(&Path::from(path), true).unwrap();
 
     // Test reloading
     let bytes = file2heap!(path).unwrap();

--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -33,7 +33,6 @@ macro_rules! io_imports {
         use std::fs::File;
         use std::io::{Error as IOError, ErrorKind as IOErrorKind, Write};
         use std::path::Path;
-        use std::path::PathBuf;
     };
 }
 
@@ -378,7 +377,7 @@ impl<T: DataSetT, const ENTRIES: usize> DataSet<T, ENTRIES> {
 
     /// Saves this dataset to the provided file
     /// If overwrite is set to false, and the filename already exists, this function will return an error.
-    pub fn save_as(&self, filename: &PathBuf, overwrite: bool) -> Result<(), DataSetError> {
+    pub fn save_as(&self, filename: &Path, overwrite: bool) -> Result<(), DataSetError> {
         use log::{info, warn};
 
         if Path::new(&filename).exists() {


### PR DESCRIPTION
# Summary

**Summarize the proposed changes**

## Architectural Changes

For all File I/O operations, I think it makes more sense to pass a `Path` instead of a `PathBuf`, especially since we want to path references here which avoids a memcopy on the end user side. It's basically the same as `&str` and `String` which we typically pass `&str` references only

Unfortunately I am unable to run the anise testbenches on my side 