### PR TITLE
Keplerian initializer now allows larger error in convergence

### DIFF
--- a/anise-gui/src/ui.rs
+++ b/anise-gui/src/ui.rs
@@ -192,11 +192,11 @@ impl eframe::App for UiApp {
                                         ui.text_edit_singleline(&mut format!("{crc}"));
 
                                         if label.ends_with("SPK") {
-                                            let num_summaries = self.almanac.spk_data[0].as_ref().unwrap().data_summaries().unwrap().len();
+                                            let num_summaries = self.almanac.spk_data[0].as_ref().unwrap().daf_summary().unwrap().num_summaries();
                                             ui.label("Number of summaries");
                                             ui.label(format!("{num_summaries}"));
                                         } else if label.ends_with("PCK") {
-                                            let num_summaries = self.almanac.bpc_data[0].as_ref().unwrap().data_summaries().unwrap().len();
+                                            let num_summaries = self.almanac.bpc_data[0].as_ref().unwrap().daf_summary().unwrap().num_summaries();
                                             ui.label("Number of summaries");
                                             ui.label(format!("{num_summaries}"));
                                         }

--- a/anise/src/astro/utils.rs
+++ b/anise/src/astro/utils.rs
@@ -15,7 +15,7 @@ use crate::errors::{MathError, PhysicsError};
 use super::PhysicsResult;
 
 /// Mean anomaly f64::EPSILON
-pub const MA_EPSILON: f64 = 1e-16;
+pub const MA_EPSILON: f64 = 1e-12;
 
 /// Computes the true anomaly from the given mean anomaly for an orbit.
 ///


### PR DESCRIPTION
# Summary

- Fix #340 by changing the MA_EPSILON from 1e-16 degrees to 1e-12 degrees.
- Fix the reported number of summaries in the GUI (was erroneously always 25, which is the maximum per record).

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

#340 

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

- Add the test from #340 
- Opened the GMAT Hermite BSP in the GUI and confirm that it includes a single summary:

![image](https://github.com/user-attachments/assets/ae4359b8-6436-4468-8a30-f478dbf8e71c)


## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->