### PR TITLE
Fix: Correct Rustdoc :type annotations for Python bindings

### DIFF
--- a/anise/src/almanac/python.rs
+++ b/anise/src/almanac/python.rs
@@ -344,7 +344,7 @@ impl Almanac {
     /// # Note
     /// The units will be those of the underlying ephemeris data (typically km and km/s)
     ///
-    /// :type target_frame: Orbit
+    /// :type target_frame: Frame
     /// :type observer_frame: Frame
     /// :type epoch: Epoch
     /// :type ab_corr: Aberration, optional
@@ -370,7 +370,7 @@ impl Almanac {
     ///
     /// Refer to [transform] for details.
     ///
-    /// :type target_frame: Orbit
+    /// :type target_frame: Frame
     /// :type observer_frame: Frame
     /// :type time_series: TimeSeries
     /// :type ab_corr: Aberration, optional
@@ -537,7 +537,7 @@ impl Almanac {
     /// # Note
     /// This function performs a recursion of no more than twice the [MAX_TREE_DEPTH].
     ///
-    /// :type target_frame: Orbit
+    /// :type target_frame: Frame
     /// :type observer_frame: Frame
     /// :type epoch: Epoch
     /// :type ab_corr: Aberration, optional
@@ -560,7 +560,7 @@ impl Almanac {
 
     /// Returns the geometric position vector, velocity vector, and acceleration vector needed to translate the `from_frame` to the `to_frame`, where the distance is in km, the velocity in km/s, and the acceleration in km/s^2.
     ///
-    /// :type target_frame: Orbit
+    /// :type target_frame: Frame
     /// :type observer_frame: Frame
     /// :type epoch: Epoch
     /// :rtype: Orbit

--- a/anise/src/astro/occultation.rs
+++ b/anise/src/astro/occultation.rs
@@ -87,7 +87,7 @@ impl Occultation {
     fn get_percentage(&self) -> PyResult<f64> {
         Ok(self.percentage)
     }
-    /// :type epoch: Epoch
+    /// :type percentage: float
     #[setter]
     fn set_percentage(&mut self, percentage: f64) -> PyResult<()> {
         self.percentage = percentage;

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -337,7 +337,7 @@ impl Orbit {
     /// In the GMAT MathSpec notation, R_{IF} is the DCM from body fixed to inertial. Similarly, R{FT} is from topocentric
     /// to body fixed.
     ///
-    /// :type _from: float
+    /// :type _from: int
     /// :rtype: DCM
     pub fn dcm_from_topocentric_to_body_fixed(&self, _from: NaifId) -> PhysicsResult<DCM> {
         let rot_mat_dt = if let Ok(pre) = self.at_epoch(self.epoch - Unit::Second * 1) {


### PR DESCRIPTION
Ensured that the Python type specified in Rustdoc comments with the `:type` flag accurately reflects the corresponding Rust type.

Corrected several instances where the documented Python type did not match the Rust type, including cases of `Orbit` vs `Frame` and incorrect primitive types for function parameters.

(Long task by Jules: six minutes!)