### PR TITLE
guard against zero summary size in name record num_entries

### DIFF
--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -780,6 +780,31 @@ mod daf_ut {
     }
 
     #[test]
+    fn zero_summary_size_name_lookup() {
+        use crate::naif::daf::FileRecord;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use zerocopy::IntoBytes;
+
+        let mut file_record = FileRecord::spk("TEST");
+        file_record.forward = 2;
+        file_record.nd = 0;
+        file_record.ni = 0;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024 * 3, 0);
+
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        // Before the guard in num_entries this divided 1024 by zero and panicked.
+        // HermiteSetType13 does not implement Debug, so we cannot assert_eq the result.
+        match daf.data_from_name::<crate::naif::daf::datatypes::HermiteSetType13>("anything") {
+            Err(DAFError::NameError { name, .. }) => assert_eq!(name, "anything"),
+            Ok(_) => panic!("unexpected data for a zero summary-size record"),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
     fn test_comments_allocation_and_range() {
         use crate::naif::daf::FileRecord;
         use crate::naif::spk::summary::SPKSummaryRecord;

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -36,7 +36,13 @@ impl NameRecord {
     ///
     /// Note that we don't actually use `&self` here, but it's just easier to call.
     pub const fn num_entries(&self, summary_size: usize) -> usize {
-        RCRD_LEN / (summary_size * DBL_SIZE)
+        let entry_size = summary_size * DBL_SIZE;
+        if entry_size == 0 {
+            // A summary size of zero (nd and ni both zero in the file record) would
+            // otherwise divide by zero here when a crafted DAF is queried by name.
+            return 0;
+        }
+        RCRD_LEN / entry_size
     }
 
     pub fn nth_name(&self, n: usize, summary_size: usize) -> &str {

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -36,7 +36,7 @@ impl NameRecord {
     ///
     /// Note that we don't actually use `&self` here, but it's just easier to call.
     pub const fn num_entries(&self, summary_size: usize) -> usize {
-        let entry_size = summary_size * DBL_SIZE;
+        let entry_size = summary_size.saturating_mul(DBL_SIZE);
         if entry_size == 0 {
             // A summary size of zero (nd and ni both zero in the file record) would
             // otherwise divide by zero here when a crafted DAF is queried by name.


### PR DESCRIPTION
# Summary

loading a crafted DAF (SPK or BPC) can panic the whole process once it is queried by name. `NameRecord::num_entries` works out how many names fit a record as `RCRD_LEN / (summary_size * DBL_SIZE)`, and `summary_size` comes straight from the file record's `nd` and `ni` fields (`nd + ni.div_ceil(2)`). a file that declares both as zero makes the divisor zero, so calling `data_from_name` or `summary_from_name` on the parsed file hits an integer divide-by-zero, which aborts even in release builds. the value is never checked between parsing and that division, so this is reachable from untrusted bytes. the fix returns zero entries when the per-entry size is zero, so a malformed record yields a name-not-found error rather than dividing by zero.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

return zero entries from `num_entries` when the summary size is zero, before that value reaches the division reached by the name-lookup paths.

## Testing and validation

added a regression test that builds an in-memory DAF whose file record sets `nd` and `ni` to zero and checks that a name lookup now returns a `NameError` instead of panicking with a divide-by-zero.

## Documentation

This PR does not primarily deal with documentation changes.
