### PR TITLE
feat: Add Python iterator support for Ephemeris

### DIFF
--- a/anise-py/tests/test_ephemeris.py
+++ b/anise-py/tests/test_ephemeris.py
@@ -1,0 +1,45 @@
+import pytest
+from anise.astro import Ephemeris, Orbit, Frame
+from anise.constants import Frames
+from anise.time import Epoch, Unit
+
+def test_ephemeris_iter():
+    start = Epoch("2024-01-01 00:00:00 UTC")
+    # EME2000 is J2000. We need to set GM for Keplerian conversion.
+    frame = Frames.EME2000.with_mu_km3_s2(398600.4418)
+
+    orbits = []
+    count = 10
+    for i in range(count):
+        epoch = start + Unit.Hour * i
+        # sma_km, ecc, inc_deg, raan_deg, aop_deg, ta_deg, epoch, frame
+        orbit = Orbit.from_keplerian(
+            7000.0, 0.001, 45.0, 10.0, 20.0, float(i) * 10.0, epoch, frame
+        )
+        orbits.append(orbit)
+
+    ephem = Ephemeris(orbits, "test_obj")
+
+    # Test forward iteration
+    iterated_orbits = []
+    for record in ephem:
+        iterated_orbits.append(record.orbit)
+
+    assert len(iterated_orbits) == count
+    for i in range(count):
+        assert iterated_orbits[i].epoch == orbits[i].epoch
+        # Check some value
+        assert abs(iterated_orbits[i].sma_km() - 7000.0) < 1e-9
+
+    # Test reversed iteration
+    reversed_orbits = []
+    for record in reversed(ephem):
+        reversed_orbits.append(record.orbit)
+
+    assert len(reversed_orbits) == count
+    for i in range(count):
+        # Should match reversed original list
+        assert reversed_orbits[i].epoch == orbits[count - 1 - i].epoch
+
+if __name__ == "__main__":
+    test_ephemeris_iter()

--- a/anise/src/ephemerides/ephemeris/mod.rs
+++ b/anise/src/ephemerides/ephemeris/mod.rs
@@ -51,7 +51,25 @@ pub struct Ephemeris {
     pub object_id: String,
     pub interpolation: DataType,
     pub degree: usize,
-    state_data: BTreeMap<Epoch, EphemerisRecord>,
+    pub(crate) state_data: BTreeMap<Epoch, EphemerisRecord>,
+}
+
+impl<'a> IntoIterator for &'a Ephemeris {
+    type Item = &'a EphemerisRecord;
+    type IntoIter = std::collections::btree_map::Values<'a, Epoch, EphemerisRecord>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state_data.values()
+    }
+}
+
+impl IntoIterator for Ephemeris {
+    type Item = EphemerisRecord;
+    type IntoIter = std::collections::btree_map::IntoValues<Epoch, EphemerisRecord>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state_data.into_values()
+    }
 }
 
 impl Ephemeris {


### PR DESCRIPTION
This PR implements a lightweight, double-ended iterator for the `Ephemeris` struct in both Rust and Python.

In Rust:
- Implemented `IntoIterator` for `Ephemeris` and `&Ephemeris`, allowing idiomatic iteration over `EphemerisRecord`s without interpolation.
- Changed visibility of `state_data` to `pub(crate)` to facilitate access from the Python binding module.

In Python:
- Added `__iter__` and `__reversed__` methods to the `Ephemeris` class.
- Introduced `EphemerisItemIterator` which holds a `Py<Ephemeris>` reference to keep the parent object alive during iteration, preventing use-after-free issues.
- The iterator yields `EphemerisRecord` objects directly from the underlying storage.

Testing:
- Added `anise-py/tests/test_ephemeris.py` which verifies:
    - Forward iteration count and values.
    - Reverse iteration order and correctness.
- Verified that the implementation handles `Py<Ephemeris>` correctly using `Bound` and `unbind()`.

---
*PR created automatically by Jules for task [7916378430693162474](https://jules.google.com/task/7916378430693162474) started by @ChristopherRabotin*