### PR TITLE
Skip over non-UTF8 lines during kpl parsing

### DIFF
--- a/anise/src/naif/kpl/parser.rs
+++ b/anise/src/naif/kpl/parser.rs
@@ -98,7 +98,11 @@ pub fn parse_bytes<R: BufRead, I: KPLItem>(
     let mut assignments = vec![];
 
     for line in reader.lines() {
-        let line = line.expect("Failed to read line");
+        //let line = line.expect("Failed to read line");
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue, // skip lines that can't be read (invalid UTF-8)
+        };
         let tline = line.trim();
 
         if tline.starts_with("\\begintext") {

--- a/anise/src/naif/kpl/parser.rs
+++ b/anise/src/naif/kpl/parser.rs
@@ -98,7 +98,6 @@ pub fn parse_bytes<R: BufRead, I: KPLItem>(
     let mut assignments = vec![];
 
     for line in reader.lines() {
-        //let line = line.expect("Failed to read line");
         let line = match line {
             Ok(l) => l,
             Err(_) => continue, // skip lines that can't be read (invalid UTF-8)


### PR DESCRIPTION
Closes https://github.com/nyx-space/anise/issues/424

# Summary

Instead of using an `.expect()` call during KPL parsing, it will not be checked if the line is a UTF-8 value and skip over it if not.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Check if each line during KPL parsing is a valid UTF-8 and skip if not.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Ran the fuzz tests for 5 minutes to ensure no additional failures occurred. The previous fuzz testing occurred within 10 seconds previously.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->