### PR TITLE
guard against zero forward pointer in daf summary reads

### DIFF
--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -220,7 +220,19 @@ impl<R: NAIFSummaryRecord> DAF<R> {
 
     /// Reads and parses the DAF summary record, starting at the provided idx (1-index!) or at the file record's forward index if no index provided.
     pub fn daf_summary(&self, idx: Option<usize>) -> Result<SummaryRecord, DAFError> {
-        let rcrd_idx = (idx.unwrap_or(self.file_record()?.fwrd_idx()) - 1) * RCRD_LEN;
+        // The forward pointer is a 1-based record index, so a value of zero is
+        // malformed; guard the subtraction so a crafted file errors out instead
+        // of underflowing.
+        let rcrd_idx = idx
+            .unwrap_or(self.file_record()?.fwrd_idx())
+            .checked_sub(1)
+            .ok_or(DecodingError::InaccessibleBytes {
+                start: 0,
+                end: RCRD_LEN,
+                size: self.bytes.len(),
+            })
+            .context(DecodingSummarySnafu { kind: R::NAME })?
+            * RCRD_LEN;
         let rcrd_bytes = self
             .bytes
             .get(rcrd_idx..rcrd_idx + RCRD_LEN)
@@ -247,7 +259,24 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         }
 
         // The file record's forward pointer points to the first summary record.
-        let rcrd_idx = (idx.unwrap_or(self.file_record()?.fwrd_idx()) - 1) * RCRD_LEN;
+        // It is a 1-based index, so reject a zero pointer rather than letting the
+        // subtraction underflow on a crafted file.
+        let rcrd_idx = match idx
+            .unwrap_or(self.file_record()?.fwrd_idx())
+            .checked_sub(1)
+            .ok_or(DecodingError::InaccessibleBytes {
+                start: 0,
+                end: RCRD_LEN,
+                size: self.bytes.len(),
+            }) {
+            Ok(it) => it * RCRD_LEN,
+            Err(source) => {
+                return Err(DAFError::DecodingSummary {
+                    kind: R::NAME,
+                    source,
+                });
+            }
+        };
         let rcrd_bytes = match self
             .bytes
             .get(rcrd_idx..rcrd_idx + RCRD_LEN)
@@ -800,6 +829,31 @@ mod daf_ut {
         match daf.data_from_name::<crate::naif::daf::datatypes::HermiteSetType13>("anything") {
             Err(DAFError::NameError { name, .. }) => assert_eq!(name, "anything"),
             Ok(_) => panic!("unexpected data for a zero summary-size record"),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn zero_forward_pointer() {
+        use crate::naif::daf::FileRecord;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use zerocopy::IntoBytes;
+
+        let mut file_record = FileRecord::spk("TEST");
+        // A zero forward pointer is malformed: it is a 1-based record index.
+        file_record.forward = 0;
+        file_record.nd = 2;
+        file_record.ni = 6;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024 * 3, 0);
+
+        // Before the guard in daf_summary/data_summaries this subtraction
+        // underflowed and panicked while building the index during parse.
+        match super::DAF::<SPKSummaryRecord>::parse(&bytes[..]) {
+            Err(DAFError::DecodingSummary { .. }) => {}
+            Ok(_) => panic!("unexpected success for a zero forward pointer"),
             Err(e) => panic!("unexpected error: {e}"),
         }
     }


### PR DESCRIPTION
# Summary

loading a crafted DAF can panic the whole process during parsing. the file record's forward pointer is a 1-based record index, and both `DAF::daf_summary` and `DAF::data_summaries` turn it into a byte offset with `(fwrd_idx - 1) * RCRD_LEN`. the pointer is never validated between parsing the file record and using it, so a file that sets `forward` to zero makes that `usize` subtraction underflow. `DAF::parse` calls `data_summaries` while building the summary index, so this is reachable straight from untrusted bytes and panics in debug builds (and wraps to a bogus offset in release). the fix guards the subtraction with `checked_sub` at both sites so a zero pointer yields a decoding error instead.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

reject a zero forward pointer in `DAF::daf_summary` and `DAF::data_summaries` via `checked_sub`, returning a `DecodingSummary` error rather than underflowing the record-index subtraction.

## Testing and validation

added a regression test that builds an in-memory DAF whose file record sets `forward` to zero and checks that `parse` now returns a `DecodingSummary` error instead of panicking on the underflow.

## Documentation

This PR does not primarily deal with documentation changes.