### PR TITLE
reject zero num_records in hermite type 12 decoder

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -97,17 +97,18 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
                 },
             });
         }
-        let num_records = slice[slice.len() - 1] as usize;
-        if num_records == 0 {
+        let num_records_f64 = slice[slice.len() - 1];
+        if !num_records_f64.is_finite() || num_records_f64 <= 0.0 {
             return Err(DecodingError::Integrity {
                 source: IntegrityError::InvalidValue {
                     dataset: Self::DATASET_NAME,
                     variable: "number of records",
-                    value: num_records as f64,
-                    reason: "must be greater than zero",
+                    value: num_records_f64,
+                    reason: "must be a finite value greater than zero",
                 },
             });
         }
+        let num_records = num_records_f64 as usize;
 
         Ok(Self {
             first_state_epoch,
@@ -656,7 +657,7 @@ mod hermite_ut {
                     dataset: "Hermite Type 12",
                     variable: "number of records",
                     value: 0.0,
-                    reason: "must be greater than zero",
+                    reason: "must be a finite value greater than zero",
                 },
             })
         {

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -98,6 +98,16 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
             });
         }
         let num_records = slice[slice.len() - 1] as usize;
+        if num_records == 0 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of records",
+                    value: num_records as f64,
+                    reason: "must be greater than zero",
+                },
+            });
+        }
 
         Ok(Self {
             first_state_epoch,
@@ -623,6 +633,34 @@ mod hermite_ut {
                     },
                 );
             }
+        }
+    }
+
+    #[test]
+    fn type12_zero_records() {
+        use super::HermiteSetType12;
+
+        // A Type 12 segment whose trailing metadata declares num_records = 0.
+        // nth_record divides record_data.len() by num_records during evaluate, so
+        // this must be rejected at decode time rather than panicking later.
+        let mut slice = vec![0.0_f64; 10];
+        let n = slice.len();
+        slice[n - 4] = 0.0; // first state epoch
+        slice[n - 3] = 10.0; // step size
+        slice[n - 2] = 3.0; // window size - 1 => samples = 4
+        slice[n - 1] = 0.0; // num_records = 0
+
+        if HermiteSetType12::from_f64_slice(&slice)
+            != Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: "Hermite Type 12",
+                    variable: "number of records",
+                    value: 0.0,
+                    reason: "must be greater than zero",
+                },
+            })
+        {
+            panic!("Type 12 with zero records should be rejected at decode time");
         }
     }
 


### PR DESCRIPTION
# Summary

loading a crafted SPK kernel can panic the whole process. the type 12 (equal-step hermite) decoder reads `num_records` from the segment's trailing metadata but never checks it, and during `evaluate` `nth_record` works out the per-record length as `record_data.len() / num_records`, so a segment that declares zero records hits an integer divide-by-zero. unlike the wrapping subtractions elsewhere this aborts even in release builds. the type 13 and type 9 decoders already sidestep this through their empty-epoch check in `evaluate`, so this just brings type 12 into line by rejecting `num_records == 0` in `from_f64_slice` at decode time.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

reject a type 12 hermite segment whose declared record count is zero, before that value can reach the division in `nth_record`.

## Testing and validation

added a regression test that feeds a type 12 slice with `num_records = 0` and checks `from_f64_slice` now returns an integrity error rather than letting `evaluate` divide by zero.

## Documentation

This PR does not primarily deal with documentation changes.
