### PR TITLE
Fix panics on creating hifitime Durations with non-finite values

### DIFF
--- a/anise/src/almanac/eclipse.rs
+++ b/anise/src/almanac/eclipse.rs
@@ -258,7 +258,9 @@ impl Almanac {
         state: Orbit,
         ab_corr: Option<Aberration>,
     ) -> AlmanacResult<Duration> {
+        // The unit_vector function returns an error if the vector is zero magnitude.
         let u_sun = self.sun_unit_vector(state.epoch, state.frame, ab_corr)?;
+        // The cross product may be zero only if the velocity is zero (we know the radius is non zero norm).
         let u_hvec = state.h_hat().map_err(|e| AlmanacError::GenericError {
             err: format!("{e}"),
         })?;
@@ -268,16 +270,11 @@ impl Almanac {
 
         let sin_theta = v.dot(&state.r_hat());
         let cos_theta = u.dot(&state.r_hat());
-
+        // Worst case scenario: both sin_theta and cos_theta are zero: atan2 still behaves well and returns zero.
         let theta_rad = sin_theta.atan2(cos_theta);
         let lst_h = (theta_rad / PI * 12.0 + 6.0).rem_euclid(24.0);
 
-        if !lst_h.is_finite() {
-            return Err(AlmanacError::GenericError {
-                err: format!("local solar time is not finite: {lst_h}"),
-            });
-        }
-
+        // Hence, no need to check that lst_h is finite.
         Ok(Unit::Hour * lst_h)
     }
 
@@ -297,12 +294,6 @@ impl Almanac {
             err: format!("{e}"),
         })?;
         let ltan = (12.0 + (raan_orbit_deg - ra_sun_deg) / 15.0).rem_euclid(24.0);
-
-        if !ltan.is_finite() {
-            return Err(AlmanacError::GenericError {
-                err: format!("local time of ascending node is not finite: {ltan}"),
-            });
-        }
 
         Ok(Unit::Hour * ltan)
     }

--- a/anise/src/almanac/eclipse.rs
+++ b/anise/src/almanac/eclipse.rs
@@ -272,6 +272,12 @@ impl Almanac {
         let theta_rad = sin_theta.atan2(cos_theta);
         let lst_h = (theta_rad / PI * 12.0 + 6.0).rem_euclid(24.0);
 
+        if !lst_h.is_finite() {
+            return Err(AlmanacError::GenericError {
+                err: format!("local solar time is not finite: {lst_h}"),
+            });
+        }
+
         Ok(Unit::Hour * lst_h)
     }
 
@@ -291,6 +297,13 @@ impl Almanac {
             err: format!("{e}"),
         })?;
         let ltan = (12.0 + (raan_orbit_deg - ra_sun_deg) / 15.0).rem_euclid(24.0);
+
+        if !ltan.is_finite() {
+            return Err(AlmanacError::GenericError {
+                err: format!("local time of ascending node is not finite: {ltan}"),
+            });
+        }
+
         Ok(Unit::Hour * ltan)
     }
 
@@ -305,6 +318,13 @@ impl Almanac {
     pub fn ltdn(&self, orbit: Orbit, ab_corr: Option<Aberration>) -> AlmanacResult<Duration> {
         let ltan_h = self.ltan(orbit, ab_corr)?.to_unit(Unit::Hour);
         let ltdn_h = (ltan_h + 12.0).rem_euclid(24.0);
+
+        if !ltdn_h.is_finite() {
+            return Err(AlmanacError::GenericError {
+                err: format!("local time of descending node is not finite: {ltdn_h}"),
+            });
+        }
+
         Ok(Unit::Hour * ltdn_h)
     }
 }

--- a/anise/src/almanac/transform.rs
+++ b/anise/src/almanac/transform.rs
@@ -17,7 +17,7 @@ use crate::{
         frames::{EARTH_J2000, SUN_J2000},
         orientations::J2000,
     },
-    errors::{AlmanacResult, EphemerisSnafu, OrientationSnafu},
+    errors::{AlmanacError, AlmanacResult, EphemerisSnafu, OrientationSnafu, PhysicsError},
     math::{Vector3, cartesian::CartesianState, units::LengthUnit},
     orientations::OrientationPhysicsSnafu,
     prelude::{Aberration, Frame},
@@ -189,7 +189,18 @@ impl Almanac {
         ab_corr: Option<Aberration>,
     ) -> AlmanacResult<Vector3> {
         let state = self.transform(target_frame, observer_frame, epoch, ab_corr)?;
-        Ok(state.radius_km / state.rmag_km())
+        if state.rmag_km() > 0.0 {
+            Ok(state.radius_km / state.rmag_km())
+        } else {
+            Err(AlmanacError::AlmanacPhysics {
+                action: "computing unit vector",
+                source: Box::new(PhysicsError::AppliedMath {
+                    source: crate::errors::MathError::DivisionByZero {
+                        action: "requested unit vector of zero magnitude",
+                    },
+                }),
+            })
+        }
     }
 
     /// Returns the unitary 3D vector between desired [Frame] (solid body) and the Sun at desired [Epoch]

--- a/anise/src/analysis/utils.rs
+++ b/anise/src/analysis/utils.rs
@@ -61,6 +61,11 @@ where
 
     for _ in 0..max_iter {
         if has_converged(xa, xb) {
+            if !xb.is_finite() {
+                return Err(AnalysisError::GenericAnalysisError {
+                    err: format!("xb is not finite: {xb}"),
+                });
+            }
             return Ok(xa_e + xb * Unit::Second);
         }
 
@@ -84,6 +89,11 @@ where
             flag = false;
         }
 
+        if !s.is_finite() {
+            return Err(AnalysisError::GenericAnalysisError {
+                err: format!("s is not finite: {s}"),
+            });
+        }
         let ys = evaluator(xa_e + s * Unit::Second)?;
         if ys.abs() <= f64::EPSILON {
             return Ok(xa_e + s * Unit::Second);
@@ -175,7 +185,13 @@ where
                 delta_ratio = 1.0;
             }
             // Update the step to try to achieve linearity.
-            let next_step = (step.to_seconds() / delta_ratio) * Unit::Second;
+            let next_step_seconds = step.to_seconds() / delta_ratio;
+            if !next_step_seconds.is_finite() {
+                return Err(AnalysisError::GenericAnalysisError {
+                    err: format!("next step is not finite: {next_step_seconds}"),
+                });
+            }
+            let next_step = next_step_seconds * Unit::Second;
             if delta_ratio > 1.1 && step >= min_step {
                 // More than 10% faster than linear scan, reject advancement, use updated step.
                 step = next_step;

--- a/anise/src/analysis/utils.rs
+++ b/anise/src/analysis/utils.rs
@@ -61,11 +61,6 @@ where
 
     for _ in 0..max_iter {
         if has_converged(xa, xb) {
-            if !xb.is_finite() {
-                return Err(AnalysisError::GenericAnalysisError {
-                    err: format!("xb is not finite: {xb}"),
-                });
-            }
             return Ok(xa_e + xb * Unit::Second);
         }
 

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -1512,6 +1512,15 @@ impl Orbit {
             delta_t_s = 0.0;
         }
 
+        if !delta_t_s.is_finite() {
+            return Err(PhysicsError::AppliedMath {
+                source: MathError::DomainError {
+                    value: delta_t_s,
+                    msg: "delta time computation failed",
+                },
+            });
+        }
+
         // Step 16: Return Ok(Duration::from_seconds(delta_t_s))
         Ok(Duration::from_seconds(delta_t_s))
     }

--- a/anise/src/ephemerides/ephemeris/stk.rs
+++ b/anise/src/ephemerides/ephemeris/stk.rs
@@ -248,6 +248,13 @@ impl Ephemeris {
                             details: format!("invalid time offset {}", parts[0]),
                         })?;
 
+                if !time_offset.is_finite() {
+                    return Err(EphemerisError::STKEParsingError {
+                        lno,
+                        details: format!("invalid time offset {}", parts[0]),
+                    });
+                }
+
                 let start_epoch = scenario_epoch.ok_or(EphemerisError::STKEParsingError {
                     lno,
                     details: "ScenarioEpoch not found before data".to_string(),
@@ -330,6 +337,12 @@ impl Ephemeris {
                     }
 
                     let time_offset = record_vals[0];
+                    if !time_offset.is_finite() {
+                        return Err(EphemerisError::STKEParsingError {
+                            lno,
+                            details: format!("invalid time offset {time_offset}"),
+                        });
+                    }
                     let start_epoch = scenario_epoch.ok_or(EphemerisError::STKEParsingError {
                         lno,
                         details: "ScenarioEpoch not found before data".to_string(),

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -148,14 +148,6 @@ impl Almanac {
                 let lt_sign = if ab_corr.transmit_mode { 1.0 } else { -1.0 };
 
                 for _ in 0..num_it {
-                    if !one_way_lt_s.is_finite() {
-                        return Err(EphemerisError::LightTimeCorrection {
-                            epoch,
-                            epoch_lt: epoch, // We can't calculate epoch_lt, so we use epoch to avoid uninitialized value error or need for Option
-                            ab_corr,
-                            source: Box::new(EphemerisError::Unreachable), // Best match we can use here to signify math failure
-                        });
-                    }
                     // Calculate the light-time corrected epoch.
                     let epoch_lt = epoch + lt_sign * one_way_lt_s * TimeUnit::Second;
                     // Find the position of the target at the corrected epoch.

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -148,6 +148,14 @@ impl Almanac {
                 let lt_sign = if ab_corr.transmit_mode { 1.0 } else { -1.0 };
 
                 for _ in 0..num_it {
+                    if !one_way_lt_s.is_finite() {
+                        return Err(EphemerisError::LightTimeCorrection {
+                            epoch,
+                            epoch_lt: epoch, // We can't calculate epoch_lt, so we use epoch to avoid uninitialized value error or need for Option
+                            ab_corr,
+                            source: Box::new(EphemerisError::Unreachable), // Best match we can use here to signify math failure
+                        });
+                    }
                     // Calculate the light-time corrected epoch.
                     let epoch_lt = epoch + lt_sign * one_way_lt_s * TimeUnit::Second;
                     // Find the position of the target at the corrected epoch.

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -265,16 +265,30 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             }
         };
 
-        // The summaries are located after the main DAF summary record within the same record.
-        Ok(
-            match Ref::<_, [R]>::from_bytes(&rcrd_bytes[SummaryRecord::SIZE..]) {
-                Ok(r) => Ref::into_ref(r),
-                Err(_) => &{
-                    R::default();
-                    [] as [R; 0]
-                },
+        let summaries = match Ref::<_, [R]>::from_bytes(&rcrd_bytes[SummaryRecord::SIZE..]) {
+            Ok(r) => Ref::into_ref(r),
+            Err(_) => &{
+                R::default();
+                [] as [R; 0]
             },
-        )
+        };
+
+        for summary in summaries {
+            if !summary.start_epoch_et_s().is_finite() || !summary.end_epoch_et_s().is_finite() {
+                return Err(DAFError::DecodingSummary {
+                    kind: R::NAME,
+                    source: DecodingError::Integrity {
+                        source: IntegrityError::SubNormal {
+                            dataset: R::NAME,
+                            variable: "start or end epoch in ET seconds",
+                        },
+                    },
+                });
+            }
+        }
+
+        // The summaries are located after the main DAF summary record within the same record.
+        Ok(summaries)
     }
 
     /// Returns the summary given the name of the summary record


### PR DESCRIPTION
hifitime 4.3.0 introduced a change where creating a Duration with a non-finite value (NaN or infinity) triggers a panic. The ANISE crate had several places where `Duration` structures were being created from `f64` calculations that could potentially yield `NaN`, including parsing offsets from STK files, calculating orbital local solar times and LTAN/LTDN, evaluating event intersections in analysis utilities, calculating light time corrections, and determining duration to specific radius.

This pull request resolves these issues by introducing `.is_finite()` validations prior to the `Duration` instantiations. If a float evaluates to `NaN` or `Infinity`, the logic is caught and an appropriate existing error type is returned (e.g. `AlmanacError`, `EphemerisError`), fulfilling the requirement to preserve existing API structures while eliminating the underlying panics.

---
*PR created automatically by Jules for task [12790778800136958201](https://jules.google.com/task/12790778800136958201) started by @ChristopherRabotin*