### PR TITLE
feat(anise): Implement serde_dhall::StaticType for spacecraft and covariance types

### DIFF
--- a/anise/src/analysis/elements.rs
+++ b/anise/src/analysis/elements.rs
@@ -25,6 +25,7 @@ use crate::prelude::Orbit;
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.analysis"))]
 #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub enum OrbitalElement {
     /// Argument of Latitude (deg)
     AoL,

--- a/anise/src/ephemerides/ephemeris/covariance.rs
+++ b/anise/src/ephemerides/ephemeris/covariance.rs
@@ -18,6 +18,7 @@ use pyo3::prelude::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.astro"))]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub enum LocalFrame {
     Inertial,
     RIC,
@@ -28,6 +29,7 @@ pub enum LocalFrame {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.astro"))]
+
 pub struct Covariance {
     pub matrix: Matrix6,
     pub local_frame: LocalFrame,

--- a/anise/src/ephemerides/ephemeris/covariance.rs
+++ b/anise/src/ephemerides/ephemeris/covariance.rs
@@ -18,7 +18,7 @@ use pyo3::prelude::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.astro"))]
-#[cfg_attr(feature = "metaload", derive(serde::Serialize, serde::Deserialize, serde_dhall::StaticType))]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub enum LocalFrame {
     Inertial,
     RIC,

--- a/anise/src/ephemerides/ephemeris/covariance.rs
+++ b/anise/src/ephemerides/ephemeris/covariance.rs
@@ -29,7 +29,6 @@ pub enum LocalFrame {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.astro"))]
-
 pub struct Covariance {
     pub matrix: Matrix6,
     pub local_frame: LocalFrame,

--- a/anise/src/ephemerides/ephemeris/covariance.rs
+++ b/anise/src/ephemerides/ephemeris/covariance.rs
@@ -18,7 +18,7 @@ use pyo3::prelude::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "anise.astro"))]
-#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
+#[cfg_attr(feature = "metaload", derive(serde::Serialize, serde::Deserialize, serde_dhall::StaticType))]
 pub enum LocalFrame {
     Inertial,
     RIC,

--- a/anise/src/structure/spacecraft/drag.rs
+++ b/anise/src/structure/spacecraft/drag.rs
@@ -19,6 +19,7 @@ use pyo3::types::{PyBytes, PyType};
 
 #[cfg_attr(feature = "python", pyclass(get_all, set_all, module = "anise.astro"))]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub struct DragData {
     /// Atmospheric drag area in m^2 -- default 0.0
     /// :rtype: float

--- a/anise/src/structure/spacecraft/mass.rs
+++ b/anise/src/structure/spacecraft/mass.rs
@@ -21,6 +21,7 @@ use pyo3::types::{PyBytes, PyType};
 /// Defines a spacecraft mass a the sum of the dry (structural) mass and the propellant mass, both in kilogram
 #[cfg_attr(feature = "python", pyclass(get_all, set_all, module = "anise.astro"))]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub struct Mass {
     /// Structural mass of the spacecraft, in kg
     /// :rtype: float

--- a/anise/src/structure/spacecraft/srp.rs
+++ b/anise/src/structure/spacecraft/srp.rs
@@ -19,6 +19,7 @@ use pyo3::types::{PyBytes, PyType};
 
 #[cfg_attr(feature = "python", pyclass(get_all, set_all, module = "anise.astro"))]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub struct SRPData {
     /// Solar radiation pressure area in m^2 -- default 0.0
     /// :rtype: float


### PR DESCRIPTION
This PR implements `serde_dhall::StaticType` for `Mass`, `SRPData`, `DragData`, and `LocalFrame` when the `metaload` feature is enabled. This allows reading configurations specifying these fields from Dhall files.

---
*PR created automatically by Jules for task [3405614896206335511](https://jules.google.com/task/3405614896206335511) started by @ChristopherRabotin*