### PR TITLE
ci: add macos-15 to github workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -211,6 +211,41 @@ jobs:
           pip install pytest numpy
           pytest
 
+  macos-15:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          working-directory: anise-py
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-15
+          path: anise-py/dist
+
+      - name: pytest
+        shell: bash
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          set -e
+          pip install anise --find-links anise-py/dist --force-reinstall
+          pip install pytest numpy
+          pytest
+
   sdist:
     runs-on: ubuntu-latest
     steps:
@@ -242,7 +277,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
-    needs: [linux, windows, macos-13, macos-14, sdist]
+    needs: [linux, windows, macos-13, macos-14, macos-15, sdist]
     steps:
       - uses: actions/download-artifact@v4 # No `name` to download all artifacts.
         with:


### PR DESCRIPTION
Add a build step for MacOS 15, and prebuild / release the package for that platform. 