### PR TITLE
Add spk_ezr function to Almanac to closesly match SPICE's spkezr function + various minor fixes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,6 +25,7 @@ jobs:
           wget -O data/de440.bsp http://public-data.nyxspace.com/anise/de440.bsp
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
+          wget -O data/gmat-hermite-big-endian.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite-big-endian.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
           wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -117,6 +117,9 @@ jobs:
           python-version: "3.11"
           architecture: ${{ matrix.target }}
 
+      - name: Fix openssl regression
+        run: cargo update openssl-src --precise 300.3.1+3.3.1
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Fix openssl regression
+        run: cargo update openssl-src --precise 300.3.1+3.3.1
+
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         continue-on-error: ${{ matrix.target == 's390x' }}
@@ -116,9 +120,6 @@ jobs:
         with:
           python-version: "3.11"
           architecture: ${{ matrix.target }}
-
-      - name: Fix openssl regression
-        run: cargo update openssl-src --precise 300.3.1+3.3.1
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,11 @@ jobs:
           cd anise # Build only the Rust library
           cargo build --features embed_ephem
           cargo build --features embed_ephem --release
+          # Clean up the data folder as if we were on docsrs
+          cp data/.cargokeep .
+          rm -rf data/
+          mkdir data && mv .cargokeep data/.cargokeep
+          cargo doc --features embed_ephem
 
   lints:
     name: Lints

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,14 +71,13 @@ jobs:
       
       - name: Test rust_embed build
         run: |
-          rm -rf data # Not available on crates.io
-          cd anise # Build only the Rust library
-          cargo build --features embed_ephem
-          cargo build --features embed_ephem --release
-          # Clean up the data folder as if we were on docsrs
+          # Clean up the data folder as if we were on crates.io
           cp data/.cargokeep .
           rm -rf data/
           mkdir data && mv .cargokeep data/.cargokeep
+          cd anise # Build only the Rust library
+          cargo build --features embed_ephem
+          cargo build --features embed_ephem --release
           cargo doc --features embed_ephem
 
   lints:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
           wget -O data/moon_fk.epa http://public-data.nyxspace.com/anise/v0.4/moon_fk.epa
           wget -O data/moon_pa_de440_200625.bpc http://public-data.nyxspace.com/anise/moon_pa_de440_200625.bpc
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
+          wget -O data/gmat-hermite-big-endian.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite-big-endian.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
           wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
@@ -110,6 +111,7 @@ jobs:
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.4/pck11.pca
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
+          wget -O data/gmat-hermite-big-endian.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite-big-endian.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
           wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp
@@ -179,6 +181,7 @@ jobs:
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.4/pck11.pca
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
+          wget -O data/gmat-hermite-big-endian.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite-big-endian.bsp
           wget -O data/variable-seg-size-hermite.bsp http://public-data.nyxspace.com/anise/ci/variable-seg-size-hermite.bsp
           wget -O data/earth_latest_high_prec.bpc http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc
           wget -O data/lro.bsp http://public-data.nyxspace.com/nyx/examples/lrorg_2023349_2024075_v01_LE.bsp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [
     ".vscode",
     "*.sh",
 ]
+include = ["data/.cargokeep"]
 
 [workspace.dependencies]
 hifitime = "4.0.0-alpha"

--- a/anise/build.rs
+++ b/anise/build.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Create the directory if it doesn't exist
     if !data_path.exists() {
-        if let Err(e) = fs::create_dir_all(&data_path) {
+        if fs::create_dir_all(&data_path).is_err() {
             eprintln!("EMBEDDED EPHEM UNAVAILABLE: failed to create directory {data_path:?}");
             // Try nothing else.
             return;

--- a/anise/src/almanac/embed.rs
+++ b/anise/src/almanac/embed.rs
@@ -16,7 +16,7 @@ struct AstroData;
 impl Almanac {
     /// Provides planetary ephemerides from 2024-01-01 until 2035-01-01. Also provides planetary constants data (from the PCK11 kernel).
     ///
-    /// Until https://github.com/nyx-space/anise/issues/269, this will provide 100 years of data
+    /// Until <https://github.com/nyx-space/anise/issues/269>, this will provide 100 years of data
     pub fn until_2035() -> AlmanacResult<Self> {
         // Regularly refer to https://github.com/nyx-space/anise/blob/master/data/ci_config.dhall for the latest CRC, although it should not change between minor versions!
         let pck11 = AstroData::get("pck11.pca").ok_or(AlmanacError::GenericError {

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -49,7 +49,7 @@ pub mod metaload;
 mod python;
 
 #[cfg(feature = "embed_ephem")]
-#[cfg_attr(docrs, doc(cfg(feature = "embed_ephem")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "embed_ephem")))]
 mod embed;
 
 #[cfg(feature = "python")]

--- a/anise/src/almanac/transform.rs
+++ b/anise/src/almanac/transform.rs
@@ -111,7 +111,7 @@ impl Almanac {
 
     /// Alias fo SPICE's `spkezr` where the inputs must be the NAIF IDs of the objects and frames with the caveat that the aberration is moved to the last positional argument.
     ///
-    pub fn spkezr(
+    pub fn spk_ezr(
         &self,
         target: NaifId,
         epoch: Epoch,

--- a/anise/src/almanac/transform.rs
+++ b/anise/src/almanac/transform.rs
@@ -108,6 +108,33 @@ impl Almanac {
     ) -> AlmanacResult<CartesianState> {
         self.transform(Frame::from_ephem_j2000(object), observer, epoch, ab_corr)
     }
+
+    /// Alias fo SPICE's `spkezr` where the inputs must be the NAIF IDs of the objects and frames with the caveat that the aberration is moved to the last positional argument.
+    ///
+    pub fn spkezr(
+        &self,
+        target: NaifId,
+        epoch: Epoch,
+        frame: NaifId,
+        observer: NaifId,
+        ab_corr: Option<Aberration>,
+    ) -> AlmanacResult<CartesianState> {
+        let tgt_j2000 = Frame::from_ephem_j2000(target);
+        let obs_j2000 = Frame::from_ephem_j2000(observer);
+
+        // Translate in J2000
+        let state = self
+            .translate(tgt_j2000, obs_j2000, epoch, ab_corr)
+            .context(EphemerisSnafu {
+                action: "transform from/to",
+            })?;
+
+        // Rotate into the desired frame
+        self.rotate_to(state, Frame::new(observer, frame))
+            .context(OrientationSnafu {
+                action: "spkerz from/to",
+            })
+    }
 }
 
 impl Almanac {

--- a/anise/src/constants.rs
+++ b/anise/src/constants.rs
@@ -236,7 +236,7 @@ pub mod orientations {
     pub const J2000_TO_ECLIPJ2000_ANGLE_RAD: f64 = 0.40909280422232897;
 
     /// Given the frame ID, try to return a human name
-    /// Source: // https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/frames.html#Appendix.%20%60%60Built%20in''%20Inertial%20Reference%20Frames
+    /// Source: <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/frames.html#Appendix.%20%60%60Built%20in''%20Inertial%20Reference%20Frames>
     pub const fn orientation_name_from_id(id: NaifId) -> Option<&'static str> {
         match id {
             J2000 => Some("J2000"),

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -436,7 +436,10 @@ mod daf_ut {
     use crate::{
         errors::IntegrityError,
         file2heap,
-        naif::daf::{datatypes::HermiteSetType13, DAFError},
+        naif::{
+            daf::{datatypes::HermiteSetType13, file_record::FileRecordError, DAFError},
+            BPC,
+        },
         prelude::SPK,
     };
 
@@ -499,6 +502,26 @@ mod daf_ut {
             // We cannot user assert_eq! because the NAIF Data Set do not (and should not) impl Debug
             // These data sets are the full record!
             panic!("nth data test failed");
+        }
+    }
+
+    #[test]
+    fn load_big_endian() {
+        // Ensure this fails
+        assert_eq!(
+            SPK::load("../data/gmat-hermite-big-endian.bsp"),
+            Err(DAFError::FileRecord {
+                kind: "SPKSummaryRecord",
+                source: FileRecordError::WrongEndian
+            })
+        );
+
+        // Now ensure the error is correctly printed
+        if let Err(e) = BPC::load("../data/gmat-hermite-big-endian.bsp") {
+            assert_eq!(
+                format!("{e}"),
+                "DAF/BPCSummaryRecord: file record issue: endian of file does not match the endian order of the machine".to_string()
+            );
         }
     }
 }

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -21,21 +21,24 @@ use super::NAIFRecord;
 #[derive(Debug, Snafu, PartialEq)]
 #[snafu(visibility(pub(crate)))]
 pub enum FileRecordError {
-    /// Endian of file does not match the endian order of the machine
+    #[snafu(display("issue: endian of file does not match the endian order of the machine"))]
     WrongEndian,
-    /// Could not parse the endian flag or internal filename as a UTF8 string
+    #[snafu(display("endian flag or internal filename is not a valid UTF8 string: {source:?}"))]
     ParsingError {
         source: Utf8Error,
     },
-    /// Endian flag should be either `BIG-IEEE` or `LTL-IEEE`
+    #[snafu(display("endian flag is `{read}` but it should be either `BIG-IEEE` or `LTL-IEEE`"))]
     InvalidEndian {
         read: String,
     },
     UnsupportedIdentifier {
         loci: String,
     },
+    #[snafu(display("indicates this is not a SPICE DAF file"))]
     NotDAF,
+    #[snafu(display("has no identifier"))]
     NoIdentifier,
+    #[snafu(display("is empty (ensure file is valid, e.g. do you need to run git-lfs)"))]
     EmptyRecord,
 }
 

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -169,9 +169,7 @@ pub enum DAFError {
         id: NaifId,
         epoch: Epoch,
     },
-    #[snafu(display(
-        "DAF/{kind}: file record is empty (ensure file is valid, e.g. do you need to run git-lfs)"
-    ))]
+    #[snafu(display("DAF/{kind}: file record {source}"))]
     FileRecord {
         kind: &'static str,
         #[snafu(backtrace)]

--- a/anise/src/naif/pck/mod.rs
+++ b/anise/src/naif/pck/mod.rs
@@ -22,7 +22,7 @@ use super::daf::DafDataType;
 
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.internals"))]
-#[derive(Clone, Copy, Debug, Default, AsBytes, FromZeroes, FromBytes)]
+#[derive(Clone, Copy, Debug, Default, AsBytes, FromZeroes, FromBytes, PartialEq)]
 #[repr(C)]
 pub struct BPCSummaryRecord {
     pub start_epoch_et_s: f64,

--- a/anise/src/structure/lookuptable.rs
+++ b/anise/src/structure/lookuptable.rs
@@ -41,7 +41,7 @@ pub enum LutError {
     InvalidIndex { index: u32 },
 }
 
-/// A LookUpTable allows finding the [Entry] associated with either an ID or a name.
+/// A LookUpTable allows finding the [u32] ("NaifId") associated with either an ID or a name.
 ///
 /// # Note
 /// _Both_ the IDs and the name MUST be unique in the look up table.

--- a/anise/src/structure/planetocentric/mod.rs
+++ b/anise/src/structure/planetocentric/mod.rs
@@ -34,7 +34,7 @@ pub const MAX_NUT_PREC_ANGLES: usize = 32;
 /// ANISE supports two different kinds of orientation data. High precision, with spline based interpolations, and constants right ascension, declination, and prime meridian, typically used for planetary constant data.
 ///
 /// # Documentation of rotation angles
-/// Source: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/pck.html#Models%20for%20the%20Sun,%20Planets,%20and%20some%20Minor%20Bodies%20in%20Text%20PCK%20Kernels
+/// Source: <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/pck.html#Models%20for%20the%20Sun,%20Planets,%20and%20some%20Minor%20Bodies%20in%20Text%20PCK%20Kernels>
 ///  The angles RA, DEC, and W are defined as follows:
 ///
 /// ```text

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -174,7 +174,7 @@ fn de440s_transform_verif_venus2emb() {
     spice::unload(spk_path);
 
     // Finally, check that ANISE's SPKEZR works as expected.
-    let state_ezr = almanac.spkezr(EARTH, epoch, ITRF93, VENUS, None).unwrap();
+    let state_ezr = almanac.spk_ezr(EARTH, epoch, ITRF93, VENUS, None).unwrap();
     assert_eq!(state_ezr, state_rtn);
 }
 

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -9,9 +9,11 @@
  */
 
 use anise::astro::Occultation;
+use anise::constants::celestial_objects::{EARTH, VENUS};
 use anise::constants::frames::{
-    EARTH_ITRF93, IAU_EARTH_FRAME, IAU_MOON_FRAME, MOON_J2000, SUN_J2000, VENUS_J2000,
+    EARTH_ITRF93, EARTH_J2000, IAU_EARTH_FRAME, IAU_MOON_FRAME, MOON_J2000, SUN_J2000, VENUS_J2000,
 };
+use anise::constants::orientations::ITRF93;
 use anise::constants::usual_planetary_constants::MEAN_EARTH_ANGULAR_VELOCITY_DEG_S;
 use anise::math::Vector3;
 use anise::prelude::*;
@@ -100,78 +102,80 @@ fn de440s_transform_verif_venus2emb() {
         vel_expct_km_s - state.velocity_km_s
     );
 
-    // TODO https://github.com/nyx-space/anise/issues/130
-    // Test the opposite translation
-    // let state_rtn = almanac
-    //     .transform(EARTH_ITRF93, VENUS_J2000, epoch, None)
-    //     .unwrap();
+    let state_rtn = almanac
+        .transform(EARTH_J2000, Frame::new(VENUS, ITRF93), epoch, None)
+        .unwrap();
 
-    // println!("state = {state}");
-    // println!("state_rtn = {state_rtn}");
+    println!("state = {state}");
+    println!("state_rtn = {state_rtn}");
 
-    // let (spice_state, _) = spice::spkezr("EARTH", epoch.to_et_seconds(), "ITRF93", "NONE", "VENUS");
+    let (spice_state, _) = spice::spkezr("EARTH", epoch.to_et_seconds(), "ITRF93", "NONE", "VENUS");
 
-    // let pos_rtn_expct_km = Vector3::new(spice_state[0], spice_state[1], spice_state[2]);
-    // let vel_rtn_expct_km_s = Vector3::new(spice_state[3], spice_state[4], spice_state[5]);
+    let pos_rtn_expct_km = Vector3::new(spice_state[0], spice_state[1], spice_state[2]);
+    let vel_rtn_expct_km_s = Vector3::new(spice_state[3], spice_state[4], spice_state[5]);
 
-    // dbg!(pos_expct_km + pos_rtn_expct_km);
-    // dbg!(vel_expct_km_s + vel_rtn_expct_km_s);
+    dbg!(pos_expct_km + pos_rtn_expct_km);
+    dbg!(vel_expct_km_s + vel_rtn_expct_km_s);
 
-    // dbg!(pos_expct_km + state_rtn.radius_km);
-    // dbg!(pos_rtn_expct_km - state_rtn.radius_km);
-    // dbg!(vel_expct_km_s + state_rtn.velocity_km_s);
-    // dbg!(vel_rtn_expct_km_s - state_rtn.velocity_km_s);
+    dbg!(pos_expct_km + state_rtn.radius_km);
+    dbg!(pos_rtn_expct_km - state_rtn.radius_km);
+    dbg!(vel_expct_km_s + state_rtn.velocity_km_s);
+    dbg!(vel_rtn_expct_km_s - state_rtn.velocity_km_s);
 
-    // assert!(
-    //     relative_eq!(
-    //         state_rtn.radius_km,
-    //         -pos_expct_km,
-    //         epsilon = POSITION_EPSILON_KM
-    //     ),
-    //     "pos = {}\nexp = {pos_expct_km}\nerr = {:e}",
-    //     state_rtn.radius_km,
-    //     pos_expct_km + state_rtn.radius_km
-    // );
+    assert!(
+        relative_eq!(
+            state_rtn.radius_km,
+            pos_rtn_expct_km,
+            epsilon = POSITION_EPSILON_KM
+        ),
+        "pos = {}\nexp = {pos_rtn_expct_km}\nerr = {:e}",
+        state_rtn.radius_km,
+        pos_rtn_expct_km - state_rtn.radius_km
+    );
 
-    // assert!(
-    //     relative_eq!(
-    //         state.velocity_km_s,
-    //         -vel_expct_km_s,
-    //         epsilon = VELOCITY_EPSILON_KM_S
-    //     ),
-    //     "vel = {}\nexp = {vel_expct_km_s}\nerr = {:e}",
-    //     state.velocity_km_s,
-    //     vel_expct_km_s + state.velocity_km_s
-    // );
+    assert!(
+        relative_eq!(
+            state_rtn.velocity_km_s,
+            vel_rtn_expct_km_s,
+            epsilon = VELOCITY_EPSILON_KM_S
+        ),
+        "vel = {}\nexp = {vel_rtn_expct_km_s}\nerr = {:e}",
+        state_rtn.velocity_km_s,
+        vel_rtn_expct_km_s - state.velocity_km_s
+    );
 
-    // // Check that the return state is exactly opposite to the forward state
-    // assert!(
-    //     relative_eq!(
-    //         state_rtn.radius_km,
-    //         -state.radius_km,
-    //         epsilon = core::f64::EPSILON
-    //     ),
-    //     "pos = {}\nexp = {}\nerr = {:e}",
-    //     state_rtn.radius_km,
-    //     -state.radius_km,
-    //     state_rtn.radius_km - state.radius_km
-    // );
+    // Check that the return state is exactly opposite to the forward state
+    assert!(
+        relative_eq!(
+            state_rtn.radius_km,
+            -state.radius_km,
+            epsilon = core::f64::EPSILON
+        ),
+        "pos = {}\nexp = {}\nerr = {:e}",
+        state_rtn.radius_km,
+        -state.radius_km,
+        state_rtn.radius_km - state.radius_km
+    );
 
-    // assert!(
-    //     relative_eq!(
-    //         state_rtn.velocity_km_s,
-    //         -state.velocity_km_s,
-    //         epsilon = core::f64::EPSILON
-    //     ),
-    //     "vel = {}\nexp = {}\nerr = {:e}",
-    //     state.velocity_km_s,
-    //     -state_rtn.velocity_km_s,
-    //     state.velocity_km_s - state_rtn.velocity_km_s,
-    // );
+    assert!(
+        relative_eq!(
+            state_rtn.velocity_km_s,
+            -state.velocity_km_s,
+            epsilon = core::f64::EPSILON
+        ),
+        "vel = {}\nexp = {}\nerr = {:e}",
+        state.velocity_km_s,
+        -state_rtn.velocity_km_s,
+        state.velocity_km_s - state_rtn.velocity_km_s,
+    );
 
     // Unload spice
     spice::unload(bpc_path);
     spice::unload(spk_path);
+
+    // Finally, check that ANISE's SPKEZR works as expected.
+    let state_ezr = almanac.spkezr(EARTH, epoch, ITRF93, VENUS, None).unwrap();
+    assert_eq!(state_ezr, state_rtn);
 }
 
 #[rstest]

--- a/data/.cargokeep
+++ b/data/.cargokeep
@@ -1,0 +1,1 @@
+Required in cargo for documenting the embed_ephem feature

--- a/data/gmat-hermite-big-endian.bsp
+++ b/data/gmat-hermite-big-endian.bsp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3db0d55ec61c9fb7e4beb0834f3e1b78a390628d45e6cee59f23827d19edeaaa
+size 14336


### PR DESCRIPTION
# Summary

The crux of this issue was not an ANISE bug, but in fact it was an issue with the way I was calling `transform` in the test. I've fixed this by correcting the observation frame and by adding an `spkezr` function.

Fix #130.

Also fix #284 by adding the proper display of the file record errors.

Also fix #302 -- https://github.com/nyx-space/anise/issues/302#issuecomment-2335092450

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

- Uncommented the test from #130.
- Add gmat-hermite-big-endian.bsp, ensuring that loading it on a little endian platform raises a WrongEndian error and correctly display that error.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->