### PR TITLE
avoid panic when opening FK files in convert-fk (propagate IO error)

### DIFF
--- a/anise-cli/src/main.rs
+++ b/anise-cli/src/main.rs
@@ -161,7 +161,7 @@ fn main() -> Result<(), CliErrors> {
             Ok(())
         }
         Actions::ConvertFk { fkfile, outfile } => {
-            let dataset = convert_fk(fkfile, false).unwrap();
+            let dataset = convert_fk(fkfile, false).context(CliDataSetSnafu)?;
 
             dataset.save_as(&outfile, false).context(CliDataSetSnafu)?;
 

--- a/anise-cli/tests/convert_fk_missing_file.rs
+++ b/anise-cli/tests/convert_fk_missing_file.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn convert_fk_missing_file_returns_error_instead_of_panic() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let missing_fk = format!("__missing_fk_{}_{}.txt", std::process::id(), nonce);
+    let output_path = format!("./target/tmp/out_{}.epa", nonce);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_anise-cli"))
+        .args(["convert-fk", &missing_fk, &output_path])
+        .output()
+        .expect("failed to run anise-cli");
+
+    assert!(
+        !output.status.success(),
+        "missing FK input should return an error"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(101),
+        "convert-fk should not panic on missing FK file"
+    );
+
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !combined.contains("panicked at"),
+        "missing FK input should be handled as an error, got output:\n{combined}"
+    );
+    assert!(
+        combined.contains("opening KPL file"),
+        "expected IO error context in output, got:\n{combined}"
+    );
+}

--- a/anise/src/naif/kpl/parser.rs
+++ b/anise/src/naif/kpl/parser.rs
@@ -84,8 +84,10 @@ pub fn parse_file<P: AsRef<Path> + fmt::Debug, I: KPLItem>(
     file_path: P,
     show_comments: bool,
 ) -> Result<HashMap<i32, I>, DataSetError> {
-    let file =
-        File::open(&file_path).unwrap_or_else(|_| panic!("Failed to open file {file_path:?}"));
+    let file = File::open(&file_path).map_err(|source| DataSetError::IO {
+        action: "opening KPL file",
+        source,
+    })?;
     let mut reader = BufReader::new(file);
     parse_bytes(&mut reader, show_comments)
 }


### PR DESCRIPTION
# Summary

Fix a user-triggerable panic in the `convert-fk` CLI command when the input FK file is missing or cannot be opened.

---

## Architectural Changes

None.

---

## New Features

None.

---

## Improvements

* Ensures consistent error handling in `convert-fk` by propagating errors instead of panicking.
* Aligns `convert-fk` behavior with existing CLI patterns (e.g., `convert-tpc`).

---

## Bug Fixes

* Fixes a panic caused by:

  * `unwrap()` in the CLI layer (`main.rs`)
  * `panic!` on file open failure in the parser (`parse_file`)
* Missing or unreadable FK files now return a structured error instead of crashing the process.

---

## Reproduction

```bash
cargo run -p anise-cli -- convert-fk ./missing_fk.txt ./out.epa
```

### Before

* Process panics due to `unwrap()` / `panic!`

### After

* Returns a handled CLI error (no panic)

---

## Root Cause

* The parser (`parse_file`) panicked when `File::open` failed.
* The CLI (`convert-fk`) unconditionally unwrapped the result, propagating the panic to users.

---

## Fix

* Replace `unwrap()` in `convert-fk` with proper error propagation using `.context(...) ?`
* Replace `panic!` on file open in the parser with `DataSetError::IO`

---

## Testing and Validation

* Added an integration test:

  * Verifies that a missing FK file no longer causes a panic
  * Confirms graceful error handling through the CLI
* Manual validation:

  * Invalid input → returns error (no panic)
  * Valid input → unchanged behavior

---

## Scope

* Limited to the `convert-fk` path and its underlying parser behaviour
* No refactoring or unrelated changes
* No API or dependency changes

---

## Impact

* Prevents CLI crashes from invalid user input
* Improves robustness and reliability of file handling
* No behaviour change for valid inputs

---

## Notes

* This change specifically addresses the `convert-fk` path.
* Similar patterns in other commands can be addressed separately if needed.
