### PR TITLE
Update the CRC32s of the PCA files

### DIFF
--- a/anise/src/almanac/metaload/metaalmanac.rs
+++ b/anise/src/almanac/metaload/metaalmanac.rs
@@ -162,14 +162,14 @@ impl Default for MetaAlmanac {
                         .join("v0.10/pck11.pca")
                         .expect("static URL join is valid")
                         .to_string(),
-                    crc32: Some(0xf151b735),
+                    crc32: Some(0x1edb3eac),
                 },
                 MetaFile {
                     uri: nyx_cloud_stor
                         .join("v0.10/moon_fk_de440.epa")
                         .expect("static URL join is valid")
                         .to_string(),
-                    crc32: Some(0x32c8f9d7),
+                    crc32: Some(0xc6c252fa),
                 },
                 MetaFile {
                     uri: jpl_cloud_stor

--- a/anise/src/almanac/metaload/mod.rs
+++ b/anise/src/almanac/metaload/mod.rs
@@ -180,7 +180,7 @@ mod meta_test {
   [ { crc32 = Some 0x7286750a
     , uri = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
     }
-  , { crc32 = Some 0xf151b735
+  , { crc32 = Some 0x1edb3eac
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck11.pca"
     }
   , { crc32 = Some 0x32c8f9d7

--- a/anise/src/almanac/metaload/mod.rs
+++ b/anise/src/almanac/metaload/mod.rs
@@ -183,7 +183,7 @@ mod meta_test {
   , { crc32 = Some 0x1edb3eac
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck11.pca"
     }
-  , { crc32 = Some 0x32c8f9d7
+  , { crc32 = Some 0xc6c252fa
     , uri = "http://public-data.nyxspace.com/anise/v0.10/moon_fk_de440.epa"
     }
   , { crc32 = Some 0xcde5ca7d

--- a/data/aer_regression.dhall
+++ b/data/aer_regression.dhall
@@ -2,8 +2,8 @@
   [ { crc32 = Some 1921414410
     , uri = "http://public-data.nyxspace.com/anise/de440s.bsp"
     }
-  , { crc32 = Some 0x92b7d662
-    , uri = "http://public-data.nyxspace.com/anise/v0.7/pck08.pca"
+  , { crc32 = Some 731191443
+    , uri = "http://public-data.nyxspace.com/anise/v0.10/pck08.pca"
     }
   , { crc32 = Some 0x256c8653
     , uri =

--- a/data/aer_regression.dhall
+++ b/data/aer_regression.dhall
@@ -1,8 +1,8 @@
 { files =
-  [ { crc32 = Some 1921414410
-    , uri = "http://public-data.nyxspace.com/anise/de440s.bsp"
+  [ { crc32 = Some 0x7286750a
+    , uri = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
     }
-  , { crc32 = Some 731191443
+  , { crc32 = Some 0x2b951893
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck08.pca"
     }
   , { crc32 = Some 0x256c8653

--- a/data/ci_config.dhall
+++ b/data/ci_config.dhall
@@ -2,7 +2,7 @@
   [ { crc32 = Some 0x7286750a
     , uri = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
     }
-  , { crc32 = Some 0x92b7d662
+  , { crc32 = Some 731191443
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck08.pca"
     }
   , { crc32 = None Natural

--- a/data/ci_config.dhall
+++ b/data/ci_config.dhall
@@ -2,7 +2,7 @@
   [ { crc32 = Some 0x7286750a
     , uri = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
     }
-  , { crc32 = Some 731191443
+  , { crc32 = Some 0x2b951893
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck08.pca"
     }
   , { crc32 = None Natural

--- a/data/latest.dhall
+++ b/data/latest.dhall
@@ -3,10 +3,10 @@
   [ { crc32 = Some 0x7286750a
     , uri = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
     }
-  , { crc32 = Some 0xf151b735
+  , { crc32 = Some 0x1edb3eac
     , uri = "http://public-data.nyxspace.com/anise/v0.10/pck11.pca"
     }
-  , { crc32 = Some 0x32c8f9d7
+  , { crc32 = Some 0xc6c252fa
     , uri = "http://public-data.nyxspace.com/anise/v0.10/moon_fk_de440.epa"
     }
   , { crc32 = Some 0xcde5ca7d


### PR DESCRIPTION
Update the CRC32s of the PCA files to the file's CRC instead of the dataset CRC

Phew, this saved me quite some transfer costs! Fix #708

