### PR TITLE
truncate lookup table names on a char boundary when decoding

### DIFF
--- a/anise/src/structure/lookuptable.rs
+++ b/anise/src/structure/lookuptable.rs
@@ -318,6 +318,10 @@ mod lut_ut {
 
         let decoded = LookUpTable::from_der(&buf).unwrap();
         assert_eq!(decoded.by_name.len(), 1);
+        // The multi-byte char straddling the cut is dropped entirely, leaving the
+        // ASCII prefix up to the nearest char boundary.
+        let expected_name = "a".repeat(super::KEY_NAME_LEN - 1);
+        assert!(decoded.by_name.contains_key(&expected_name));
     }
 
     #[test]

--- a/anise/src/structure/lookuptable.rs
+++ b/anise/src/structure/lookuptable.rs
@@ -226,8 +226,14 @@ impl<'a> Decode<'a> for LookUpTable {
 
         for (name, entry) in names.iter().zip(name_entries.iter()) {
             let key = core::str::from_utf8(name.as_bytes())?;
-            lut.by_name
-                .insert(key[..KEY_NAME_LEN.min(key.len())].to_string(), *entry);
+            // Cap the stored name at KEY_NAME_LEN bytes, but step back to the nearest
+            // char boundary so a multi-byte UTF-8 sequence straddling that index does
+            // not panic the slice.
+            let mut end = KEY_NAME_LEN.min(key.len());
+            while end > 0 && !key.is_char_boundary(end) {
+                end -= 1;
+            }
+            lut.by_name.insert(key[..end].to_string(), *entry);
         }
 
         if !lut.check_integrity() {
@@ -296,6 +302,22 @@ mod lut_ut {
         let repr_dec = LookUpTable::from_der(&buf).unwrap();
 
         assert_eq!(repr, repr_dec);
+    }
+
+    #[test]
+    fn decode_multibyte_name_over_key_len() {
+        // A name longer than KEY_NAME_LEN whose byte at the truncation index lands
+        // in the middle of a multi-byte UTF-8 char must not panic on decode.
+        let mut repr = LookUpTable::default();
+        let name = "a".repeat(super::KEY_NAME_LEN - 1) + "é";
+        assert!(name.len() > super::KEY_NAME_LEN);
+        repr.append_name(&name, 0).unwrap();
+
+        let mut buf = vec![];
+        repr.encode_to_vec(&mut buf).unwrap();
+
+        let decoded = LookUpTable::from_der(&buf).unwrap();
+        assert_eq!(decoded.by_name.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

When loading an ANISE dataset (a PCA, EPA or spacecraft file) the lookup table is decoded in `LookUpTable::decode`, reached from `DataSet::try_from_bytes` / `from_der`. Each entry name is read as a UTF-8 string and then capped at `KEY_NAME_LEN` (32) bytes with `key[..KEY_NAME_LEN.min(key.len())]`. The trouble is that this is a byte slice, so if a name is longer than 32 bytes and a multi-byte UTF-8 sequence happens to straddle byte index 32, the slice does not fall on a char boundary and the decode panics instead of returning an error. Since the names come straight from the file being parsed, a crafted dataset is enough to abort the load, and `try_from_bytes` panics rather than handing back the `Result` a caller would expect to be able to handle.

The fix keeps the same 32-byte cap but walks the index back to the nearest char boundary before slicing, so a name whose boundary lands mid-character is simply truncated a byte or two earlier.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Step the name truncation index back to a char boundary in `LookUpTable::decode` so a multi-byte UTF-8 name longer than `KEY_NAME_LEN` no longer panics the slice.

## Testing and validation

Added a regression test that builds a lookup table whose name is `KEY_NAME_LEN - 1` ASCII bytes followed by a two-byte character (33 bytes total, so the cut falls inside that character), encodes it and decodes it back. Before the change that decode panics with "byte index 32 is not a char boundary"; after it, the name decodes fine and the test passes.

## Documentation

This PR does not primarily deal with documentation changes.
