### PR TITLE
Update kpl/tpc key extraction to return -1 if unwrap fails

### DIFF
--- a/anise/src/naif/kpl/tpc.rs
+++ b/anise/src/naif/kpl/tpc.rs
@@ -26,7 +26,7 @@ impl KPLItem for TPCItem {
     fn extract_key(data: &Assignment) -> i32 {
         if data.keyword.starts_with("BODY") {
             let parts: Vec<&str> = data.keyword.split('_').collect();
-            parts[0][4..].parse::<i32>().unwrap()
+            parts[0][4..].parse::<i32>().unwrap_or(-1)
         } else {
             -1
         }


### PR DESCRIPTION
Closes https://github.com/nyx-space/anise/issues/415

# Summary

When running the fuzz test for tpcitem_extract_key, a failure was encountered quickly where the call used to get the key value is being used on a non-i32 value, which leads to a crash.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Return a `-1` if the TPC Item key extraction cannot unwrap the value.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Issue was uncovered with minimal run time during fuzz tests. This time, the `tpcitem_extract_key` test was run for 10 minutes to ensure no additional failures need to be addressed. Note, the previous failures were found within 10 seconds of fuzz testing.
Command is `cargo fuzz run tpcitem_extract_key -- -max_total_time=600`

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->