### PR TITLE
Support SPK Type 3 chebyshev position and velocity

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
           wget -O data/de430.bsp http://public-data.nyxspace.com/anise/de430.bsp
           wget -O data/de440s.bsp http://public-data.nyxspace.com/anise/de440s.bsp
           wget -O data/de440.bsp http://public-data.nyxspace.com/anise/de440.bsp
+          wget -O data/de440_type3.bsp http://public-data.nyxspace.com/anise/de440_type3.bsp
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.4/pck11.pca
           wget -O data/moon_fk.epa http://public-data.nyxspace.com/anise/v0.4/moon_fk.epa
@@ -112,6 +113,7 @@ jobs:
           wget -O data/de430.bsp http://public-data.nyxspace.com/anise/de430.bsp
           wget -O data/de440s.bsp http://public-data.nyxspace.com/anise/de440s.bsp
           wget -O data/de440.bsp http://public-data.nyxspace.com/anise/de440.bsp
+          wget -O data/de440_type3.bsp http://public-data.nyxspace.com/anise/de440_type3.bsp
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.4/pck11.pca
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
@@ -182,6 +184,7 @@ jobs:
           wget -O data/de430.bsp http://public-data.nyxspace.com/anise/de430.bsp
           wget -O data/de440s.bsp http://public-data.nyxspace.com/anise/de440s.bsp
           wget -O data/de440.bsp http://public-data.nyxspace.com/anise/de440.bsp
+          wget -O data/de440_type3.bsp http://public-data.nyxspace.com/anise/de440_type3.bsp
           wget -O data/pck08.pca http://public-data.nyxspace.com/anise/v0.4/pck08.pca
           wget -O data/pck11.pca http://public-data.nyxspace.com/anise/v0.4/pck11.pca
           wget -O data/gmat-hermite.bsp http://public-data.nyxspace.com/anise/ci/gmat-hermite.bsp
@@ -214,6 +217,7 @@ jobs:
           cargo llvm-cov test --no-report validate_bpc_to_iau_rotations -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_jplde_de440s_no_aberration --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_jplde_de440s_aberration_lt --features spkezr_validation -- --nocapture --ignored
+          cargo llvm-cov test --no-report validate_jplde_de440_type3_no_aberration --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_hermite_type13_from_gmat --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report validate_lagrange_type9_with_varying_segment_sizes --features spkezr_validation -- --nocapture --ignored
           cargo llvm-cov test --no-report ut_embed --features embed_ephem

--- a/anise/src/ephemerides/translate_to_parent.rs
+++ b/anise/src/ephemerides/translate_to_parent.rs
@@ -17,7 +17,9 @@ use crate::ephemerides::EphemInterpolationSnafu;
 use crate::hifitime::Epoch;
 use crate::math::cartesian::CartesianState;
 use crate::math::Vector3;
-use crate::naif::daf::datatypes::{HermiteSetType13, LagrangeSetType9, Type2ChebyshevSet};
+use crate::naif::daf::datatypes::{
+    HermiteSetType13, LagrangeSetType9, Type2ChebyshevSet, Type3ChebyshevSet,
+};
 use crate::naif::daf::{DAFError, DafDataType, NAIFDataSet, NAIFSummaryRecord};
 use crate::prelude::Frame;
 
@@ -58,6 +60,16 @@ impl Almanac {
                 let data =
                     spk_data
                         .nth_data::<Type2ChebyshevSet>(idx_in_spk)
+                        .context(SPKSnafu {
+                            action: "fetching data for interpolation",
+                        })?;
+                data.evaluate(epoch, summary)
+                    .context(EphemInterpolationSnafu)?
+            }
+            DafDataType::Type3ChebyshevSextuplet => {
+                let data =
+                    spk_data
+                        .nth_data::<Type3ChebyshevSet>(idx_in_spk)
                         .context(SPKSnafu {
                             action: "fetching data for interpolation",
                         })?;

--- a/anise/src/math/interpolation/mod.rs
+++ b/anise/src/math/interpolation/mod.rs
@@ -12,7 +12,7 @@ mod chebyshev;
 mod hermite;
 mod lagrange;
 
-pub use chebyshev::chebyshev_eval;
+pub use chebyshev::{chebyshev_eval, chebyshev_eval_poly};
 pub use hermite::hermite_eval;
 use hifitime::Epoch;
 pub use lagrange::lagrange_eval;

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -30,9 +30,64 @@ pub struct Type2ChebyshevSet<'a> {
     pub record_data: &'a [f64],
 }
 
-impl<'a> Type2ChebyshevSet<'a> {
-    pub fn degree(&self) -> usize {
-        (self.rsize - 2) / 3 - 1
+impl<'a> fmt::Display for Type2ChebyshevSet<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "start: {:E}\tlength: {}\trsize: {}\tnum_records: {}\tlen data: {}",
+            self.init_epoch,
+            self.interval_length,
+            self.rsize,
+            self.num_records,
+            self.record_data.len()
+        )
+    }
+}
+
+#[derive(PartialEq)]
+pub struct Type3ChebyshevSet<'a> {
+    pub init_epoch: Epoch,
+    pub interval_length: Duration,
+    pub rsize: usize,
+    pub num_records: usize,
+    pub record_data: &'a [f64],
+}
+
+impl<'a> fmt::Display for Type3ChebyshevSet<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "start: {:E}\tlength: {}\trsize: {}\tnum_records: {}\tlen data: {}",
+            self.init_epoch,
+            self.interval_length,
+            self.rsize,
+            self.num_records,
+            self.record_data.len()
+        )
+    }
+}
+
+trait ChebyshevSet<'a>: PartialEq + fmt::Display {
+    fn new(
+        init_epoch: Epoch,
+        interval_length: Duration,
+        rsize: usize,
+        num_records: usize,
+        record_data: &'a [f64],
+    ) -> Self;
+
+    fn init_epoch(&self) -> Epoch;
+    fn interval_length(&self) -> Duration;
+    fn rsize(&self) -> usize;
+    fn num_records(&self) -> usize;
+    fn record_data(&self) -> &'a [f64];
+
+    fn set_init_epoch(&mut self, init_epoch: Epoch);
+    fn set_num_records(&mut self, num_records: usize);
+    fn set_record_data(&mut self, record_data: &'a [f64]);
+
+    fn degree(&self) -> usize {
+        (self.rsize() - 2) / 3 - 1
     }
 
     fn spline_idx<S: NAIFSummaryRecord>(
@@ -51,29 +106,101 @@ impl<'a> Type2ChebyshevSet<'a> {
             });
         }
 
-        let window_duration_s = self.interval_length.to_seconds();
+        let window_duration_s = self.interval_length().to_seconds();
 
         let ephem_start_delta_s = epoch.to_et_seconds() - summary.start_epoch_et_s();
 
-        Ok(((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records))
+        Ok(((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records()))
     }
 }
 
-impl<'a> fmt::Display for Type2ChebyshevSet<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "start: {:E}\tlength: {}\trsize: {}\tnum_records: {}\tlen data: {}",
-            self.init_epoch,
-            self.interval_length,
-            self.rsize,
-            self.num_records,
-            self.record_data.len()
-        )
+impl<'a> ChebyshevSet<'a> for Type2ChebyshevSet<'a> {
+    fn new(
+        init_epoch: Epoch,
+        interval_length: Duration,
+        rsize: usize,
+        num_records: usize,
+        record_data: &'a [f64],
+    ) -> Self {
+        Self {
+            init_epoch,
+            interval_length,
+            rsize,
+            num_records,
+            record_data,
+        }
+    }
+
+    fn init_epoch(&self) -> Epoch {
+        self.init_epoch
+    }
+    fn interval_length(&self) -> Duration {
+        self.interval_length
+    }
+    fn rsize(&self) -> usize {
+        self.rsize
+    }
+    fn num_records(&self) -> usize {
+        self.num_records
+    }
+    fn record_data(&self) -> &'a [f64] {
+        self.record_data
+    }
+
+    fn set_init_epoch(&mut self, init_epoch: Epoch) {
+        self.init_epoch = init_epoch;
+    }
+    fn set_num_records(&mut self, num_records: usize) {
+        self.num_records = num_records;
+    }
+    fn set_record_data(&mut self, record_data: &'a [f64]) {
+        self.record_data = record_data;
+    }
+}
+impl<'a> ChebyshevSet<'a> for Type3ChebyshevSet<'a> {
+    fn new(
+        init_epoch: Epoch,
+        interval_length: Duration,
+        rsize: usize,
+        num_records: usize,
+        record_data: &'a [f64],
+    ) -> Self {
+        Self {
+            init_epoch,
+            interval_length,
+            rsize,
+            num_records,
+            record_data,
+        }
+    }
+
+    fn init_epoch(&self) -> Epoch {
+        self.init_epoch
+    }
+    fn interval_length(&self) -> Duration {
+        self.interval_length
+    }
+    fn rsize(&self) -> usize {
+        self.rsize
+    }
+    fn num_records(&self) -> usize {
+        self.num_records
+    }
+    fn record_data(&self) -> &'a [f64] {
+        self.record_data
+    }
+    fn set_init_epoch(&mut self, init_epoch: Epoch) {
+        self.init_epoch = init_epoch;
+    }
+    fn set_num_records(&mut self, num_records: usize) {
+        self.num_records = num_records;
+    }
+    fn set_record_data(&mut self, record_data: &'a [f64]) {
+        self.record_data = record_data;
     }
 }
 
-impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
+impl<'a, T: ChebyshevSet<'a>> NAIFDataSet<'a> for T {
     type StateKind = (Vector3, Vector3);
     type RecordKind = Type2ChebyshevRecord<'a>;
     const DATASET_NAME: &'static str = "Chebyshev Type 2";
@@ -123,23 +250,23 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         let rsize = slice[slice.len() - 2] as usize;
         let num_records = slice[slice.len() - 1] as usize;
 
-        Ok(Self {
-            init_epoch: start_epoch,
+        Ok(Self::new(
+            start_epoch,
             interval_length,
             rsize,
             num_records,
-            record_data: &slice[0..slice.len() - 4],
-        })
+            &slice[0..slice.len() - 4],
+        ))
     }
 
     fn nth_record(&self, n: usize) -> Result<Self::RecordKind, DecodingError> {
         Ok(Self::RecordKind::from_slice_f64(
-            self.record_data
-                .get(n * self.rsize..(n + 1) * self.rsize)
+            self.record_data()
+                .get(n * self.rsize()..(n + 1) * self.rsize())
                 .ok_or(DecodingError::InaccessibleBytes {
-                    start: n * self.rsize,
-                    end: (n + 1) * self.rsize,
-                    size: self.record_data.len(),
+                    start: n * self.rsize(),
+                    end: (n + 1) * self.rsize(),
+                    size: self.record_data().len(),
                 })?,
         ))
     }
@@ -151,7 +278,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
     ) -> Result<(Vector3, Vector3), InterpolationError> {
         let spline_idx = self.spline_idx(epoch, summary)?;
 
-        let window_duration_s = self.interval_length.to_seconds();
+        let window_duration_s = self.interval_length().to_seconds();
         let radius_s = window_duration_s / 2.0;
 
         // Now, build the X, Y, Z data from the record data.
@@ -179,7 +306,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
 
     fn check_integrity(&self) -> Result<(), IntegrityError> {
         // Verify that none of the data is invalid once when we load it.
-        for val in self.record_data {
+        for val in self.record_data() {
             if !val.is_finite() {
                 return Err(IntegrityError::SubNormal {
                     dataset: Self::DATASET_NAME,
@@ -206,23 +333,27 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         let end_idx = if let Some(end) = new_end {
             self.spline_idx(end, summary)?
         } else {
-            self.num_records - 1
+            self.num_records() - 1
         };
 
-        self.record_data = &self.record_data[start_idx * self.rsize..(end_idx + 1) * self.rsize];
-        self.num_records = (self.record_data.len() / self.rsize) - 1;
-        self.init_epoch = self.nth_record(0).unwrap().midpoint_epoch() - 0.5 * self.interval_length;
+        self.set_record_data(
+            &self.record_data()[start_idx * self.rsize()..(end_idx + 1) * self.rsize()],
+        );
+        self.set_num_records((self.record_data().len() / self.rsize()) - 1);
+        self.set_init_epoch(
+            self.nth_record(0).unwrap().midpoint_epoch() - 0.5 * self.interval_length(),
+        );
 
         Ok(self)
     }
 
     /// Builds the DAF array representing a Chebyshev Type 2 interpolation set.
     fn to_f64_daf_vec(&self) -> Result<Vec<f64>, InterpolationError> {
-        let mut data = self.record_data.to_vec();
-        data.push(self.init_epoch.to_et_seconds());
-        data.push(self.interval_length.to_seconds());
-        data.push(self.rsize as f64);
-        data.push(self.num_records as f64);
+        let mut data = self.record_data().to_vec();
+        data.push(self.init_epoch().to_et_seconds());
+        data.push(self.interval_length().to_seconds());
+        data.push(self.rsize() as f64);
+        data.push(self.num_records() as f64);
 
         Ok(data)
     }
@@ -313,213 +444,6 @@ impl<'a> NAIFDataRecord<'a> for Type3ChebyshevRecord<'a> {
             vy_coeffs: &slice[2 + num_coeffs * 4..num_coeffs * 5],
             vz_coeffs: &slice[2 + num_coeffs * 5..],
         }
-    }
-}
-
-#[derive(PartialEq)]
-pub struct Type3ChebyshevSet<'a> {
-    pub init_epoch: Epoch,
-    pub interval_length: Duration,
-    pub rsize: usize,
-    pub num_records: usize,
-    pub record_data: &'a [f64],
-}
-
-impl<'a> Type3ChebyshevSet<'a> {
-    pub fn degree(&self) -> usize {
-        (self.rsize - 2) / 3 - 1
-    }
-
-    fn spline_idx<S: NAIFSummaryRecord>(
-        &self,
-        epoch: Epoch,
-        summary: &S,
-    ) -> Result<usize, InterpolationError> {
-        if epoch < summary.start_epoch() - 1_i64.nanoseconds()
-            || epoch > summary.end_epoch() + 1_i64.nanoseconds()
-        {
-            // No need to go any further.
-            return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
-                start: summary.start_epoch(),
-                end: summary.end_epoch(),
-            });
-        }
-
-        let window_duration_s = self.interval_length.to_seconds();
-
-        let ephem_start_delta_s = epoch.to_et_seconds() - summary.start_epoch_et_s();
-
-        Ok(((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records))
-    }
-}
-
-impl<'a> fmt::Display for Type3ChebyshevSet<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "start: {:E}\tlength: {}\trsize: {}\tnum_records: {}\tlen data: {}",
-            self.init_epoch,
-            self.interval_length,
-            self.rsize,
-            self.num_records,
-            self.record_data.len()
-        )
-    }
-}
-
-impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
-    type StateKind = (Vector3, Vector3);
-    type RecordKind = Type2ChebyshevRecord<'a>;
-    const DATASET_NAME: &'static str = "Chebyshev Type 2";
-
-    fn from_f64_slice(slice: &'a [f64]) -> Result<Self, DecodingError> {
-        ensure!(
-            slice.len() >= 5,
-            TooFewDoublesSnafu {
-                dataset: Self::DATASET_NAME,
-                need: 5_usize,
-                got: slice.len()
-            }
-        );
-        // For this kind of record, the data is stored at the very end of the dataset
-        let seconds_since_j2000 = slice[slice.len() - 4];
-        if !seconds_since_j2000.is_finite() {
-            return Err(DecodingError::Integrity {
-                source: IntegrityError::SubNormal {
-                    dataset: Self::DATASET_NAME,
-                    variable: "seconds since J2000 ET",
-                },
-            });
-        }
-
-        let start_epoch = Epoch::from_et_seconds(seconds_since_j2000);
-
-        let interval_length_s = slice[slice.len() - 3];
-        if !interval_length_s.is_finite() {
-            return Err(DecodingError::Integrity {
-                source: IntegrityError::SubNormal {
-                    dataset: Self::DATASET_NAME,
-                    variable: "interval length in seconds",
-                },
-            });
-        } else if interval_length_s <= 0.0 {
-            return Err(DecodingError::Integrity {
-                source: IntegrityError::InvalidValue {
-                    dataset: Self::DATASET_NAME,
-                    variable: "interval length in seconds",
-                    value: interval_length_s,
-                    reason: "must be strictly greater than zero",
-                },
-            });
-        }
-
-        let interval_length = interval_length_s.seconds();
-        let rsize = slice[slice.len() - 2] as usize;
-        let num_records = slice[slice.len() - 1] as usize;
-
-        Ok(Self {
-            init_epoch: start_epoch,
-            interval_length,
-            rsize,
-            num_records,
-            record_data: &slice[0..slice.len() - 4],
-        })
-    }
-
-    fn nth_record(&self, n: usize) -> Result<Self::RecordKind, DecodingError> {
-        Ok(Self::RecordKind::from_slice_f64(
-            self.record_data
-                .get(n * self.rsize..(n + 1) * self.rsize)
-                .ok_or(DecodingError::InaccessibleBytes {
-                    start: n * self.rsize,
-                    end: (n + 1) * self.rsize,
-                    size: self.record_data.len(),
-                })?,
-        ))
-    }
-
-    fn evaluate<S: NAIFSummaryRecord>(
-        &self,
-        epoch: Epoch,
-        summary: &S,
-    ) -> Result<(Vector3, Vector3), InterpolationError> {
-        let spline_idx = self.spline_idx(epoch, summary)?;
-
-        let window_duration_s = self.interval_length.to_seconds();
-        let radius_s = window_duration_s / 2.0;
-
-        // Now, build the X, Y, Z data from the record data.
-        let record = self
-            .nth_record(spline_idx - 1)
-            .context(InterpDecodingSnafu)?;
-
-        let normalized_time = (epoch.to_et_seconds() - record.midpoint_et_s) / radius_s;
-
-        let mut state = Vector3::zeros();
-        let mut rate = Vector3::zeros();
-
-        for (cno, coeffs) in [record.x_coeffs, record.y_coeffs, record.z_coeffs]
-            .iter()
-            .enumerate()
-        {
-            let (val, deriv) =
-                chebyshev_eval(normalized_time, coeffs, radius_s, epoch, self.degree())?;
-            state[cno] = val;
-            rate[cno] = deriv;
-        }
-
-        Ok((state, rate))
-    }
-
-    fn check_integrity(&self) -> Result<(), IntegrityError> {
-        // Verify that none of the data is invalid once when we load it.
-        for val in self.record_data {
-            if !val.is_finite() {
-                return Err(IntegrityError::SubNormal {
-                    dataset: Self::DATASET_NAME,
-                    variable: "one of the record data",
-                });
-            }
-        }
-
-        Ok(())
-    }
-
-    fn truncate<S: NAIFSummaryRecord>(
-        mut self,
-        summary: &S,
-        new_start: Option<Epoch>,
-        new_end: Option<Epoch>,
-    ) -> Result<Self, InterpolationError> {
-        let start_idx = if let Some(start) = new_start {
-            self.spline_idx(start, summary)? - 1
-        } else {
-            0
-        };
-
-        let end_idx = if let Some(end) = new_end {
-            self.spline_idx(end, summary)?
-        } else {
-            self.num_records - 1
-        };
-
-        self.record_data = &self.record_data[start_idx * self.rsize..(end_idx + 1) * self.rsize];
-        self.num_records = (self.record_data.len() / self.rsize) - 1;
-        self.init_epoch = self.nth_record(0).unwrap().midpoint_epoch() - 0.5 * self.interval_length;
-
-        Ok(self)
-    }
-
-    /// Builds the DAF array representing a Chebyshev Type 2 interpolation set.
-    fn to_f64_daf_vec(&self) -> Result<Vec<f64>, InterpolationError> {
-        let mut data = self.record_data.to_vec();
-        data.push(self.init_epoch.to_et_seconds());
-        data.push(self.interval_length.to_seconds());
-        data.push(self.rsize as f64);
-        data.push(self.num_records as f64);
-
-        Ok(data)
     }
 }
 

--- a/anise/src/naif/daf/datatypes/mod.rs
+++ b/anise/src/naif/daf/datatypes/mod.rs
@@ -9,10 +9,12 @@
  */
 
 pub mod chebyshev;
+pub mod chebyshev3;
 pub mod hermite;
 pub mod lagrange;
 pub mod posvel;
 
 pub use chebyshev::*;
+pub use chebyshev3::*;
 pub use hermite::*;
 pub use lagrange::*;

--- a/anise/tests/almanac/mod.rs
+++ b/anise/tests/almanac/mod.rs
@@ -1,6 +1,6 @@
 // Start by creating the ANISE planetary data
 use anise::{
-    constants::frames::{EARTH_ITRF93, EARTH_J2000},
+    constants::frames::{EARTH_ITRF93, EARTH_J2000, SUN_J2000},
     naif::kpl::parser::convert_tpc,
     prelude::{Aberration, Almanac, Orbit, BPC, SPK},
 };
@@ -84,49 +84,24 @@ fn test_type3_state_transformation() {
     let ctx = Almanac::default();
 
     let spk = SPK::load("../data/de440_type3.bsp").unwrap();
-    let bpc = BPC::load("../data/earth_latest_high_prec.bpc").unwrap();
 
     let almanac = ctx
         .with_spk(spk)
         .unwrap()
-        .with_bpc(bpc)
-        .unwrap()
         .load("../data/pck08.pca")
         .unwrap();
 
-    // Let's build an orbit
-    // Start by grabbing a copy of the frame.
-    let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
-    // Define an epoch
     let epoch = Epoch::from_str("2021-10-29 12:34:56 TDB").unwrap();
 
-    let orig_state = Orbit::keplerian(
-        8_191.93, 1e-6, 12.85, 306.614, 314.19, 99.887_7, epoch, eme2k,
-    );
+    let to_parent = almanac.translate_to_parent(EARTH_J2000, epoch).unwrap();
 
-    // Transform that into another frame.
-    let state_itrf93 = almanac
-        .transform_to(orig_state, EARTH_ITRF93, Aberration::NONE)
-        .unwrap();
+    println!("{to_parent}");
 
-    // Check that the frame is correctly set.
-    assert_eq!(state_itrf93.frame.ephemeris_id, EARTH_ITRF93.ephemeris_id);
-    assert_eq!(
-        state_itrf93.frame.orientation_id,
-        EARTH_ITRF93.orientation_id
-    );
+    // Ensure that we can query the type 3 chebyshev DE440 file
 
-    println!("{orig_state:x}");
-    println!("{state_itrf93:X}");
+    let state = almanac
+        .translate(EARTH_J2000, SUN_J2000, epoch, None)
+        .expect("type 3 chebyshev could not be queried");
 
-    // Convert back.
-    // Note that the Aberration correction constants are actually options!
-    let from_state_itrf93_to_eme2k = almanac
-        .transform_to(state_itrf93, EARTH_J2000, None)
-        .unwrap();
-
-    println!("{from_state_itrf93_to_eme2k}");
-    println!("{from_state_itrf93_to_eme2k:x}");
-
-    assert_eq!(orig_state, from_state_itrf93_to_eme2k);
+    println!("{state:x}");
 }

--- a/anise/tests/almanac/mod.rs
+++ b/anise/tests/almanac/mod.rs
@@ -77,3 +77,56 @@ fn test_state_transformation() {
 
     assert_eq!(orig_state, from_state_itrf93_to_eme2k);
 }
+
+#[test]
+fn test_type3_state_transformation() {
+    // Load BSP and BPC
+    let ctx = Almanac::default();
+
+    let spk = SPK::load("../data/de440_type3.bsp").unwrap();
+    let bpc = BPC::load("../data/earth_latest_high_prec.bpc").unwrap();
+
+    let almanac = ctx
+        .with_spk(spk)
+        .unwrap()
+        .with_bpc(bpc)
+        .unwrap()
+        .load("../data/pck08.pca")
+        .unwrap();
+
+    // Let's build an orbit
+    // Start by grabbing a copy of the frame.
+    let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
+    // Define an epoch
+    let epoch = Epoch::from_str("2021-10-29 12:34:56 TDB").unwrap();
+
+    let orig_state = Orbit::keplerian(
+        8_191.93, 1e-6, 12.85, 306.614, 314.19, 99.887_7, epoch, eme2k,
+    );
+
+    // Transform that into another frame.
+    let state_itrf93 = almanac
+        .transform_to(orig_state, EARTH_ITRF93, Aberration::NONE)
+        .unwrap();
+
+    // Check that the frame is correctly set.
+    assert_eq!(state_itrf93.frame.ephemeris_id, EARTH_ITRF93.ephemeris_id);
+    assert_eq!(
+        state_itrf93.frame.orientation_id,
+        EARTH_ITRF93.orientation_id
+    );
+
+    println!("{orig_state:x}");
+    println!("{state_itrf93:X}");
+
+    // Convert back.
+    // Note that the Aberration correction constants are actually options!
+    let from_state_itrf93_to_eme2k = almanac
+        .transform_to(state_itrf93, EARTH_J2000, None)
+        .unwrap();
+
+    println!("{from_state_itrf93_to_eme2k}");
+    println!("{from_state_itrf93_to_eme2k:x}");
+
+    assert_eq!(orig_state, from_state_itrf93_to_eme2k);
+}

--- a/anise/tests/ephemerides/validation/mod.rs
+++ b/anise/tests/ephemerides/validation/mod.rs
@@ -9,6 +9,7 @@
  */
 
 mod type02_chebyshev_jpl_de;
+mod type03_chebyshev_jpl_de;
 mod type09_lagrange;
 mod type13_hermite;
 

--- a/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
+++ b/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
@@ -9,7 +9,6 @@
  */
 
 use super::{compare::*, validate::Validation};
-use anise::prelude::Aberration;
 
 #[ignore = "Requires Rust SPICE -- must be executed serially"]
 #[test]

--- a/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
+++ b/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
@@ -13,7 +13,7 @@ use anise::prelude::Aberration;
 
 #[ignore = "Requires Rust SPICE -- must be executed serially"]
 #[test]
-fn validate_jplde_de440_full() {
+fn validate_jplde_de440_type3_no_aberration() {
     let file_name = "spk-type3-validation-de440".to_string();
     let comparator = CompareEphem::new(
         vec!["../data/de440_type3.bsp".to_string()],

--- a/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
+++ b/anise/tests/ephemerides/validation/type03_chebyshev_jpl_de.rs
@@ -1,0 +1,35 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use super::{compare::*, validate::Validation};
+use anise::prelude::Aberration;
+
+#[ignore = "Requires Rust SPICE -- must be executed serially"]
+#[test]
+fn validate_jplde_de440_full() {
+    let file_name = "spk-type3-validation-de440".to_string();
+    let comparator = CompareEphem::new(
+        vec!["../data/de440_type3.bsp".to_string()],
+        file_name.clone(),
+        1_000,
+        None,
+    );
+
+    let err_count = comparator.run();
+
+    assert_eq!(err_count, 0, "None of the queries should fail!");
+
+    let validator = Validation {
+        file_name,
+        ..Default::default()
+    };
+
+    validator.validate();
+}

--- a/data/de440_type3.bsp
+++ b/data/de440_type3.bsp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e655129d94609bd7d22e792d8e7b2772e314cc42f03ed04f2ea46e0fa75b993
+size 360009728


### PR DESCRIPTION
# Summary

Add support for SPK type 3 BSP

Fix #320

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No public changes.

Internally, because the dataset for type 2 and type 3 Chebyshev is identical, I've created a private trait that avoids code duplication.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

Support SPK type3 Chebyshev interpolation.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

A new DE440-type3 BSP file is added to the tests and validated as part of the validation suite. This file is also used in one of the integration tests.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->