### PR TITLE
feat: implement iterator on Ephemeris

### DIFF
--- a/anise-py/anise/astro.pyi
+++ b/anise-py/anise/astro.pyi
@@ -195,7 +195,7 @@ class Ephemeris:
     """Initializes a new Ephemeris from the list of Orbit instances and a given object ID.
 
     In Python if you need to build an ephemeris with covariance, initialize with an empty list of
-    orbit instances and then insert each EphemEntry with covariance."""
+    orbit instances and then insert each EphemerisRecord with covariance."""
 
     degree: int
     interpolation: str

--- a/anise-py/tests/test_almanac.py
+++ b/anise-py/tests/test_almanac.py
@@ -471,12 +471,19 @@ def test_oem():
     assert ephem_from_list.end_epoch() == ephem_from_empty.end_epoch()
     assert ephem_from_list.len() == ephem_from_empty.len()
 
+    # Check that we can iterate over an ephem entry by entry
+    entry_count = 0
+    for entry in ephem:
+        entry_count += 1
+        assert isinstance(entry, EphemerisRecord)
+    assert entry_count == ephem.len()
+
 
 if __name__ == "__main__":
     # test_meta_load()
     # test_exports()
     # test_frame_defs()
     # test_convert_tpc()
-    test_state_transformation()
+    # test_state_transformation()
     # test_location()
-    # test_oem()
+    test_oem()

--- a/anise/src/ephemerides/ephemeris/mod.rs
+++ b/anise/src/ephemerides/ephemeris/mod.rs
@@ -20,7 +20,10 @@ use core::fmt;
 use covariance::interpolate_covar_log_euclidean;
 use hifitime::{Epoch, TimeSeries};
 use snafu::ResultExt;
-use std::collections::BTreeMap;
+use std::collections::{
+    btree_map::{IntoValues, Values},
+    BTreeMap,
+};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -40,7 +43,7 @@ pub use record::EphemerisRecord;
 /// Initializes a new Ephemeris from the list of Orbit instances and a given object ID.
 ///
 /// In Python if you need to build an ephemeris with covariance, initialize with an empty list of
-/// orbit instances and then insert each EphemEntry with covariance.
+/// orbit instances and then insert each EphemerisRecord with covariance.
 ///
 /// :type orbit_list: list
 /// :type object_id: str
@@ -510,6 +513,24 @@ impl fmt::Display for Ephemeris {
     }
 }
 
+impl<'a> IntoIterator for &'a Ephemeris {
+    type Item = &'a EphemerisRecord;
+    type IntoIter = Values<'a, Epoch, EphemerisRecord>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state_data.values()
+    }
+}
+
+impl IntoIterator for Ephemeris {
+    type Item = EphemerisRecord;
+    type IntoIter = IntoValues<Epoch, EphemerisRecord>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state_data.into_values()
+    }
+}
+
 #[cfg(test)]
 mod ut_oem {
     use super::{Almanac, DataType, Ephemeris, LocalFrame};
@@ -559,6 +580,13 @@ mod ut_oem {
         assert_eq!(ephem.degree, 7);
 
         println!("{ephem}");
+
+        let mut num_entries = 0;
+        for _entry in &ephem {
+            num_entries += 1;
+        }
+
+        assert_eq!(num_entries, ephem.state_data.len());
 
         // Check that we can interpolate
         let epoch = start + Unit::Second * 5;

--- a/anise/src/ephemerides/ephemeris/mod.rs
+++ b/anise/src/ephemerides/ephemeris/mod.rs
@@ -581,12 +581,7 @@ mod ut_oem {
 
         println!("{ephem}");
 
-        let mut num_entries = 0;
-        for _entry in &ephem {
-            num_entries += 1;
-        }
-
-        assert_eq!(num_entries, ephem.state_data.len());
+        assert_eq!((&ephem).into_iter().count(), ephem.state_data.len());
 
         // Check that we can interpolate
         let epoch = start + Unit::Second * 5;

--- a/anise/src/ephemerides/ephemeris/oem.rs
+++ b/anise/src/ephemerides/ephemeris/oem.rs
@@ -44,7 +44,7 @@ impl Ephemeris {
         let mut time_system = String::new();
         let mut center_name = None;
         let mut orient_name = None;
-        let mut interpolation = DataType::Type13HermiteUnequalStep;
+        let mut interpolation = DataType::Type9LagrangeUnequalStep;
         let mut degree = 5;
         let mut object_id: Option<String> = None;
         let mut cov_epoch = None;

--- a/anise/src/ephemerides/ephemeris/python.rs
+++ b/anise/src/ephemerides/ephemeris/python.rs
@@ -126,6 +126,20 @@ impl Ephemeris {
     fn __repr__(&self) -> String {
         format!("{self}@{self:p}")
     }
+
+    fn __iter__(slf: Bound<'_, Self>) -> PyResult<EphemerisIterator> {
+        let items: Vec<EphemerisRecord> = slf.borrow().state_data.values().copied().collect();
+        Ok(EphemerisIterator {
+            items: items.into_iter(),
+        })
+    }
+
+    fn __reversed__(slf: Bound<'_, Self>) -> PyResult<EphemerisIterator> {
+        let items: Vec<EphemerisRecord> = slf.borrow().state_data.values().rev().copied().collect();
+        Ok(EphemerisIterator {
+            items: items.into_iter(),
+        })
+    }
 }
 
 #[pymethods]
@@ -167,5 +181,21 @@ impl Covariance {
     /// :rtype: str
     fn __repr__(&self) -> String {
         format!("{self}@{self:p}")
+    }
+}
+
+#[pyclass]
+struct EphemerisIterator {
+    items: std::vec::IntoIter<EphemerisRecord>,
+}
+
+#[pymethods]
+impl EphemerisIterator {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<EphemerisRecord> {
+        slf.items.next()
     }
 }

--- a/anise/src/ephemerides/ephemeris/stk.rs
+++ b/anise/src/ephemerides/ephemeris/stk.rs
@@ -45,7 +45,7 @@ impl Ephemeris {
         // Define header variables we care about.
         let mut center_name = None;
         let mut orient_name = None;
-        let mut interpolation = DataType::Type13HermiteUnequalStep;
+        let mut interpolation = DataType::Type9LagrangeUnequalStep;
         let mut samples_m1 = 5;
         let object_id: String = path
             .as_ref()


### PR DESCRIPTION
# Summary

Allow iteration of an ephemeris, both in Rust and Python. It will iterate through the exact ephemeris records instead of interpolating. One should use this if the ephemeris has any maneuver as that will throw off the interpolation.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

Allow iteration of an ephemeris, both in Rust and Python. It will iterate through the exact ephemeris records instead of interpolating.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

Switch the default OEM and STK interpolator to Lagrange because it behaves nicely in the presence of maneuvers.

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Ensure that one can iterate over an ephemeris both in Rust and in Python and match the correct number of entries.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->