### PR TITLE
FK Item Parsing Crashes if Body ID is Empty

### DIFF
--- a/anise/src/naif/kpl/fk.rs
+++ b/anise/src/naif/kpl/fk.rs
@@ -49,13 +49,22 @@ impl KPLItem for FKItem {
 
     fn parse(&mut self, data: Assignment) {
         if data.keyword.starts_with("FRAME_") || data.keyword.starts_with("TKFRAME_") {
+            if data.value.is_empty() {
+                warn!("Empty value for `{}` -- ignoring", data.keyword);
+                return;
+            }
+
             match self.body_id {
                 None => {
                     // The data always starts with the definition of the frame
                     // So if the body isn't set, it'll be the first item to set
                     let next_ = data.keyword.find('_').unwrap();
                     self.name = Some(data.keyword[next_ + 1..].to_string());
-                    self.body_id = Some(data.value.parse::<i32>().unwrap());
+                    if let Ok(parsed_id) = data.value.parse::<i32>() {
+                        self.body_id = Some(parsed_id);
+                    } else {
+                        warn!("Failed to parse body ID from value `{}`", data.value);
+                    }
                 }
                 Some(body_id) => {
                     // The parameter starts with the ID of the frame.


### PR DESCRIPTION
# Summary

When running the fuzz test for `fkitem_parse`, a failure was encountered quickly where the call setting the body_id is being used on a non-i32 value, which leads to a crash.

Issue ticket located at: https://github.com/nyx-space/anise/issues/411

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Check `data.value.is_empty()` before pulling the value during FK Item parsing.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Issue was uncovered with minimal run time during fuzz tests. This time, the `fkitem_parse` test was run for 10 minutes to ensure no additional failures need to be addressed. Note, the previous failures were found within 10 seconds of fuzz testing.
Command is `cargo fuzz run fk_item_parse -- -max_total_time=600`

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->