### PR TITLE
Fix #703: if event eval has not changed, keep the current step + Update to hifitime 4.3.0, enabling Lunar Time and Lunar Coordinated Time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-hifitime = "4.2.5"
+hifitime = "4.3.0"
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }

--- a/anise/src/analysis/utils.rs
+++ b/anise/src/analysis/utils.rs
@@ -153,7 +153,6 @@ where
 
         // Ensure that we're scanning linearly.
         let delta = (y_next - y_prev).abs();
-        let delta_ratio = delta / step.to_seconds();
 
         // For angles, we smooth the evaluation with an atan2 function of the difference
         // between the desired and the event's evaluation angle.
@@ -169,6 +168,12 @@ where
                 brackets.push((t, t + step));
             }
         } else {
+            let mut delta_ratio = delta / step.to_seconds();
+            if delta_ratio == 0.0 {
+                // If the event eval returned the same value at the current step (i.e. y_next == y_prev)
+                // do not modify modify the step it takes.
+                delta_ratio = 1.0;
+            }
             // Update the step to try to achieve linearity.
             let next_step = (step.to_seconds() / delta_ratio) * Unit::Second;
             if delta_ratio > 1.1 && step >= min_step {

--- a/anise/src/constants.rs
+++ b/anise/src/constants.rs
@@ -273,12 +273,10 @@ pub mod orientations {
     pub const IAU_URANUS: NaifId = 799;
     pub const IAU_NEPTUNE: NaifId = 899;
 
-    /// Angle between J2000 to solar system ecliptic J2000 ([ECLIPJ2000]), in radians (about 23.43929 degrees). Apply this rotation about the X axis (R1).
+    /// Angle between J2000 to solar system ecliptic J2000 ([ECLIPJ2000]), in radians (about 23.43929 degrees). Apply this rotation about the X axis (R1)
     ///
-    /// Also used as SOFA's `EPS0` (obliquity at J2000.0) by the
-    /// J2000→ICRS frame-bias rotation in `orientations/rotate_to_parent.rs`.
-    /// Changing this constant shifts both the ECLIPJ2000 rotation and the
-    /// ICRS frame bias — that is intentional, but be aware of the coupling.
+    /// Also used as SOFA's `EPS0` (obliquity at J2000.0) by J2000→ICRS frame-bias rotation in the rotate_to_parent function.
+    /// Changing this constant shifts both the ECLIPJ2000 rotation and the ICRS frame bias — that is intentional, but be aware of the coupling.
     pub const J2000_TO_ECLIPJ2000_ANGLE_RAD: f64 = 0.40909280422232897;
 
     /// Given the frame ID, try to return a human name


### PR DESCRIPTION
# Summary

Fix #703: if event eval has not changed, keep the current step

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

- Update to hifitime 4.3.0, enabling Lunar Time and Lunar Coordinated Time.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

The `test_analysis_event` test was triggering the bug, so I simply executed that with the (easy) fix.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->