### PR TITLE
avoid char-boundary panic in daf file record identification

### DIFF
--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -98,18 +98,23 @@ impl FileRecord {
     }
 
     pub fn identification(&self) -> Result<&str, FileRecordError> {
-        let str_locidw =
-            core::str::from_utf8(&self.id_str).map_err(|_| FileRecordError::NoIdentifier)?;
+        // Require the record to be valid UTF-8 so it can be reported back.
+        core::str::from_utf8(&self.id_str).map_err(|_| FileRecordError::NoIdentifier)?;
 
-        if &str_locidw[0..3] != "DAF" || str_locidw.chars().nth(3) != Some('/') {
+        // The identifier is the fixed ASCII marker `DAF/` followed by the sub-type.
+        // Compare against the raw bytes: slicing the decoded string at byte offsets
+        // 3 and 4 panics if a multi-byte character straddles those offsets.
+        if &self.id_str[..4] != b"DAF/" {
             Err(FileRecordError::NotDAF)
         } else {
-            let loci = str_locidw[4..].trim();
+            let loci = core::str::from_utf8(&self.id_str[4..])
+                .map_err(|_| FileRecordError::NoIdentifier)?
+                .trim();
             match loci {
                 "SPK" => Ok("SPK"),
                 "PCK" => Ok("PCK"),
                 _ => {
-                    error!("DAF of type `{}` is not yet supported", &str_locidw[4..]);
+                    error!("DAF of type `{loci}` is not yet supported");
                     Err(FileRecordError::UnsupportedIdentifier {
                         loci: loci.to_string(),
                     })
@@ -166,6 +171,27 @@ impl FileRecord {
             endian_str: Endian::daf_endian_str(),
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod ut_file_record {
+    use super::{FileRecord, FileRecordError};
+
+    #[test]
+    fn identification_non_ascii_id_str() {
+        // First eight bytes are valid UTF-8 but start with a 4-byte character, so
+        // slicing the decoded string at byte offset 3 or 4 would land inside it.
+        let mut rec = FileRecord::default();
+        rec.id_str = [0xF0, 0x9F, 0x98, 0x80, 0x20, 0x20, 0x20, 0x20];
+        assert_eq!(rec.identification(), Err(FileRecordError::NotDAF));
+    }
+
+    #[test]
+    fn identification_spk() {
+        let mut rec = FileRecord::default();
+        rec.id_str = *b"DAF/SPK ";
+        assert_eq!(rec.identification(), Ok("SPK"));
     }
 }
 

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -98,18 +98,17 @@ impl FileRecord {
     }
 
     pub fn identification(&self) -> Result<&str, FileRecordError> {
-        // Require the record to be valid UTF-8 so it can be reported back.
-        core::str::from_utf8(&self.id_str).map_err(|_| FileRecordError::NoIdentifier)?;
+        let str_locidw =
+            core::str::from_utf8(&self.id_str).map_err(|_| FileRecordError::NoIdentifier)?;
 
         // The identifier is the fixed ASCII marker `DAF/` followed by the sub-type.
-        // Compare against the raw bytes: slicing the decoded string at byte offsets
-        // 3 and 4 panics if a multi-byte character straddles those offsets.
-        if &self.id_str[..4] != b"DAF/" {
+        // Using `starts_with` avoids slicing at a fixed byte offset, which would
+        // panic if a multi-byte character straddled that offset. Once the ASCII
+        // `DAF/` prefix is confirmed, byte offset 4 is a valid char boundary.
+        if !str_locidw.starts_with("DAF/") {
             Err(FileRecordError::NotDAF)
         } else {
-            let loci = core::str::from_utf8(&self.id_str[4..])
-                .map_err(|_| FileRecordError::NoIdentifier)?
-                .trim();
+            let loci = str_locidw[4..].trim();
             match loci {
                 "SPK" => Ok("SPK"),
                 "PCK" => Ok("PCK"),


### PR DESCRIPTION
the daf reader identifies a file by decoding the first eight bytes of the file record with from_utf8 and then slicing the resulting string at fixed byte offsets, checking str_locidw[0..3] against "DAF" and reading str_locidw[4..] for the sub-type. those eight bytes come straight from the input, and while from_utf8 rejects invalid utf8, it happily accepts a multi-byte character, so a record that begins with, say, a four-byte codepoint decodes fine but then makes the [0..3] and [4..] slices land in the middle of that character. rust slice bounds on strings are always checked, so this panics rather than erroring, and it is reachable from Almanac::load_from_bytes which calls identification() on untrusted bytes before it knows what kind of file it is holding. i noticed it while feeding some non-spice files through the loader. the fix keeps the from_utf8 check so a genuinely non-utf8 record is still reported as having no identifier, but validates the fixed "DAF/" marker against the raw bytes and only decodes the sub-type tail, so there is no longer a string slice at a fixed offset to trip over. added a small regression test for the non-ascii case alongside the normal spk path.