### PR TITLE
Fix Python GIL deadlock in `many` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py", "anise/fuzz"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."
@@ -46,7 +46,7 @@ numpy = "0.25"
 ndarray = ">= 0.15, < 0.17"
 rayon = "1.10.0"
 
-anise = { version = "0.6.1", path = "anise", default-features = false }
+anise = { version = "0.6.2", path = "anise", default-features = false }
 
 [profile.bench]
 debug = true

--- a/anise/src/almanac/python.rs
+++ b/anise/src/almanac/python.rs
@@ -143,14 +143,16 @@ impl Almanac {
     ))]
     fn py_azimuth_elevation_range_sez_many(
         &self,
+        py: Python, // New parameter
         rx_tx_states: Vec<(CartesianState, CartesianState)>,
         obstructing_body: Option<Frame>,
         ab_corr: Option<Aberration>,
     ) -> Vec<AzElRange> {
-        let mut rslt = rx_tx_states
-            .par_iter()
-            .filter_map(|(rx, tx)| {
-                self.azimuth_elevation_range_sez(*rx, *tx, obstructing_body, ab_corr)
+        py.allow_threads(|| {
+            let mut rslt = rx_tx_states
+                .par_iter()
+                .filter_map(|(rx, tx)| {
+                    self.azimuth_elevation_range_sez(*rx, *tx, obstructing_body, ab_corr)
                     .map_or_else(
                         |e| {
                             println!("{e}");
@@ -160,8 +162,9 @@ impl Almanac {
                     )
             })
             .collect::<Vec<AzElRange>>();
-        rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
-        rslt
+            rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
+            rslt
+        })
     }
 
     /// Computes whether the line of sight between an observer and an observed Cartesian state is obstructed by the obstructing body.
@@ -283,14 +286,16 @@ impl Almanac {
     ))]
     fn py_solar_eclipsing_many(
         &self,
+        py: Python, // New parameter
         eclipsing_frame: Frame,
         observers: Vec<Orbit>,
         ab_corr: Option<Aberration>,
     ) -> Vec<Occultation> {
-        let mut rslt = observers
-            .par_iter()
-            .filter_map(|observer| {
-                self.solar_eclipsing(eclipsing_frame, *observer, ab_corr)
+        py.allow_threads(|| {
+            let mut rslt = observers
+                .par_iter()
+                .filter_map(|observer| {
+                    self.solar_eclipsing(eclipsing_frame, *observer, ab_corr)
                     .map_or_else(
                         |e| {
                             println!("{e}");
@@ -300,8 +305,9 @@ impl Almanac {
                     )
             })
             .collect::<Vec<Occultation>>();
-        rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
-        rslt
+            rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
+            rslt
+        })
     }
 
     /// Computes the Beta angle (β) for a given orbital state, in degrees. A Beta angle of 0° indicates that the orbit plane is edge-on to the Sun, leading to maximum eclipse time. Conversely, a Beta angle of +90° or -90° means the orbit plane is face-on to the Sun, resulting in continuous sunlight exposure and no eclipses.
@@ -377,15 +383,17 @@ impl Almanac {
     ))]
     fn py_transform_many<'py>(
         &self,
+        py: Python, // New parameter
         target_frame: Frame,
         observer_frame: Frame,
         time_series: TimeSeries,
         ab_corr: Option<Aberration>,
     ) -> Vec<CartesianState> {
-        let mut states = time_series
-            .par_bridge()
-            .filter_map(|epoch| {
-                self.transform(target_frame, observer_frame, epoch, ab_corr)
+        py.allow_threads(|| {
+            let mut states = time_series
+                .par_bridge()
+                .filter_map(|epoch| {
+                    self.transform(target_frame, observer_frame, epoch, ab_corr)
                     .map_or_else(
                         |e| {
                             eprintln!("{e}");
@@ -395,8 +403,9 @@ impl Almanac {
                     )
             })
             .collect::<Vec<CartesianState>>();
-        states.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
-        states
+            states.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
+            states
+        })
     }
 
     /// Returns the provided state as seen from the observer frame, given the aberration.
@@ -436,14 +445,16 @@ impl Almanac {
     ))]
     fn py_transform_many_to(
         &self,
+        py: Python, // New parameter
         states: Vec<CartesianState>,
         observer_frame: Frame,
         ab_corr: Option<Aberration>,
     ) -> Vec<CartesianState> {
-        let mut rslt = states
-            .par_iter()
-            .filter_map(|state| {
-                self.transform_to(*state, observer_frame, ab_corr)
+        py.allow_threads(|| {
+            let mut rslt = states
+                .par_iter()
+                .filter_map(|state| {
+                    self.transform_to(*state, observer_frame, ab_corr)
                     .map_or_else(
                         |e| {
                             println!("{e}");
@@ -453,8 +464,9 @@ impl Almanac {
                     )
             })
             .collect::<Vec<CartesianState>>();
-        rslt.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
-        rslt
+            rslt.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
+            rslt
+        })
     }
 
     /// Returns the Cartesian state of the object as seen from the provided observer frame (essentially `spkezr`).

--- a/anise/src/almanac/python.rs
+++ b/anise/src/almanac/python.rs
@@ -143,7 +143,7 @@ impl Almanac {
     ))]
     fn py_azimuth_elevation_range_sez_many(
         &self,
-        py: Python, // New parameter
+        py: Python,
         rx_tx_states: Vec<(CartesianState, CartesianState)>,
         obstructing_body: Option<Frame>,
         ab_corr: Option<Aberration>,
@@ -153,15 +153,15 @@ impl Almanac {
                 .par_iter()
                 .filter_map(|(rx, tx)| {
                     self.azimuth_elevation_range_sez(*rx, *tx, obstructing_body, ab_corr)
-                    .map_or_else(
-                        |e| {
-                            println!("{e}");
-                            None
-                        },
-                        |aer| Some(aer),
-                    )
-            })
-            .collect::<Vec<AzElRange>>();
+                        .map_or_else(
+                            |e| {
+                                println!("{e}");
+                                None
+                            },
+                            |aer| Some(aer),
+                        )
+                })
+                .collect::<Vec<AzElRange>>();
             rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
             rslt
         })
@@ -286,7 +286,7 @@ impl Almanac {
     ))]
     fn py_solar_eclipsing_many(
         &self,
-        py: Python, // New parameter
+        py: Python,
         eclipsing_frame: Frame,
         observers: Vec<Orbit>,
         ab_corr: Option<Aberration>,
@@ -296,15 +296,15 @@ impl Almanac {
                 .par_iter()
                 .filter_map(|observer| {
                     self.solar_eclipsing(eclipsing_frame, *observer, ab_corr)
-                    .map_or_else(
-                        |e| {
-                            println!("{e}");
-                            None
-                        },
-                        |aer| Some(aer),
-                    )
-            })
-            .collect::<Vec<Occultation>>();
+                        .map_or_else(
+                            |e| {
+                                println!("{e}");
+                                None
+                            },
+                            |aer| Some(aer),
+                        )
+                })
+                .collect::<Vec<Occultation>>();
             rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
             rslt
         })
@@ -383,7 +383,7 @@ impl Almanac {
     ))]
     fn py_transform_many<'py>(
         &self,
-        py: Python, // New parameter
+        py: Python,
         target_frame: Frame,
         observer_frame: Frame,
         time_series: TimeSeries,
@@ -394,15 +394,15 @@ impl Almanac {
                 .par_bridge()
                 .filter_map(|epoch| {
                     self.transform(target_frame, observer_frame, epoch, ab_corr)
-                    .map_or_else(
-                        |e| {
-                            eprintln!("{e}");
-                            None
-                        },
-                        |state| Some(state),
-                    )
-            })
-            .collect::<Vec<CartesianState>>();
+                        .map_or_else(
+                            |e| {
+                                eprintln!("{e}");
+                                None
+                            },
+                            |state| Some(state),
+                        )
+                })
+                .collect::<Vec<CartesianState>>();
             states.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
             states
         })
@@ -445,7 +445,7 @@ impl Almanac {
     ))]
     fn py_transform_many_to(
         &self,
-        py: Python, // New parameter
+        py: Python,
         states: Vec<CartesianState>,
         observer_frame: Frame,
         ab_corr: Option<Aberration>,
@@ -455,15 +455,15 @@ impl Almanac {
                 .par_iter()
                 .filter_map(|state| {
                     self.transform_to(*state, observer_frame, ab_corr)
-                    .map_or_else(
-                        |e| {
-                            println!("{e}");
-                            None
-                        },
-                        |state| Some(state),
-                    )
-            })
-            .collect::<Vec<CartesianState>>();
+                        .map_or_else(
+                            |e| {
+                                println!("{e}");
+                                None
+                            },
+                            |state| Some(state),
+                        )
+                })
+                .collect::<Vec<CartesianState>>();
             rslt.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
             rslt
         })

--- a/anise/tests/astro/orbit.rs
+++ b/anise/tests/astro/orbit.rs
@@ -855,3 +855,21 @@ fn gh_regression_340(almanac: Almanac) {
         assert!(orbit.at_epoch(epoch).is_ok(), "error on {epoch}");
     }
 }
+
+#[rstest]
+fn misc_verif(almanac: Almanac) {
+    let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
+
+    // Blue Ghost landing day!
+    let epoch = Epoch::from_gregorian_utc_at_noon(2025, 3, 2);
+
+    // LTAN
+    let prograde = Orbit::new(0.0, 7000.0, 0.0, -1.0, 0.0, 7.5, epoch, eme2k);
+    f64_eq!(prograde.ltan_deg().unwrap(), 90.0, "prograde LTAN");
+
+    let retrograde = Orbit::new(0.0, -7000.0, 0.0, -1.0, 0.0, 7.5, epoch, eme2k);
+    f64_eq!(retrograde.ltan_deg().unwrap(), 270.0, "retrograde LTAN");
+
+    let equatorial = Orbit::keplerian(7000.0, 1e-4, 1e-12, 270.0, 45.0, 76.0, epoch, eme2k);
+    assert!(equatorial.ltan_deg().is_err())
+}


### PR DESCRIPTION
The `many` functions in `anise/src/almanac/python.rs` use Rayon for parallelism. This can cause deadlocks in Python versions older than 3.13 due to the GIL.

This commit fixes the issue by:
- Adding `py: Python` as a parameter to the affected functions.
- Wrapping the Rayon calls within `py.allow_threads(|| { ... })` to release the GIL.

The modified functions are:
- `py_azimuth_elevation_range_sez_many`
- `py_solar_eclipsing_many`
- `py_transform_many`
- `py_transform_many_to`


Fix #457 