### PR TITLE
Fix STK .e file distance unit default to meters

### DIFF
--- a/data/tests/ansys-stk/stk_cov.e
+++ b/data/tests/ansys-stk/stk_cov.e
@@ -17,6 +17,8 @@ BEGIN Ephemeris
 
     CoordinateSystem		 ICRF
 
+    DistanceUnit Kilometers
+
     CovarianceFormat LowerTriangular
 
     EphemerisTimePosVel

--- a/data/tests/ansys-stk/test_v12.e
+++ b/data/tests/ansys-stk/test_v12.e
@@ -21,6 +21,8 @@ BEGIN Ephemeris
 
     CoordinateSystem		 ICRF
 
+    DistanceUnit Kilometers
+
     BEGIN SegmentBoundaryTimes
 
          0.0


### PR DESCRIPTION
This PR fixes a bug where STK .e files without a `DistanceUnit` header were incorrectly assumed to be in kilometers. According to STK documentation, the default is meters. The parser now correctly defaults to meters and performs the necessary conversion to ANISE's internal kilometer-based representation. Existing test files were updated to explicitly specify kilometers to preserve current test behavior.

Fixes #637

---
*PR created automatically by Jules for task [4545834885385126133](https://jules.google.com/task/4545834885385126133) started by @ChristopherRabotin*