### PR TITLE
Update python macos dist

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -165,6 +165,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          working-directory: anise-py
       - name: Upload wheels
         uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
Used the updated maturin CI build for the macos and release steps. This should include the sdist as well.

Note that this change will be included in the 0.9.2 release since Github CIs were down earlier today, so release 0.9.2 was never pushed.