### PR TITLE
Fix Type2/Type3 spline indexing for trimmed segments

### DIFF
--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -53,7 +53,9 @@ impl Type3ChebyshevSet<'_> {
 
         let window_duration_s = self.interval_length.to_seconds();
 
-        let ephem_start_delta_s = epoch.to_et_seconds() - summary.start_epoch_et_s();
+        // For trimmed kernels, the summary bounds may no longer align exactly with the
+        // dataset footer epoch. Use the dataset init epoch for record selection.
+        let ephem_start_delta_s = epoch.to_et_seconds() - self.init_epoch.to_et_seconds();
 
         Ok(((ephem_start_delta_s / window_duration_s) as usize + 1).min(self.num_records))
     }
@@ -294,8 +296,9 @@ impl<'a> NAIFDataRecord<'a> for Type3ChebyshevRecord<'a> {
 mod chebyshev_ut {
     use crate::{
         errors::{DecodingError, IntegrityError},
-        naif::daf::NAIFDataSet,
+        naif::{daf::NAIFDataSet, spk::summary::SPKSummaryRecord},
     };
+    use hifitime::Epoch;
 
     use super::Type3ChebyshevSet;
 
@@ -376,5 +379,39 @@ mod chebyshev_ut {
                 );
             }
         }
+    }
+
+    #[test]
+    fn evaluate_uses_init_epoch_for_record_selection() {
+        // Three degree-0 records with unique constants per record.
+        let dataset = Type3ChebyshevSet::from_f64_slice(&[
+            5.0, 5.0, 1.0, 10.0, 100.0, 0.1, 1.1, 2.1, //
+            15.0, 5.0, 2.0, 20.0, 200.0, 0.2, 1.2, 2.2, //
+            25.0, 5.0, 3.0, 30.0, 300.0, 0.3, 1.3, 2.3, //
+            0.0, 10.0, 8.0, 3.0,
+        ])
+        .unwrap();
+
+        let shifted_summary = SPKSummaryRecord {
+            start_epoch_et_s: 4.0,
+            end_epoch_et_s: 30.0,
+            target_id: 301,
+            center_id: 3,
+            frame_id: 1,
+            data_type_i: 3,
+            start_idx: 1,
+            end_idx: 28,
+        };
+
+        let epoch = Epoch::from_et_seconds(12.0);
+        assert_eq!(dataset.spline_idx(epoch, &shifted_summary).unwrap(), 2);
+
+        let (state, rate) = dataset.evaluate(epoch, &shifted_summary).unwrap();
+        assert_eq!(state[0], 2.0);
+        assert_eq!(state[1], 20.0);
+        assert_eq!(state[2], 200.0);
+        assert_eq!(rate[0], 0.2);
+        assert_eq!(rate[1], 1.2);
+        assert_eq!(rate[2], 2.2);
     }
 }


### PR DESCRIPTION
# Summary

Fix Type2/Type3 spline record selection for trimmed SPK segments by anchoring index calculation to dataset `init_epoch` (footer metadata) instead of summary start epoch. Add targeted regressions for both types.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

- Fix incorrect Type2/Type3 record selection when trimmed segment summary coverage start differs from dataset `init_epoch`.
- Prevent large full-vs-trimmed divergence caused by selecting the wrong Chebyshev record.

## Testing and validation

- Added regression tests:
  - `/Users/tobyhede/psrc/anise/anise/src/naif/daf/datatypes/chebyshev.rs` (`evaluate_uses_init_epoch_for_record_selection`)
  - `/Users/tobyhede/psrc/anise/anise/src/naif/daf/datatypes/chebyshev3.rs` (`evaluate_uses_init_epoch_for_record_selection`)
- Ran:
  - `cargo fmt --all -- --check`
  - `CSPICE_DIR=/tmp/cspice-shim2 cargo clippy -p anise -- -D warnings`
  - `CSPICE_DIR=/tmp/cspice-shim2 cargo test -p anise evaluate_uses_init_epoch_for_record_selection -- --nocapture`

## Documentation

This PR does not primarily deal with documentation changes.
