### PR TITLE
Avoid panic on truncated input by using bounds-checked slice in CLI

### DIFF
--- a/anise-cli/src/main.rs
+++ b/anise-cli/src/main.rs
@@ -41,11 +41,9 @@ pub enum CliErrors {
     FilePersist {
         source: io::Error,
     },
-    /// ANISE error encountered"
     CliDAF {
         source: DAFError,
     },
-    /// ANISE error encountered"
     CliDataType {
         error: Box<dyn std::error::Error>,
     },
@@ -120,12 +118,17 @@ fn main() -> Result<(), CliErrors> {
                 }
             } else {
                 // Load the header only
-                let file_record_bytes = bytes.get(..FileRecord::SIZE).ok_or_else(|| {
-                    CliErrors::ArgumentError {
-                        arg: format!("file too small: expected at least {} bytes", FileRecord::SIZE),
-                    }
-                })?;
-                let file_record = FileRecord::read_from_bytes(file_record_bytes).unwrap();
+                let file_record_bytes =
+                    bytes
+                        .get(..FileRecord::SIZE)
+                        .ok_or_else(|| CliErrors::ArgumentError {
+                            arg: format!(
+                                "file too small: expected at least {} bytes",
+                                FileRecord::SIZE
+                            ),
+                        })?;
+                let file_record = FileRecord::read_from_bytes(file_record_bytes)
+                    .expect("cannot read bytes that exist");
                 match file_record.identification().context(CliFileRecordSnafu)? {
                     "PCK" => {
                         info!("Loading {path_str:?} as DAF/PCK");
@@ -207,12 +210,17 @@ fn main() -> Result<(), CliErrors> {
 fn read_and_record(path_str: PathBuf) -> Result<(bytes::BytesMut, FileRecord), CliErrors> {
     let bytes = file2heap!(path_str).context(AniseSnafu)?;
     // Load the header only
-    let file_record_bytes = bytes.get(..FileRecord::SIZE).ok_or_else(|| {
-        CliErrors::ArgumentError {
-            arg: format!("file too small: expected at least {} bytes", FileRecord::SIZE),
-        }
-    })?;
-    let file_record = FileRecord::read_from_bytes(file_record_bytes).unwrap();
+    let file_record_bytes =
+        bytes
+            .get(..FileRecord::SIZE)
+            .ok_or_else(|| CliErrors::ArgumentError {
+                arg: format!(
+                    "file too small: expected at least {} bytes",
+                    FileRecord::SIZE
+                ),
+            })?;
+    let file_record =
+        FileRecord::read_from_bytes(file_record_bytes).expect("cannot read bytes that exist");
     Ok((bytes, file_record))
 }
 

--- a/anise-cli/src/main.rs
+++ b/anise-cli/src/main.rs
@@ -120,7 +120,12 @@ fn main() -> Result<(), CliErrors> {
                 }
             } else {
                 // Load the header only
-                let file_record = FileRecord::read_from_bytes(&bytes[..FileRecord::SIZE]).unwrap();
+                let file_record_bytes = bytes.get(..FileRecord::SIZE).ok_or_else(|| {
+                    CliErrors::ArgumentError {
+                        arg: format!("file too small: expected at least {} bytes", FileRecord::SIZE),
+                    }
+                })?;
+                let file_record = FileRecord::read_from_bytes(file_record_bytes).unwrap();
                 match file_record.identification().context(CliFileRecordSnafu)? {
                     "PCK" => {
                         info!("Loading {path_str:?} as DAF/PCK");
@@ -161,7 +166,7 @@ fn main() -> Result<(), CliErrors> {
             Ok(())
         }
         Actions::ConvertFk { fkfile, outfile } => {
-            let dataset = convert_fk(fkfile, false).unwrap();
+            let dataset = convert_fk(fkfile, false).context(CliDataSetSnafu)?;
 
             dataset.save_as(&outfile, false).context(CliDataSetSnafu)?;
 
@@ -202,7 +207,12 @@ fn main() -> Result<(), CliErrors> {
 fn read_and_record(path_str: PathBuf) -> Result<(bytes::BytesMut, FileRecord), CliErrors> {
     let bytes = file2heap!(path_str).context(AniseSnafu)?;
     // Load the header only
-    let file_record = FileRecord::read_from_bytes(&bytes[..FileRecord::SIZE]).unwrap();
+    let file_record_bytes = bytes.get(..FileRecord::SIZE).ok_or_else(|| {
+        CliErrors::ArgumentError {
+            arg: format!("file too small: expected at least {} bytes", FileRecord::SIZE),
+        }
+    })?;
+    let file_record = FileRecord::read_from_bytes(file_record_bytes).unwrap();
     Ok((bytes, file_record))
 }
 


### PR DESCRIPTION
# Summary

This PR improves the robustness of the CLI by removing panic paths when handling user-provided input files.

---

## Architectural Changes

None.

---

## New Features

None.

---

## Improvements

* Replaced unchecked slicing (`&bytes[..SIZE]`) with bounds-checked access using `.get(..SIZE)`
* Ensures safe handling of truncated or malformed input files
* Aligns with existing safe slice usage patterns in the codebase
* Replaced one `.unwrap()` in `convert_fk` flow with proper error propagation using `.context(...)`

---

## Bug Fixes

* Fixed panic when processing files smaller than `FileRecord::SIZE`
* Fixed potential panic in `convert_fk` path by replacing `.unwrap()` with error propagation

---

## Testing and Validation

* Verified that truncated files now return a clean error instead of panicking
* Confirmed valid files behave unchanged
* Ensured compilation succeeds without introducing new warnings or errors

---

## Documentation

No documentation changes.

---

## Notes

* Changes are limited to CLI only
* No impact on library behavior
* No API changes
* Follows existing error handling patterns