### PR TITLE
avoid underflow on zero daf summary start index

### DIFF
--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -496,7 +496,7 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         // The summary's start pointer is a 1-based array index, so a zero is
         // malformed; guard the subtraction so a crafted summary errors out
         // instead of underflowing.
-        let end = this_summary.end_index() * DBL_SIZE;
+        let end = this_summary.end_index().saturating_mul(DBL_SIZE);
         let start = this_summary
             .start_index()
             .checked_sub(1)
@@ -509,7 +509,7 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                     size: self.bytes.len(),
                 },
             })?
-            * DBL_SIZE;
+            .saturating_mul(DBL_SIZE);
         let data: &[f64] = Ref::into_ref(
             Ref::<&[u8], [f64]>::from_bytes(
                 match self

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -493,8 +493,23 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             });
         }
 
-        let start = (this_summary.start_index() - 1) * DBL_SIZE;
+        // The summary's start pointer is a 1-based array index, so a zero is
+        // malformed; guard the subtraction so a crafted summary errors out
+        // instead of underflowing.
         let end = this_summary.end_index() * DBL_SIZE;
+        let start = this_summary
+            .start_index()
+            .checked_sub(1)
+            .ok_or(DAFError::DecodingData {
+                kind: R::NAME,
+                idx,
+                source: DecodingError::InaccessibleBytes {
+                    start: 0,
+                    end,
+                    size: self.bytes.len(),
+                },
+            })?
+            * DBL_SIZE;
         let data: &[f64] = Ref::into_ref(
             Ref::<&[u8], [f64]>::from_bytes(
                 match self
@@ -854,6 +869,51 @@ mod daf_ut {
         match super::DAF::<SPKSummaryRecord>::parse(&bytes[..]) {
             Err(DAFError::DecodingSummary { .. }) => {}
             Ok(_) => panic!("unexpected success for a zero forward pointer"),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn zero_start_index_nth_data() {
+        use crate::naif::daf::FileRecord;
+        use crate::naif::daf::summary_record::SummaryRecord;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use zerocopy::IntoBytes;
+
+        let mut file_record = FileRecord::spk("TEST");
+        file_record.forward = 2;
+        file_record.nd = 2;
+        file_record.ni = 6;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024, 0);
+
+        // Summary record (record 2): one summary whose start index is a malformed 0.
+        let summary_header = SummaryRecord {
+            next_record: 0.0,
+            prev_record: 0.0,
+            num_summaries: 1.0,
+        };
+        let mut summary = SPKSummaryRecord::default();
+        summary.data_type_i = 13;
+        summary.start_idx = 0; // 1-based index, so 0 is malformed
+        summary.end_idx = 5;
+
+        let mut summary_record = Vec::new();
+        summary_record.extend_from_slice(summary_header.as_bytes());
+        summary_record.extend_from_slice(summary.as_bytes());
+        summary_record.resize(1024, 0);
+        bytes.extend(summary_record);
+
+        // Name record (record 3).
+        bytes.extend(vec![0u8; 1024]);
+
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        // Before the guard this subtracted 1 from a zero start index and panicked.
+        match daf.nth_data::<crate::naif::daf::datatypes::HermiteSetType13>(None, 0) {
+            Err(DAFError::DecodingData { .. }) => {}
+            Ok(_) => panic!("unexpected success for a zero start index"),
             Err(e) => panic!("unexpected error: {e}"),
         }
     }

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -73,12 +73,12 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                     idx,
                     source: DecodingError::InaccessibleBytes {
                         start: 0,
-                        end: orig_index_end * DBL_SIZE,
+                        end: orig_index_end.saturating_mul(DBL_SIZE),
                         size: self.bytes.len(),
                     },
                 })?;
-        let orig_data_start = orig_index_start * DBL_SIZE;
-        let orig_data_end = orig_index_end * DBL_SIZE;
+        let orig_data_start = orig_index_start.saturating_mul(DBL_SIZE);
+        let orig_data_end = orig_index_end.saturating_mul(DBL_SIZE);
 
         let original_size = ((orig_data_end - orig_data_start) / DBL_SIZE) as isize;
 
@@ -161,12 +161,12 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                     idx,
                     source: DecodingError::InaccessibleBytes {
                         start: 0,
-                        end: orig_index_end * DBL_SIZE,
+                        end: orig_index_end.saturating_mul(DBL_SIZE),
                         size: self.bytes.len(),
                     },
                 })?;
-        let orig_data_start = orig_index_start * DBL_SIZE;
-        let orig_data_end = orig_index_end * DBL_SIZE;
+        let orig_data_start = orig_index_start.saturating_mul(DBL_SIZE);
+        let orig_data_end = orig_index_end.saturating_mul(DBL_SIZE);
 
         let original_size = ((orig_data_end - orig_data_start) / DBL_SIZE) as isize;
 

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -60,8 +60,23 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             });
         }
 
-        let orig_index_start = this_summary.start_index() - 1;
         let orig_index_end = this_summary.end_index();
+        // The summary's start pointer is a 1-based array index, so a zero is
+        // malformed; guard the subtraction so a crafted summary errors out
+        // instead of underflowing.
+        let orig_index_start =
+            this_summary
+                .start_index()
+                .checked_sub(1)
+                .ok_or(DAFError::DecodingData {
+                    kind: R::NAME,
+                    idx,
+                    source: DecodingError::InaccessibleBytes {
+                        start: 0,
+                        end: orig_index_end * DBL_SIZE,
+                        size: self.bytes.len(),
+                    },
+                })?;
         let orig_data_start = orig_index_start * DBL_SIZE;
         let orig_data_end = orig_index_end * DBL_SIZE;
 
@@ -133,8 +148,23 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             });
         }
 
-        let orig_index_start = this_summary.start_index() - 1;
         let orig_index_end = this_summary.end_index();
+        // The summary's start pointer is a 1-based array index, so a zero is
+        // malformed; guard the subtraction so a crafted summary errors out
+        // instead of underflowing.
+        let orig_index_start =
+            this_summary
+                .start_index()
+                .checked_sub(1)
+                .ok_or(DAFError::DecodingData {
+                    kind: R::NAME,
+                    idx,
+                    source: DecodingError::InaccessibleBytes {
+                        start: 0,
+                        end: orig_index_end * DBL_SIZE,
+                        size: self.bytes.len(),
+                    },
+                })?;
         let orig_data_start = orig_index_start * DBL_SIZE;
         let orig_data_end = orig_index_end * DBL_SIZE;
 


### PR DESCRIPTION
# Summary

`nth_data` locates a segment's doubles with `(start_index() - 1) * DBL_SIZE`, but `start_index()` is read straight from the summary record. A crafted SPK/BPC can set the 1-based start pointer to `0` while leaving the end pointer non-zero, so `is_empty()` is false and the subtraction underflows, panicking while the file is queried. `set_nth_data` and `delete_nth_data` build the same `start_index() - 1` offset and underflow the same way when editing such a file. This mirrors the zero forward-pointer guard already added to `daf_summary`/`data_summaries`.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Guard the 1-based summary start pointer with `checked_sub(1)` in `nth_data`, `set_nth_data`, and `delete_nth_data`, returning a decoding error instead of underflowing when a summary declares a zero start index.

## Testing and validation

Added `zero_start_index_nth_data`, which builds an in-memory DAF whose single summary has `start_idx = 0` and `end_idx = 5` and checks that `nth_data` returns `DecodingData` rather than panicking. Verified the crafted input panics with `attempt to subtract with overflow` at `daf.rs` before the change and returns an error after it.

## Documentation

This PR does not primarily deal with documentation changes.
