### PR TITLE
Update kpl/fk key extraction to return -1 if unwrap fails

### DIFF
--- a/anise/src/naif/kpl/fk.rs
+++ b/anise/src/naif/kpl/fk.rs
@@ -33,7 +33,7 @@ impl KPLItem for FKItem {
                     Ok(frame_id) => frame_id,
                     Err(_) => {
                         // The frame ID is not in the key, so we must be a name key.
-                        data.value.trim().parse::<i32>().unwrap()
+                        data.value.trim().parse::<i32>().unwrap_or(-1)
                     }
                 },
                 None => -1,


### PR DESCRIPTION
# Summary

When running the fuzz test for fkitem_extract_key, a failure was encountered quickly where the call used to get the key value is being used on a non-i32 value, which leads to a crash.

Issue ticket located at: https://github.com/nyx-space/anise/issues/413

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Return a `-1` if the FK Item key extraction cannot unwrap the value.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Issue was uncovered with minimal run time during fuzz tests. This time, the `fkitem_extract_key` test was run for 10 minutes to ensure no additional failures need to be addressed. Note, the previous failures were found within 10 seconds of fuzz testing.
Command is cargo fuzz run fkitem_extract_key -- -max_total_time=600

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->