### PR TITLE
Almanac load_from_bytes Fails Fuzz Tests

### DIFF
--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -10,7 +10,7 @@
 
 use bytes::Bytes;
 use hifitime::TimeScale;
-use log::info;
+use log::{info, warn};
 use snafu::ResultExt;
 use zerocopy::FromBytes;
 
@@ -164,9 +164,25 @@ impl Almanac {
         }
 
         if let Ok(metadata) = Metadata::decode_header(&bytes) {
+            // Use `try_from` to validate the dataset type
+            let dataset_type = DataSetType::try_from(metadata.dataset_type as u8)
+                .map_err(|err| AlmanacError::GenericError {
+                    err: format!("Invalid dataset type: {}", err),
+                })?;
+                
             // Now, we can load this depending on the kind of data that it is
-            match metadata.dataset_type {
-                DataSetType::NotApplicable => unreachable!("no such ANISE data yet"),
+            match dataset_type {
+                DataSetType::NotApplicable => {
+                    // Not something that can be decoded
+                    warn!(
+                        "Encountered unsupported dataset type: {:?} in {}",
+                        dataset_type,
+                        path.unwrap_or("bytes")
+                    );
+                    return Err(AlmanacError::GenericError {
+                        err: "Encountered DataSetType::NotApplicable, which is not supported for loading".to_string(),
+                    });
+                }
                 DataSetType::SpacecraftData => {
                     // Decode as spacecraft data
                     let dataset = SpacecraftDataSet::try_from_bytes(bytes).context({

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -181,9 +181,9 @@ impl Almanac {
                         dataset_type,
                         path.unwrap_or("bytes")
                     );
-                    return Err(AlmanacError::GenericError {
+                    Err(AlmanacError::GenericError {
                         err: "Encountered DataSetType::NotApplicable, which is not supported for loading".to_string(),
-                    });
+                    })
                 }
                 DataSetType::SpacecraftData => {
                     // Decode as spacecraft data

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -10,7 +10,7 @@
 
 use bytes::Bytes;
 use hifitime::TimeScale;
-use log::{info, warn};
+use log::info;
 use snafu::ResultExt;
 use zerocopy::FromBytes;
 
@@ -168,7 +168,7 @@ impl Almanac {
             let dataset_type =
                 DataSetType::try_from(metadata.dataset_type as u8).map_err(|err| {
                     AlmanacError::GenericError {
-                        err: format!("Invalid dataset type: {}", err),
+                        err: format!("Invalid dataset type: {err}"),
                     }
                 })?;
 
@@ -176,13 +176,11 @@ impl Almanac {
             match dataset_type {
                 DataSetType::NotApplicable => {
                     // Not something that can be decoded
-                    warn!(
-                        "Encountered unsupported dataset type: {:?} in {}",
-                        dataset_type,
-                        path.unwrap_or("bytes")
-                    );
                     Err(AlmanacError::GenericError {
-                        err: "Encountered DataSetType::NotApplicable, which is not supported for loading".to_string(),
+                        err: format!(
+                            "Unsupported dataset type: DataSetType::NotApplicable in {}",
+                            path.unwrap_or("bytes")
+                        ),
                     })
                 }
                 DataSetType::SpacecraftData => {

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -165,11 +165,13 @@ impl Almanac {
 
         if let Ok(metadata) = Metadata::decode_header(&bytes) {
             // Use `try_from` to validate the dataset type
-            let dataset_type = DataSetType::try_from(metadata.dataset_type as u8)
-                .map_err(|err| AlmanacError::GenericError {
-                    err: format!("Invalid dataset type: {}", err),
+            let dataset_type =
+                DataSetType::try_from(metadata.dataset_type as u8).map_err(|err| {
+                    AlmanacError::GenericError {
+                        err: format!("Invalid dataset type: {}", err),
+                    }
                 })?;
-                
+
             // Now, we can load this depending on the kind of data that it is
             match dataset_type {
                 DataSetType::NotApplicable => {

--- a/anise/src/structure/dataset/datatype.rs
+++ b/anise/src/structure/dataset/datatype.rs
@@ -20,14 +20,16 @@ pub enum DataSetType {
     EulerParameterData,
 }
 
-impl From<u8> for DataSetType {
-    fn from(val: u8) -> Self {
+impl TryFrom<u8> for DataSetType {
+    type Error = &'static str;
+
+    fn try_from(val: u8) -> Result<Self, Self::Error> {
         match val {
-            0 => DataSetType::NotApplicable,
-            1 => DataSetType::SpacecraftData,
-            2 => DataSetType::PlanetaryData,
-            3 => DataSetType::EulerParameterData,
-            _ => panic!("Invalid value for DataSetType {val}"),
+            0 => Ok(DataSetType::NotApplicable),
+            1 => Ok(DataSetType::SpacecraftData),
+            2 => Ok(DataSetType::PlanetaryData),
+            3 => Ok(DataSetType::EulerParameterData),
+            _ => Err("Invalid value for DataSetType"),
         }
     }
 }
@@ -51,6 +53,10 @@ impl Encode for DataSetType {
 impl<'a> Decode<'a> for DataSetType {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         let asu8: u8 = decoder.decode()?;
-        Ok(Self::from(asu8))
+        DataSetType::try_from(asu8)
+            .map_err(|_| { der::Error::new(
+                der::ErrorKind::Value { tag: der::Tag::Integer },
+                der::Length::ONE            
+        )})
     }
 }

--- a/anise/src/structure/dataset/datatype.rs
+++ b/anise/src/structure/dataset/datatype.rs
@@ -53,10 +53,13 @@ impl Encode for DataSetType {
 impl<'a> Decode<'a> for DataSetType {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         let asu8: u8 = decoder.decode()?;
-        DataSetType::try_from(asu8)
-            .map_err(|_| { der::Error::new(
-                der::ErrorKind::Value { tag: der::Tag::Integer },
-                der::Length::ONE            
-        )})
+        DataSetType::try_from(asu8).map_err(|_| {
+            der::Error::new(
+                der::ErrorKind::Value {
+                    tag: der::Tag::Integer,
+                },
+                der::Length::ONE,
+            )
+        })
     }
 }

--- a/anise/src/structure/metadata.rs
+++ b/anise/src/structure/metadata.rs
@@ -95,10 +95,14 @@ impl<'a> Decode<'a> for Metadata {
         let anise_version = decoder.decode()?;
         let dataset_type = decoder.decode()?;
         let creation_date = Epoch::from_str(decoder.decode::<Utf8StringRef<'a>>()?.as_str())
-            .map_err(|_| { der::Error::new(
-                der::ErrorKind::Value { tag: der::Tag::Integer },
-                der::Length::ONE,
-            )})?;
+            .map_err(|_| {
+                der::Error::new(
+                    der::ErrorKind::Value {
+                        tag: der::Tag::Integer,
+                    },
+                    der::Length::ONE,
+                )
+            })?;
         let orig_str = decoder.decode::<Utf8StringRef<'a>>()?.as_str();
         let originator = orig_str[..MAX_ORIGINATOR_LEN.min(orig_str.len())]
             .try_into()

--- a/anise/src/structure/metadata.rs
+++ b/anise/src/structure/metadata.rs
@@ -98,7 +98,7 @@ impl<'a> Decode<'a> for Metadata {
             .map_err(|_| {
                 der::Error::new(
                     der::ErrorKind::Value {
-                        tag: der::Tag::Integer,
+                        tag: der::Tag::Utf8String,
                     },
                     der::Length::ONE,
                 )

--- a/anise/src/structure/metadata.rs
+++ b/anise/src/structure/metadata.rs
@@ -94,8 +94,11 @@ impl<'a> Decode<'a> for Metadata {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         let anise_version = decoder.decode()?;
         let dataset_type = decoder.decode()?;
-        let creation_date =
-            Epoch::from_str(decoder.decode::<Utf8StringRef<'a>>()?.as_str()).unwrap();
+        let creation_date = Epoch::from_str(decoder.decode::<Utf8StringRef<'a>>()?.as_str())
+            .map_err(|_| { der::Error::new(
+                der::ErrorKind::Value { tag: der::Tag::Integer },
+                der::Length::ONE,
+            )})?;
         let orig_str = decoder.decode::<Utf8StringRef<'a>>()?.as_str();
         let originator = orig_str[..MAX_ORIGINATOR_LEN.min(orig_str.len())]
             .try_into()


### PR DESCRIPTION
Closes https://github.com/nyx-space/anise/issues/417


# Summary

When running the fuzz test for `orientations_paths_root`, a failure was encountered quickly where an unsupported dataset type will cause a crash in the `_load_from_bytes` method of the `Almanac` object. This pull request aims to fix this such that the fuzz tests can pass.

The current solution is to replace the crash with an error.
An alternate solution, should the crash be a desired failure, is to update the fuzz tests so they pass (i.e. validate the inputs being used in the fuzz test)

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Update dataset decoding in `_load_from_bytes` method of `Almanac` object creation so it raises an Error instead of crashing. 

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Run related fuzz test for 15 minutes, even though original failure was encountered within 10 seconds.
`cargo fuzz run orientations_paths_root -- -max_total_time`

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->