### PR TITLE
Implement a binary search querying of ordered NAIF IDs in DAF files

### DIFF
--- a/anise/src/ephemerides/ephemeris/spk.rs
+++ b/anise/src/ephemerides/ephemeris/spk.rs
@@ -18,9 +18,9 @@ use crate::{
     NaifId,
 };
 use bytes::BytesMut;
-use indexmap::IndexMap;
 use log::warn;
 use snafu::ensure;
+use std::collections::HashMap;
 use std::{fs::File, io::Write};
 use zerocopy::IntoBytes;
 
@@ -173,7 +173,7 @@ impl Ephemeris {
         let mut spk = SPK {
             bytes: BytesMut::from(&padded_bytes[..]),
             crc32: None,
-            index: IndexMap::new(),
+            index: HashMap::new(),
         };
         spk.set_crc32();
         Ok(spk)

--- a/anise/src/ephemerides/ephemeris/spk.rs
+++ b/anise/src/ephemerides/ephemeris/spk.rs
@@ -18,6 +18,7 @@ use crate::{
     NaifId,
 };
 use bytes::BytesMut;
+use indexmap::IndexMap;
 use log::warn;
 use snafu::ensure;
 use std::{fs::File, io::Write};
@@ -172,7 +173,7 @@ impl Ephemeris {
         let mut spk = SPK {
             bytes: BytesMut::from(&padded_bytes[..]),
             crc32: None,
-            _daf_type: std::marker::PhantomData,
+            index: IndexMap::new(),
         };
         spk.set_crc32();
         Ok(spk)

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -20,9 +20,9 @@ use crate::{errors::IntegrityError, DBL_SIZE};
 use bytes::{Bytes, BytesMut};
 use core::fmt::Debug;
 use core::hash::Hash;
-use core::marker::PhantomData;
 use core::ops::Deref;
 use hifitime::{Epoch, Unit};
+use indexmap::IndexMap;
 use log::error;
 use snafu::ResultExt;
 
@@ -43,8 +43,10 @@ pub(crate) const RCRD_LEN: usize = 1024;
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct DAF<R: NAIFSummaryRecord> {
     pub bytes: BytesMut,
+    /// CRC32 field enables memory scrubbing, reducing memory errors in a radiation-laden environment.
     pub crc32: Option<u32>,
-    pub _daf_type: PhantomData<R>,
+    /// Index of the NAIF ID to its summary record only if all of the summaries for this ID are chronologically ordered. Enables binary search for that ID.
+    pub index: IndexMap<i32, Vec<(R, Option<usize>, usize)>>,
 }
 
 impl<R: NAIFSummaryRecord> DAF<R> {
@@ -61,16 +63,48 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     /// 2.  The CRC32 checksum of the bytes is computed.
     /// 3.  The `file_record` and `name_record` are parsed to ensure the file is a valid DAF.
     pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
-        let me = Self {
+        let mut me = Self {
             bytes: BytesMut::from(&bytes[..]),
             crc32: None,
-            _daf_type: PhantomData,
+            index: IndexMap::new(),
         };
         // Check that the file record and name record can be parsed successfully.
         // This validates that the file is a DAF and that the endianness is correct.
         me.file_record()?;
         // Ensure tha twe can parse the first name record.
         me.name_record(None)?;
+        // Build the index for all of the NAIF IDs which are ordered in the file.
+        let mut index: IndexMap<i32, Vec<(R, Option<usize>, usize)>> = IndexMap::new();
+        let mut unsorted = vec![];
+        let mut blk_idx = None;
+        loop {
+            for (summary_idx, cur_sum) in me.data_summaries(blk_idx)?.iter().enumerate() {
+                if let Some(prev_summaries) = index.get_mut(&cur_sum.id()) {
+                    let prev_sum: &R =
+                        &prev_summaries.last().expect("there must be at least one").0;
+                    if prev_sum.end_epoch() > cur_sum.start_epoch() {
+                        // This index is not sorted because the previous summary starts before the current one, and we're iterating linerarly.
+                        index.swap_remove(&cur_sum.id());
+                        unsorted.push(cur_sum.id());
+                    } else {
+                        // Append this summary to the index.
+                        prev_summaries.push((*cur_sum, blk_idx, summary_idx));
+                    }
+                } else if !unsorted.contains(&cur_sum.id()) {
+                    index.insert(cur_sum.id(), vec![(*cur_sum, blk_idx, summary_idx)]);
+                }
+            }
+            let summary = me.daf_summary(blk_idx)?;
+            if summary.is_final_record() || summary.is_corrupt() {
+                break;
+            } else {
+                dbg!(summary);
+                blk_idx = Some(summary.next_record());
+            }
+        }
+
+        me.index = index;
+
         Ok(me)
     }
 
@@ -310,36 +344,61 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         Err(DAFError::SummaryIdError { kind: R::NAME, id })
     }
 
-    /// Returns the summary given the id of the summary record if that summary has data defined at the requested epoch
+    /// Returns the summary, block index, and summary index in that block for the id of the summary record if that summary has data defined at the requested epoch
     pub fn summary_from_id_at_epoch(
         &self,
         id: i32,
         epoch: Epoch,
     ) -> Result<(&R, Option<usize>, usize), DAFError> {
-        // NOTE: We iterate through the whole summary because a specific NAIF ID may be repeated in the summary for different valid epochs
-        // so we can't just call `summary_from_id`.
-        let mut idx = None;
-        loop {
-            for (summary_idx, summary) in self.data_summaries(idx)?.iter().enumerate() {
-                if summary.id() == id
-                    && epoch >= summary.start_epoch() - Unit::Nanosecond * 100
-                    && epoch <= summary.end_epoch() + Unit::Nanosecond * 100
-                {
-                    return Ok((summary, idx, summary_idx));
+        // If the summaries are ordered in the DAF file, then they are in the index, so we can run a binary search to find the proper index.
+        if let Some(idx_data) = self.index.get(&id) {
+            let idx = idx_data.partition_point(|(summaries, _blk_idx, _summary_idx)| {
+                summaries.start_epoch() <= epoch
+            });
+            if idx == 0 {
+                Err(DAFError::InterpolationDataErrorFromId {
+                    kind: R::NAME,
+                    id,
+                    epoch,
+                })
+            } else {
+                let (summary, blk_idx, summary_idx) = &idx_data[idx - 1];
+                if epoch <= summary.end_epoch() + Unit::Nanosecond * 100 {
+                    Ok((summary, *blk_idx, *summary_idx))
+                } else {
+                    Err(DAFError::InterpolationDataErrorFromId {
+                        kind: R::NAME,
+                        id,
+                        epoch,
+                    })
                 }
             }
-            let summary = self.daf_summary(idx)?;
-            if summary.is_final_record() {
-                break;
-            } else {
-                idx = Some(summary.next_record());
+        } else {
+            // NOTE: We iterate through the whole summary because a specific NAIF ID may be repeated in the summary for different valid epochs
+            // so we can't just call `summary_from_id`.
+            let mut blk_idx = None;
+            loop {
+                for (summary_idx, summary) in self.data_summaries(blk_idx)?.iter().enumerate() {
+                    if summary.id() == id
+                        && epoch >= summary.start_epoch() - Unit::Nanosecond * 100
+                        && epoch <= summary.end_epoch() + Unit::Nanosecond * 100
+                    {
+                        return Ok((summary, blk_idx, summary_idx));
+                    }
+                }
+                let summary = self.daf_summary(blk_idx)?;
+                if summary.is_final_record() {
+                    break;
+                } else {
+                    blk_idx = Some(summary.next_record());
+                }
             }
+            Err(DAFError::InterpolationDataErrorFromId {
+                kind: R::NAME,
+                id,
+                epoch,
+            })
         }
-        Err(DAFError::InterpolationDataErrorFromId {
-            kind: R::NAME,
-            id,
-            epoch,
-        })
     }
 
     /// Provided a name that is in the summary, return its full data, if name is available.

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -22,9 +22,9 @@ use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::Deref;
 use hifitime::{Epoch, Unit};
-use indexmap::IndexMap;
 use log::error;
 use snafu::ResultExt;
+use std::collections::{HashMap, HashSet};
 
 use zerocopy::IntoBytes;
 use zerocopy::{FromBytes, Ref};
@@ -46,7 +46,7 @@ pub struct DAF<R: NAIFSummaryRecord> {
     /// CRC32 field enables memory scrubbing, reducing memory errors in a radiation-laden environment.
     pub crc32: Option<u32>,
     /// Index of the NAIF ID to its summary record only if all of the summaries for this ID are chronologically ordered. Enables binary search for that ID.
-    pub index: IndexMap<i32, Vec<(R, Option<usize>, usize)>>,
+    pub index: HashMap<i32, Vec<(R, Option<usize>, usize)>>,
 }
 
 impl<R: NAIFSummaryRecord> DAF<R> {
@@ -66,7 +66,7 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         let mut me = Self {
             bytes: BytesMut::from(&bytes[..]),
             crc32: None,
-            index: IndexMap::new(),
+            index: HashMap::new(),
         };
         // Check that the file record and name record can be parsed successfully.
         // This validates that the file is a DAF and that the endianness is correct.
@@ -74,8 +74,8 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         // Ensure tha twe can parse the first name record.
         me.name_record(None)?;
         // Build the index for all of the NAIF IDs which are ordered in the file.
-        let mut index: IndexMap<i32, Vec<(R, Option<usize>, usize)>> = IndexMap::new();
-        let mut unsorted = vec![];
+        let mut index: HashMap<i32, Vec<(R, Option<usize>, usize)>> = HashMap::new();
+        let mut unsorted = HashSet::new();
         let mut blk_idx = None;
         loop {
             for (summary_idx, cur_sum) in me.data_summaries(blk_idx)?.iter().enumerate() {
@@ -84,8 +84,8 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                         &prev_summaries.last().expect("there must be at least one").0;
                     if prev_sum.end_epoch() > cur_sum.start_epoch() {
                         // This index is not sorted because the previous summary starts before the current one, and we're iterating linerarly.
-                        index.swap_remove(&cur_sum.id());
-                        unsorted.push(cur_sum.id());
+                        index.remove(&cur_sum.id());
+                        unsorted.insert(cur_sum.id());
                     } else {
                         // Append this summary to the index.
                         prev_summaries.push((*cur_sum, blk_idx, summary_idx));
@@ -98,7 +98,6 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             if summary.is_final_record() || summary.is_corrupt() {
                 break;
             } else {
-                dbg!(summary);
                 blk_idx = Some(summary.next_record());
             }
         }
@@ -352,8 +351,8 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     ) -> Result<(&R, Option<usize>, usize), DAFError> {
         // If the summaries are ordered in the DAF file, then they are in the index, so we can run a binary search to find the proper index.
         if let Some(idx_data) = self.index.get(&id) {
-            let idx = idx_data.partition_point(|(summaries, _blk_idx, _summary_idx)| {
-                summaries.start_epoch() <= epoch
+            let idx = idx_data.partition_point(|(summary, _blk_idx, _summary_idx)| {
+                summary.start_epoch() - Unit::Nanosecond * 100 <= epoch
             });
             if idx == 0 {
                 Err(DAFError::InterpolationDataErrorFromId {

--- a/anise/src/naif/daf/summary_record.rs
+++ b/anise/src/naif/daf/summary_record.rs
@@ -39,4 +39,11 @@ impl SummaryRecord {
     pub fn is_final_record(&self) -> bool {
         self.next_record() == 0
     }
+
+    /// Returns true if this summary seems to be corrupted: number of summaries, or next/previous record are not integers
+    pub fn is_corrupt(&self) -> bool {
+        self.num_summaries.round() != self.num_summaries
+            || self.prev_record.round() != self.prev_record
+            || self.next_record.round() != self.next_record
+    }
 }


### PR DESCRIPTION
# Summary

DAF parsing now builds an index for NAIF ID summaries which are ordered. Enables O(log N) searching for ordered DAF files (which is most). Non-ordered summaries still use the previous O(N) searching.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

While it does not affect the API, the DAF parsing now builds an index for the NAIF IDs whose summaries are chronologically ordered throughout the DAF summary blocks. This enables the `summary_id_at_epoch` function to perform a binary search, at an O(log N) cost, when seeking a specific summary, at the expense of a constant O(N) cost parsing a DAF file. The trade-off is well worth it.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

No change in the tests, thereby ensuring identical behavior to the CSPICE and previous ANISE version.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->