### PR TITLE
update to python fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-hifitime = { git = "https://github.com/nyx-space/hifitime", rev = "501f3a012c60d3ca26446fc37270adb8782bfd5b" }
+hifitime = { git = "https://github.com/nyx-space/hifitime", rev = "501f3a012c60d3ca26446fc37270adb8782bfd5b" } # TODO: Revert to a released version from crates.io once the required changes for Python bindings are published.
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }


### PR DESCRIPTION
# Summary

Hello, I need the Nyx workspace to update to the latest commit in hifitime.
Otherwise I can't investigate python bindings on my side. And the SP3 lib would require this up to nyx itself