### PR TITLE
Fix benchmark tests dependencies 

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,15 +36,8 @@ jobs:
       - name: Install CSPICE
         run: sh dev-env-setup.sh && cd .. # Return to root
 
-      - uses: taiki-e/install-action@cargo-binstall
       - name: Install iai-callgrind-runner
-        run: |
-          version=$(cargo metadata --format-version=1 |\
-            jq '.packages[] | select(.name == "iai-callgrind").version' |\
-            tr -d '"'
-          )
-          cargo binstall --no-confirm iai-callgrind-runner --version $version
-          sudo apt-get install -y valgrind
+        run: cargo install iai-callgrind-runner --version 0.15.2
 
 
       - name: Bench JPL Ephemerides

--- a/anise/Cargo.toml
+++ b/anise/Cargo.toml
@@ -50,7 +50,8 @@ rust-spice = "0.7.6"
 parquet = "55.0.0"
 arrow = "55.0.0"
 criterion = "0.6"
-iai-callgrind = "0.15"
+iai-callgrind = "0.15.2"
+iai-callgrind-runner = "0.15.2"
 pretty_env_logger = { workspace = true }
 rstest = { workspace = true }
 approx = "0.5.1"


### PR DESCRIPTION
The benchmark CI was failing because `iai-callgrind-runner` was not installed. I've added a step to the benchmark workflow to install `iai-callgrind-runner` before running the benchmarks.

I've also updated the version of `iai-callgrind` to `0.15.2` and added `iai-callgrind-runner` to the `dev-dependencies` of the `anise` crate.


