### PR TITLE
Add AER regression test; freeze Earth high prec BPC used in AER test

### DIFF
--- a/anise/src/almanac/aer.rs
+++ b/anise/src/almanac/aer.rs
@@ -191,7 +191,7 @@ mod ut_aer {
         let longitude_deg = 4.250_556;
         let height_km = 0.834_939;
 
-        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../data/ci_config.dhall");
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../data/aer_regression.dhall");
         let almanac = MetaAlmanac::new(path.to_str().unwrap().to_string())
             .unwrap()
             .process(false)

--- a/data/aer_regression.dhall
+++ b/data/aer_regression.dhall
@@ -5,9 +5,9 @@
   , { crc32 = Some 3072159656
     , uri = "http://public-data.nyxspace.com/anise/v0.5/pck08.pca"
     }
-  , { crc32 = None Natural
+  , { crc32 = Some 0x256c8653
     , uri =
-        "http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc"
+        "http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2025-05-24.bpc"
     }
   ]
 }

--- a/data/ci_config.dhall
+++ b/data/ci_config.dhall
@@ -5,9 +5,9 @@
   , { crc32 = Some 3072159656
     , uri = "http://public-data.nyxspace.com/anise/v0.5/pck08.pca"
     }
-  , { crc32 = None Natural
+  , { crc32 = Some 0x256c8653
     , uri =
-        "http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2023-09-08.bpc"
+        "http://public-data.nyxspace.com/anise/ci/earth_latest_high_prec-2025-05-24.bpc"
     }
   ]
 }


### PR DESCRIPTION
# Summary

Add AER regression test: data validated in cislunar flight.

Fixes #434 .

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Add regression tests on the gmat_verif tests.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->