### PR TITLE
Fix bug in `translate_state` for custom input vectors

### DIFF
--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -236,6 +236,7 @@ impl Almanac {
     ) -> Result<CartesianState, EphemerisError> {
         // Compute the frame translation
         let frame_state = self.translate(from_frame, observer_frame, epoch, ab_corr)?;
+        dbg!(frame_state);
 
         let dist_unit_factor = LengthUnit::Kilometer.from_meters() * distance_unit.to_meters();
         let time_unit_factor = time_unit.in_seconds();
@@ -246,6 +247,7 @@ impl Almanac {
             epoch,
             frame: from_frame,
         };
+        dbg!(input_state);
 
         (input_state + frame_state).context(EphemerisPhysicsSnafu {
             action: "translating states (likely a bug!)",

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -234,23 +234,16 @@ impl Almanac {
         distance_unit: LengthUnit,
         time_unit: TimeUnit,
     ) -> Result<CartesianState, EphemerisError> {
-        // Compute the frame translation
-        let frame_state = self.translate(from_frame, observer_frame, epoch, ab_corr)?;
-        dbg!(frame_state);
-
         let dist_unit_factor = LengthUnit::Kilometer.from_meters() * distance_unit.to_meters();
         let time_unit_factor = time_unit.in_seconds();
 
-        let input_state = CartesianState {
+        let state = CartesianState {
             radius_km: position * dist_unit_factor,
             velocity_km_s: velocity * dist_unit_factor / time_unit_factor,
             epoch,
             frame: from_frame,
         };
-        dbg!(input_state);
 
-        (input_state + frame_state).context(EphemerisPhysicsSnafu {
-            action: "translating states (likely a bug!)",
-        })
+        self.translate_to(state, observer_frame, ab_corr)
     }
 }

--- a/anise/tests/orientations/mod.rs
+++ b/anise/tests/orientations/mod.rs
@@ -523,7 +523,11 @@ fn regression_test_issue_431_test() {
 
     let epoch = Epoch::from_str("2022-06-29 00:00:00 TDB").unwrap();
 
-    almanac
+    let expected = almanac
+        .translate(EARTH_J2000, MOON_PA_DE421_FRAME, epoch, None)
+        .unwrap();
+
+    let computed = almanac
         .translate_state_to(
             Vector3::zeros(),
             Vector3::zeros(),
@@ -536,5 +540,5 @@ fn regression_test_issue_431_test() {
         )
         .unwrap();
 
-    assert!(true);
+    assert_eq!(expected, computed);
 }

--- a/anise/tests/orientations/mod.rs
+++ b/anise/tests/orientations/mod.rs
@@ -2,13 +2,14 @@ use std::path::PathBuf;
 
 use anise::constants::frames::{
     EARTH_ITRF93, EARTH_J2000, EME2000, IAU_JUPITER_FRAME, IAU_MOON_FRAME,
-    JUPITER_BARYCENTER_J2000, MOON_J2000, MOON_ME_DE440_ME421_FRAME, MOON_PA_DE440_FRAME,
+    JUPITER_BARYCENTER_J2000, MOON_J2000, MOON_ME_DE440_ME421_FRAME, MOON_PA_DE421_FRAME,
+    MOON_PA_DE440_FRAME,
 };
 use anise::constants::orientations::{
     ECLIPJ2000, IAU_JUPITER, IAU_MOON, ITRF93, J2000, MOON_PA_DE440,
 };
 use anise::math::rotation::DCM;
-use anise::math::Matrix3;
+use anise::math::{Matrix3, Vector3};
 use anise::naif::kpl::parser::convert_tpc;
 
 use anise::prelude::*;
@@ -505,4 +506,35 @@ fn regression_test_issue_357_test_moon_me_j2k() {
         .unwrap();
     let (lat, long, alt) = orbit_moon_me.latlongalt().unwrap();
     dbg!(lat, long, alt);
+}
+
+#[test]
+fn regression_test_issue_431_test() {
+    use core::str::FromStr;
+
+    let almanac = Almanac::new("../data/pck11.pca")
+        .unwrap()
+        .load("../data/moon_fk_de440.epa")
+        .unwrap()
+        .load("../data/moon_pa_de440_200625.bpc")
+        .unwrap()
+        .load("../data/de440s.bsp")
+        .unwrap();
+
+    let epoch = Epoch::from_str("2022-06-29 00:00:00 TDB").unwrap();
+
+    almanac
+        .translate_state_to(
+            Vector3::zeros(),
+            Vector3::zeros(),
+            EARTH_J2000,
+            MOON_PA_DE421_FRAME,
+            epoch,
+            None,
+            LengthUnit::Kilometer,
+            TimeUnit::Second,
+        )
+        .unwrap();
+
+    assert!(true);
 }


### PR DESCRIPTION
# Summary

**Fix #431**, consolidate the logic to `translate_to` which is more thoroughly tested.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Fix #431 

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

* Add a test that translate a zero state from  Earth J2000 to the MOON_PA_DE421_FRAME as in the bug report; check that it matches the state expected by a direct translation via the `translate` function.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->