### PR TITLE
guard lagrange_eval against more than MAX_SAMPLES points

### DIFF
--- a/anise/src/math/interpolation/lagrange.rs
+++ b/anise/src/math/interpolation/lagrange.rs
@@ -25,6 +25,10 @@ pub fn lagrange_eval(
         return Err(InterpolationError::CorruptedData {
             what: "list of abscissas (xs) is empty",
         });
+    } else if xs.len() > MAX_SAMPLES {
+        return Err(InterpolationError::CorruptedData {
+            what: "list of abscissas (xs) contains more items than MAX_SAMPLES (32)",
+        });
     }
 
     // At this point, we know that the lengths of items is correct, so we can directly address them without worry for overflowing the array.
@@ -64,6 +68,21 @@ pub fn lagrange_eval(
     let f = work[0];
     let df = dwork[0];
     Ok((f, df))
+}
+
+#[test]
+fn lagrange_rejects_too_many_samples() {
+    // The workspace arrays are sized to MAX_SAMPLES, so more abscissas than that used to index
+    // past them. A Type 9 ephemeris built from an untrusted OEM/STK file whose interpolation
+    // degree exceeds 32 reaches here, so the oversize input must be rejected like hermite_eval.
+    let xs: Vec<f64> = (0..MAX_SAMPLES + 1).map(|i| i as f64).collect();
+    let ys: Vec<f64> = xs.iter().map(|x| x * 2.0).collect();
+    assert_eq!(
+        lagrange_eval(&xs, &ys, 1.5),
+        Err(InterpolationError::CorruptedData {
+            what: "list of abscissas (xs) contains more items than MAX_SAMPLES (32)",
+        })
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Summary

`lagrange_eval` copies the ordinates into a fixed `MAX_SAMPLES` (32) workspace array before it checks how many points it was handed, so anything longer than 32 walks off the end of that array and panics. The sibling `hermite_eval` already rejects this, and the Type 9 path in `Ephemeris::at` reaches it with `xs` of length up to `2 * degree`, where `degree` comes straight from a CCSDS OEM or STK `.e` file with no cap. A file that sets a large `INTERPOLATION_DEGREE` alongside enough state records then panics during interpolation instead of returning an error. This adds the same length check `hermite_eval` uses.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Reject inputs with more than `MAX_SAMPLES` points in `lagrange_eval` so an oversized interpolation window from an untrusted ephemeris file returns `CorruptedData` rather than indexing past the workspace and panicking.

## Testing and validation

Added `lagrange_rejects_too_many_samples`, which feeds 33 points and asserts the new error. It panics with `index out of bounds: the len is 32 but the index is 32` before the change and passes after. Existing `lagrange_spice_docs_example` and the datatypes tests still pass.

## Documentation

This PR does not primarily deal with documentation changes.
