### PR TITLE
guard epoch directory index in type 9 and type 13 evaluate

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -439,6 +439,15 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
                 (dir_idx * 100) - 1
             };
 
+            // The directory index is derived from the untrusted epoch registry, whose length
+            // and values need not agree with num_records. If it lands past the epoch data the
+            // slice below would panic, so treat an out-of-range directory as corrupt data.
+            if sub_array_start_idx >= self.num_records {
+                return Err(InterpolationError::CorruptedData {
+                    what: "epoch directory index is out of bounds of the epoch data",
+                });
+            }
+
             // The block is at most 100 records long, or fewer if at the end of epoch_data.
             // Ensure end index does not exceed total number of records.
             let sub_array_end_idx = (sub_array_start_idx + 99).min(self.num_records - 1);
@@ -684,6 +693,35 @@ mod hermite_ut {
                         value: 4.0,
                         reason: "must be at least the interpolation window size (samples)",
                     },
+                }
+            ),
+        }
+    }
+
+    #[test]
+    fn type13_registry_index_out_of_bounds() {
+        use super::HermiteSetType13;
+        use crate::math::interpolation::InterpolationError;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use hifitime::Epoch;
+
+        // Two records (12 state doubles + 2 epochs), one epoch-registry entry, window size 2.
+        // The registry entry sits below an in-range query epoch, so the directory search yields
+        // start index 99, which points past the 2-element epoch data.
+        let mut slice = vec![0.0_f64; 17];
+        slice[12] = 0.0; // epoch_data[0]
+        slice[13] = 100.0; // epoch_data[1]
+        slice[14] = -1000.0; // single registry entry, below the query epoch
+        slice[15] = 1.0; // samples - 1 => window size 2
+        slice[16] = 2.0; // num_records
+        let set = HermiteSetType13::from_f64_slice(&slice).unwrap();
+        let summary = SPKSummaryRecord::default();
+        match set.evaluate(Epoch::from_et_seconds(50.0), &summary) {
+            Ok(_) => panic!("an out-of-range epoch directory must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                InterpolationError::CorruptedData {
+                    what: "epoch directory index is out of bounds of the epoch data",
                 }
             ),
         }

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -383,6 +383,15 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
                 (dir_idx * 100) - 1
             };
 
+            // The directory index is derived from the untrusted epoch registry, whose length
+            // and values need not agree with num_records. If it lands past the epoch data the
+            // slice below would panic, so treat an out-of-range directory as corrupt data.
+            if sub_array_start_idx >= self.num_records {
+                return Err(InterpolationError::CorruptedData {
+                    what: "epoch directory index is out of bounds of the epoch data",
+                });
+            }
+
             // The block is at most 100 records long, or fewer if at the end of epoch_data.
             // Ensure end index does not exceed total number of records.
             let sub_array_end_idx = (sub_array_start_idx + 99).min(self.num_records - 1);
@@ -551,6 +560,30 @@ mod ut_lagrange {
                         value: 4.0,
                         reason: "must be at least the interpolation window size (degree + 1)",
                     },
+                }
+            ),
+        }
+    }
+
+    #[test]
+    fn type9_registry_index_out_of_bounds() {
+        // Two records (12 state doubles + 2 epochs), one epoch-registry entry, window size 2.
+        // The registry entry sits below an in-range query epoch, so the directory search yields
+        // start index 99, which points past the 2-element epoch data.
+        let mut slice = vec![0.0_f64; 17];
+        slice[12] = 0.0; // epoch_data[0]
+        slice[13] = 100.0; // epoch_data[1]
+        slice[14] = -1000.0; // single registry entry, below the query epoch
+        slice[15] = 1.0; // degree => window size 2
+        slice[16] = 2.0; // num_records
+        let set = LagrangeSetType9::from_f64_slice(&slice).unwrap();
+        let summary = SPKSummaryRecord::default();
+        match set.evaluate(Epoch::from_et_seconds(50.0), &summary) {
+            Ok(_) => panic!("an out-of-range epoch directory must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                InterpolationError::CorruptedData {
+                    what: "epoch directory index is out of bounds of the epoch data",
                 }
             ),
         }


### PR DESCRIPTION
# Summary

the epoch directory search in `LagrangeSetType9::evaluate` and `HermiteSetType13::evaluate` reads `sub_array_start_idx` as `(dir_idx * 100) - 1`, where `dir_idx` is a partition point over the epoch registry, and then slices `epoch_data` at that index. both the registry length and `num_records` come straight from the segment, so the code's assumption that the registry is only populated once there are at least 100 records is not guaranteed. a segment with a small `num_records` and a single registry entry that sits below an in-range query epoch drives the start index past `epoch_data` (99 into a two-element slice), and the slice panics while an ephemeris is being evaluated. the two decoders share the same directory-search block, so both are affected. added a bounds check that returns `CorruptedData` when the directory index lands outside `epoch_data`, which leaves valid kernels untouched since a well-formed directory always points within the records.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

reject an out-of-range epoch directory index in the type 9 lagrange and type 13 hermite evaluators instead of panicking on the `epoch_data` slice.

## Testing and validation

added `type9_registry_index_out_of_bounds` and `type13_registry_index_out_of_bounds`, each building a two-record segment with one registry entry below the query epoch. both panic on the current code and now return `CorruptedData`. existing datatype tests still pass.

## Documentation

This PR does not primarily deal with documentation changes.
