### PR TITLE
cap interpolation window size in hermite and lagrange decoders

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -294,6 +294,16 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
         }
 
         let samples = num_samples_f64 as usize + 1;
+        if samples > MAX_SAMPLES {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of interpolation samples",
+                    value: samples as f64,
+                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                },
+            });
+        }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
         let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
         let state_data =

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -86,6 +86,16 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
 
         let step_size = step_size_s.seconds();
         let degree = slice[slice.len() - 2] as usize;
+        if degree + 1 > MAX_SAMPLES {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "interpolation window size",
+                    value: (degree + 1) as f64,
+                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                },
+            });
+        }
         let num_records = slice[slice.len() - 1] as usize;
 
         let record_data = &slice[0..slice.len() - 4];
@@ -254,6 +264,16 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
         // For this kind of record, the metadata is stored at the very end of the dataset
         let num_records = slice[slice.len() - 1] as usize;
         let degree = slice[slice.len() - 2] as usize;
+        if degree + 1 > MAX_SAMPLES {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "interpolation window size",
+                    value: (degree + 1) as f64,
+                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                },
+            });
+        }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
         let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
         let state_data =


### PR DESCRIPTION
Type 13 Hermite and Type 8/9 Lagrange read the interpolation window size from the file footer but never cap it like Type 12 does, so a crafted SPK with a window larger than MAX_SAMPLES indexes past the fixed `[f64; MAX_SAMPLES]` buffers in `evaluate`. The cap lives in each `from_f64_slice` so the bad value is rejected at decode time.