### PR TITLE
reject segments with fewer records than the interpolation window

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -315,6 +315,19 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
                 },
             });
         }
+        // A non-empty segment must carry at least a full interpolation window of states.
+        // With fewer, evaluate() recentres the window with `last_idx - 2 * num_left`, which
+        // underflows and panics when the segment is queried at an interior epoch.
+        if num_records > 0 && num_records < samples {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of records",
+                    value: num_records as f64,
+                    reason: "must be at least the interpolation window size (samples)",
+                },
+            });
+        }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
         let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
         let state_data =
@@ -634,6 +647,30 @@ mod hermite_ut {
                     },
                 );
             }
+        }
+    }
+
+    #[test]
+    fn rejects_window_larger_than_records_type13() {
+        // num_records = 4 but the declared window is samples = 7. evaluate() would recentre the
+        // window with `last_idx - 2 * num_left` and underflow when queried at an interior epoch,
+        // so the segment must be rejected at decode time.
+        let mut slice = vec![0.0_f64; 30];
+        slice[28] = 6.0; // window size - 1 => samples = 7
+        slice[29] = 4.0; // num_records
+        match HermiteSetType13::from_f64_slice(&slice) {
+            Ok(_) => panic!("a window larger than the record count must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Hermite Type 13",
+                        variable: "number of records",
+                        value: 4.0,
+                        reason: "must be at least the interpolation window size (samples)",
+                    },
+                }
+            ),
         }
     }
 

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -274,6 +274,19 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
                 },
             });
         }
+        // A non-empty segment must carry at least a full interpolation window of states.
+        // With fewer, evaluate() recentres the window with `last_idx - 2 * num_left`, which
+        // underflows and panics when the segment is queried at an interior epoch.
+        if num_records > 0 && num_records < degree + 1 {
+            return Err(DecodingError::Integrity {
+                source: IntegrityError::InvalidValue {
+                    dataset: Self::DATASET_NAME,
+                    variable: "number of records",
+                    value: num_records as f64,
+                    reason: "must be at least the interpolation window size (degree + 1)",
+                },
+            });
+        }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
         let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
         let state_data =
@@ -518,6 +531,30 @@ mod ut_lagrange {
     use super::*;
     use crate::naif::spk::summary::SPKSummaryRecord;
     use hifitime::Epoch;
+
+    #[test]
+    fn rejects_window_larger_than_records_type9() {
+        // num_records = 4 but the declared window is degree + 1 = 7. evaluate() would recentre
+        // the window with `last_idx - 2 * num_left` and underflow when queried at an interior
+        // epoch, so the segment must be rejected at decode time.
+        let mut slice = vec![0.0_f64; 30];
+        slice[28] = 6.0; // degree => window size 7
+        slice[29] = 4.0; // num_records
+        match LagrangeSetType9::from_f64_slice(&slice) {
+            Ok(_) => panic!("a window larger than the record count must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Lagrange Type 9",
+                        variable: "number of records",
+                        value: 4.0,
+                        reason: "must be at least the interpolation window size (degree + 1)",
+                    },
+                }
+            ),
+        }
+    }
 
     #[test]
     fn test_lagrange_type8() {


### PR DESCRIPTION
# Summary

querying a loaded ephemeris can panic when a segment declares fewer states than its interpolation window. the type 9 lagrange and type 13 hermite decoders read `num_records` and the window size (`degree + 1` for lagrange, `samples` for hermite) from the segment footer but never check that there are at least a window's worth of states. when such a segment is evaluated at an interior epoch, `evaluate` recentres the window with `first_idx = last_idx - 2 * num_left`, and because `num_records` is below `2 * num_left` that subtraction underflows, which panics in debug and wraps to a bogus index in release. a window larger than the available states cannot be interpolated anyway, so this rejects those segments in `from_f64_slice`, in the same place the existing `MAX_SAMPLES` window cap already sits. the empty case (`num_records == 0`) is left untouched so the existing empty-epoch guard in `evaluate` still handles it.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

reject a type 9 lagrange or type 13 hermite segment whose declared record count is below its interpolation window, before that mismatch can underflow the window recentring in `evaluate`.

## Testing and validation

added a regression test per decoder that feeds a slice with `num_records = 4` and a window of 7, and checks `from_f64_slice` now returns an integrity error instead of letting a later `evaluate` underflow.

## Documentation

This PR does not primarily deal with documentation changes.
