### PR TITLE
Upgrade dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-hifitime = "4.2.2"
+hifitime = "4.2.3"
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }
@@ -41,9 +41,9 @@ zerocopy = { version = "0.8.0", features = ["derive"] }
 bytes = "1.6.0"
 snafu = { version = "0.8.0", features = ["backtrace"] }
 rstest = "0.26.1"
-pyo3 = { version = "0.26", features = ["multiple-pymethods"] }
+pyo3 = { version = "0.27", features = ["multiple-pymethods"] }
 pyo3-log = "0.13"
-numpy = "0.26"
+numpy = "0.27"
 ndarray = ">= 0.15, < 0.17"
 rayon = "1.10.0"
 


### PR DESCRIPTION
Updated hifitime, pyo3, and numpy dependencies to their latest versions for improved functionality and performance.


