### PR TITLE
Fix transformation when it involved multi-barycenter hops

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,7 @@ jobs:
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
+          wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,7 @@ jobs:
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
+          wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -180,6 +181,7 @@ jobs:
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
+          wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
+          wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cspice.tar.Z
 *.epa
 anise-gui/dist/
 anise-py/notebooks/.ipynb_checkpoints/ANISE Tutorial for querying SPK files-checkpoint.ipynb
+data/lro.bsp

--- a/anise/build.rs
+++ b/anise/build.rs
@@ -28,7 +28,11 @@ fn main() {
 
     // Create the directory if it doesn't exist
     if !data_path.exists() {
-        fs::create_dir_all(&data_path).expect(&format!("failed to create directory {data_path:?}"));
+        if let Err(e) = fs::create_dir_all(&data_path) {
+            eprintln!("EMBEDDED EPHEM UNAVAILABLE: failed to create directory {data_path:?}");
+            // Try nothing else.
+            return;
+        }
     }
 
     for (url, dest_path) in embedded_files {

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -179,14 +179,14 @@ impl Almanac {
                         return Ok((items, common_path, to_frame.ephemeris_id));
                     }
 
+                    common_path[items] = Some(from_obj.unwrap());
+                    items += 1;
+
                     if from_obj == to_obj {
                         // This is where the paths branch meet, so the root is the parent of the current item.
                         // Recall that the path is _from_ the source to the root of the context, so we're walking them
                         // backward until we find "where" the paths branched out.
                         return Ok((items, common_path, to_obj.unwrap()));
-                    } else {
-                        common_path[items] = Some(from_obj.unwrap());
-                        items += 1;
                     }
                 }
             }

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -66,7 +66,7 @@ impl Almanac {
 
         match ab_corr {
             None => {
-                let (node_count, path, common_node) =
+                let (node_count, _path, common_node) =
                     self.common_ephemeris_path(observer_frame, target_frame, epoch)?;
 
                 // The fwrd variables are the states from the `from frame` to the common node
@@ -85,7 +85,7 @@ impl Almanac {
                         self.translation_parts_to_parent(target_frame, epoch)?
                     };
 
-                for cur_node_id in path.iter().take(node_count) {
+                for _ in 0..node_count {
                     if !frame_fwrd.ephem_origin_id_match(common_node) {
                         let (cur_pos_fwrd, cur_vel_fwrd, cur_frame_fwrd) =
                             self.translation_parts_to_parent(frame_fwrd, epoch)?;
@@ -102,11 +102,6 @@ impl Almanac {
                         pos_bwrd += cur_pos_bwrd;
                         vel_bwrd += cur_vel_bwrd;
                         frame_bwrd = cur_frame_bwrd;
-                    }
-
-                    // We know this exist, so we can safely unwrap it
-                    if cur_node_id.unwrap() == common_node {
-                        break;
                     }
                 }
 

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -206,7 +206,19 @@ fn gh_283_multi_barycenter() {
 
     let epoch = Epoch::from_gregorian_utc_at_midnight(2024, 1, 1);
 
-    // This state is identical in ANISE and SPICE, queried from a BSP.
+    // First, let's test that the common ephemeris path is correct
+    let (node_count, path, common_node) = almanac
+        .common_ephemeris_path(lro_frame, SUN_J2000, epoch)
+        .unwrap();
+
+    assert_eq!(common_node, 0, "common node should be the SSB");
+    assert_eq!(node_count, 3, "node count should be Moon, EMB, SSB");
+    assert_eq!(
+        path,
+        [Some(301), Some(3), Some(0), None, None, None, None, None,],
+        "node count should be Moon, EMB, SSB"
+    );
+
     let spice_lro_state = Orbit::new(
         -25181236.12671419,
         133176946.34310651,
@@ -227,4 +239,7 @@ fn gh_283_multi_barycenter() {
     let rss_vel_km_s = anise_lro_state.rss_velocity_km_s(&spice_lro_state).unwrap();
 
     dbg!(rss_pos_km, rss_vel_km_s);
+
+    assert!(rss_pos_km < f64::EPSILON);
+    assert!(rss_vel_km_s < 1e-8);
 }


### PR DESCRIPTION
# Summary

There was a bug when the transformation involved multiple barycenter hops. Specifically, one of the barycenter translations was skipped. It is no longer skipped.

Fixes #285 (poorly named branch -- oops).

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

There was a bug when the transformation involved multiple barycenter hops.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Add the LRO test case where the state of LRO wrt the Sun is computed in SPICE and ANISE. Ensure that the position error is exactly zero (and velocity error is less than 1 mm/s).

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->