### PR TITLE
Refactor period function to handle non-finite values

### DIFF
--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -786,8 +786,8 @@ impl Orbit {
     /// :rtype: Duration
     pub fn period(&self) -> PhysicsResult<Duration> {
         let period2_s2 = self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
-        if period_s2.is_finite() {
-            Ok(TAU * period_s2.sqrt().seconds())
+        if period2_s2.is_finite() {
+            Ok(TAU * period2_s2.sqrt().seconds())
         } else {
             Ok(Duration::ZERO)
         }

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -785,10 +785,12 @@ impl Orbit {
     ///
     /// :rtype: Duration
     pub fn period(&self) -> PhysicsResult<Duration> {
-        Ok(TAU
-            * (self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?)
-                .sqrt()
-                .seconds())
+        let period2_s2 = self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
+        if period_s2.is_finite() {
+            Ok(TAU * period_s2.sqrt().seconds())
+        } else {
+            Ok(Duration::ZERO)
+        }
     }
 
     /// Returns the mean motion in degrees per seconds

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -785,7 +785,7 @@ impl Orbit {
     ///
     /// :rtype: Duration
     pub fn period(&self) -> PhysicsResult<Duration> {
-        let period2_s2 = (self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
+        let period2_s2 = self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
         if period2_s2 > 0.0 {
             Ok(TAU * period2_s2.sqrt().seconds())
         } else {

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -785,8 +785,8 @@ impl Orbit {
     ///
     /// :rtype: Duration
     pub fn period(&self) -> PhysicsResult<Duration> {
-        let period2_s2 = self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
-        if period2_s2.is_finite() {
+        let period2_s2 = (self.sma_km()?.powi(3) / self.frame.mu_km3_s2()?;
+        if period2_s2 > 0.0 {
             Ok(TAU * period2_s2.sqrt().seconds())
         } else {
             Ok(Duration::ZERO)


### PR DESCRIPTION
Hifitime 4.3.0 prevents the creation of non-finite durations; these occur when the orbit is hyperbolic.
