### PR TITLE
reject undersized rsize in chebyshev type 2 and 3 decoders

### DIFF
--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -137,6 +137,30 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
             });
         }
         let num_records = slice[slice.len() - 1] as usize;
+        // A segment with no records would underflow num_records - 1 in evaluate() and truncate(),
+        // and a record count that overruns the footer-trimmed data would slice out of bounds when
+        // a record is decoded. Reject both, using saturating_mul so the product cannot wrap first.
+        if num_records == 0 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of records (num_records)",
+                    value: 0.0,
+                    reason: "must be at least 1",
+                },
+            });
+        }
+        let total_size = num_records.saturating_mul(rsize);
+        if total_size > slice.len().saturating_sub(4) {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "total records size",
+                    value: total_size as f64,
+                    reason: "total size of records exceeds the available data slice",
+                },
+            });
+        }
 
         Ok(Self {
             init_epoch: start_epoch,
@@ -362,9 +386,21 @@ mod chebyshev_ut {
             }
         }
 
-        // Load a slice whose metadata is OK but the record data is not
-        let dataset =
-            Type2ChebyshevSet::from_f64_slice(&[f64::INFINITY, 0.0, 2e-16, 0.0, 0.0]).unwrap();
+        // Load a slice whose metadata is OK but the record data is not. The footer carries a
+        // single valid-sized record (rsize 5, num_records 1) so decoding succeeds and the
+        // subnormal value in the record data is only caught by check_integrity.
+        let dataset = Type2ChebyshevSet::from_f64_slice(&[
+            f64::INFINITY,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2e-16,
+            5.0,
+            1.0,
+        ])
+        .unwrap();
         match dataset.check_integrity() {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {
@@ -380,7 +416,7 @@ mod chebyshev_ut {
     }
 
     #[test]
-    fn rejects_undersized_rsize() {
+    fn rejects_invalid_rsize_and_num_records() {
         // rsize = 1 in the footer is far too small to hold a record. Before this guard the
         // dataset decoded fine but degree() and the record decoder panicked with a subtract
         // overflow while evaluating a crafted segment.
@@ -394,6 +430,39 @@ mod chebyshev_ut {
                         variable: "record size (rsize)",
                         value: 1.0,
                         reason: "must be at least 5 to hold the record metadata and coefficients",
+                    },
+                }
+            ),
+        }
+
+        // num_records = 0 would underflow num_records - 1 during evaluation and truncation.
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 5.0, 0.0]) {
+            Ok(_) => panic!("test failed: zero num_records was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 2",
+                        variable: "number of records (num_records)",
+                        value: 0.0,
+                        reason: "must be at least 1",
+                    },
+                }
+            ),
+        }
+
+        // num_records * rsize overruns the footer-trimmed data, so a record decode would slice
+        // out of bounds.
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 5.0, 10.0]) {
+            Ok(_) => panic!("test failed: oversized record count was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 2",
+                        variable: "total records size",
+                        value: 50.0,
+                        reason: "total size of records exceeds the available data slice",
                     },
                 }
             ),

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -123,6 +123,19 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
 
         let interval_length = interval_length_s.seconds();
         let rsize = slice[slice.len() - 2] as usize;
+        // A valid Type 2 record holds two metadata doubles (midpoint, radius) plus at least
+        // one Chebyshev coefficient per axis, so rsize must be at least 5. Anything smaller
+        // makes degree() and the record decoder underflow when they compute (rsize - 2) / 3 - 1.
+        if rsize < 5 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "record size (rsize)",
+                    value: rsize as f64,
+                    reason: "must be at least 5 to hold the record metadata and coefficients",
+                },
+            });
+        }
         let num_records = slice[slice.len() - 1] as usize;
 
         Ok(Self {
@@ -363,6 +376,27 @@ mod chebyshev_ut {
                     },
                 );
             }
+        }
+    }
+
+    #[test]
+    fn rejects_undersized_rsize() {
+        // rsize = 1 in the footer is far too small to hold a record. Before this guard the
+        // dataset decoded fine but degree() and the record decoder panicked with a subtract
+        // overflow while evaluating a crafted segment.
+        match Type2ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 1.0, 1.0]) {
+            Ok(_) => panic!("test failed: undersized rsize was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 2",
+                        variable: "record size (rsize)",
+                        value: 1.0,
+                        reason: "must be at least 5 to hold the record metadata and coefficients",
+                    },
+                }
+            ),
         }
     }
 

--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -138,6 +138,30 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
             });
         }
         let num_records = slice[slice.len() - 1] as usize;
+        // A segment with no records would underflow num_records - 1 in evaluate() and truncate(),
+        // and a record count that overruns the footer-trimmed data would slice out of bounds when
+        // a record is decoded. Reject both, using saturating_mul so the product cannot wrap first.
+        if num_records == 0 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of records (num_records)",
+                    value: 0.0,
+                    reason: "must be at least 1",
+                },
+            });
+        }
+        let total_size = num_records.saturating_mul(rsize);
+        if total_size > slice.len().saturating_sub(4) {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "total records size",
+                    value: total_size as f64,
+                    reason: "total size of records exceeds the available data slice",
+                },
+            });
+        }
 
         Ok(Self {
             init_epoch: start_epoch,
@@ -382,9 +406,24 @@ mod chebyshev_ut {
             }
         }
 
-        // Load a slice whose metadata is OK but the record data is not
-        let dataset =
-            Type3ChebyshevSet::from_f64_slice(&[f64::INFINITY, 0.0, 2e-16, 0.0, 0.0]).unwrap();
+        // Load a slice whose metadata is OK but the record data is not. The footer carries a
+        // single valid-sized record (rsize 8, num_records 1) so decoding succeeds and the
+        // subnormal value in the record data is only caught by check_integrity.
+        let dataset = Type3ChebyshevSet::from_f64_slice(&[
+            f64::INFINITY,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2e-16,
+            8.0,
+            1.0,
+        ])
+        .unwrap();
         match dataset.check_integrity() {
             Ok(_) => panic!("test failed on invalid interval_length"),
             Err(e) => {
@@ -400,7 +439,7 @@ mod chebyshev_ut {
     }
 
     #[test]
-    fn rejects_undersized_rsize() {
+    fn rejects_invalid_rsize_and_num_records() {
         // rsize = 1 in the footer is far too small to hold a record. Before this guard the
         // dataset decoded fine but degree() and the record decoder panicked with a subtract
         // overflow while evaluating a crafted segment.
@@ -414,6 +453,39 @@ mod chebyshev_ut {
                         variable: "record size (rsize)",
                         value: 1.0,
                         reason: "must be at least 8 to hold the record metadata and coefficients",
+                    },
+                }
+            ),
+        }
+
+        // num_records = 0 would underflow num_records - 1 during evaluation and truncation.
+        match Type3ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 8.0, 0.0]) {
+            Ok(_) => panic!("test failed: zero num_records was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 3",
+                        variable: "number of records (num_records)",
+                        value: 0.0,
+                        reason: "must be at least 1",
+                    },
+                }
+            ),
+        }
+
+        // num_records * rsize overruns the footer-trimmed data, so a record decode would slice
+        // out of bounds.
+        match Type3ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 8.0, 10.0]) {
+            Ok(_) => panic!("test failed: oversized record count was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 3",
+                        variable: "total records size",
+                        value: 80.0,
+                        reason: "total size of records exceeds the available data slice",
                     },
                 }
             ),

--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -123,6 +123,20 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
 
         let interval_length = interval_length_s.seconds();
         let rsize = slice[slice.len() - 2] as usize;
+        // A valid Type 3 record holds two metadata doubles (midpoint, radius) plus at least
+        // one coefficient for each of the six position and velocity axes, so rsize must be at
+        // least 8. Anything smaller makes degree() and the record decoder underflow when they
+        // compute (rsize - 2) / 6 - 1.
+        if rsize < 8 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "record size (rsize)",
+                    value: rsize as f64,
+                    reason: "must be at least 8 to hold the record metadata and coefficients",
+                },
+            });
+        }
         let num_records = slice[slice.len() - 1] as usize;
 
         Ok(Self {
@@ -382,6 +396,27 @@ mod chebyshev_ut {
                     },
                 );
             }
+        }
+    }
+
+    #[test]
+    fn rejects_undersized_rsize() {
+        // rsize = 1 in the footer is far too small to hold a record. Before this guard the
+        // dataset decoded fine but degree() and the record decoder panicked with a subtract
+        // overflow while evaluating a crafted segment.
+        match Type3ChebyshevSet::from_f64_slice(&[0.0, 0.0, 10.0, 1.0, 1.0]) {
+            Ok(_) => panic!("test failed: undersized rsize was accepted"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Chebyshev Type 3",
+                        variable: "record size (rsize)",
+                        value: 1.0,
+                        reason: "must be at least 8 to hold the record metadata and coefficients",
+                    },
+                }
+            ),
         }
     }
 


### PR DESCRIPTION
# Summary

The Type 2 and Type 3 Chebyshev decoders read `rsize` (the record size) straight from the segment footer in `from_f64_slice` and never check it. `degree()` later evaluates `(rsize - 2) / 3 - 1` for Type 2 and `(rsize - 2) / 6 - 1` for Type 3, and the per-record decoder computes `num_coeffs = (slice.len() - 2) / N`, so a crafted SPK or BPC whose footer sets `rsize` below the minimum makes those `usize` subtractions wrap and panic. It is reachable through the normal evaluation path, since `nth_data::<Type2ChebyshevSet>` / `Type3ChebyshevSet` is what runs when you query a loaded ephemeris or orientation, so loading an untrusted kernel and asking for a state is enough to hit it. The guard rejects any `rsize` too small to hold the two metadata doubles plus one coefficient per axis (5 for Type 2, 8 for Type 3), which lines up with the window-size caps the hermite and lagrange decoders already apply at decode time.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Reject undersized `rsize` in the Type 2 and Type 3 Chebyshev decoders before it underflows `degree()` and the record decoder.

## Testing and validation

Added a regression test to each decoder that feeds a footer with `rsize = 1` and checks the decoder now returns an `InvalidValue` integrity error rather than decoding a dataset that panics on the first evaluation. Without the guard the same input panics with `attempt to subtract with overflow`.

## Documentation

This PR does not primarily deal with documentation changes.
