### PR TITLE
avoid fixed-offset slice panic on file uris in metafile process

### DIFF
--- a/anise/src/almanac/metaload/metafile.rs
+++ b/anise/src/almanac/metaload/metafile.rs
@@ -72,13 +72,15 @@ impl MetaFile {
                         // assumes the URI is always `file://` followed by the path, but the parser
                         // also accepts shorter forms like `file:/path` and `file:path`, so on a
                         // short URI it slices out of bounds and on a multi-byte character landing on
-                        // the offset it slices off a char boundary, panicking in both cases. Strip
-                        // the scheme and the optional `//` authority marker without a fixed offset.
-                        let after_scheme = &self.uri[url.scheme().len() + 1..];
-                        self.uri = after_scheme
-                            .strip_prefix("//")
-                            .unwrap_or(after_scheme)
-                            .to_string();
+                        // the offset it slices off a char boundary, panicking in both cases. Split
+                        // at the scheme separator and strip the optional `//` authority marker,
+                        // which also copes with any leading whitespace the parser trims.
+                        if let Some((_, after_scheme)) = self.uri.split_once(':') {
+                            self.uri = after_scheme
+                                .strip_prefix("//")
+                                .unwrap_or(after_scheme)
+                                .to_string();
+                        }
                     }
                     return Ok(());
                 }

--- a/anise/src/almanac/metaload/metafile.rs
+++ b/anise/src/almanac/metaload/metafile.rs
@@ -68,8 +68,17 @@ impl MetaFile {
                 if !url.scheme().starts_with("http") {
                     // This means it could be either a path with `file:///`, or an absolute path on Windows.
                     if url.scheme() == "file" {
-                        // Remove the first four characters plus `://`, regardless of case
-                        self.uri = self.uri[7..].to_string();
+                        // Recover the local path from the `file:` URI. A fixed `[7..]` slice
+                        // assumes the URI is always `file://` followed by the path, but the parser
+                        // also accepts shorter forms like `file:/path` and `file:path`, so on a
+                        // short URI it slices out of bounds and on a multi-byte character landing on
+                        // the offset it slices off a char boundary, panicking in both cases. Strip
+                        // the scheme and the optional `//` authority marker without a fixed offset.
+                        let after_scheme = &self.uri[url.scheme().len() + 1..];
+                        self.uri = after_scheme
+                            .strip_prefix("//")
+                            .unwrap_or(after_scheme)
+                            .to_string();
                     }
                     return Ok(());
                 }
@@ -390,6 +399,33 @@ mod ut_metafile {
         };
         assert!(unix_rel_path.process(true).is_ok());
         assert_eq!(unix_rel_path.uri, "../Users/me/meta.dhall".to_string());
+    }
+
+    #[test]
+    fn short_and_non_ascii_file_uris() {
+        // A `file:` URI that is not exactly `file://<path>` used to slice the raw string at a
+        // hard-coded byte offset, panicking when the URI was shorter than the offset or had a
+        // multi-byte character landing on it.
+        for uri in [
+            "file:",
+            "file:x",
+            "file:/\u{20AC}", // multi-byte char straddling the old offset
+            "file:a\u{E4}",
+        ] {
+            let mut mf = MetaFile {
+                uri: uri.to_string(),
+                crc32: None,
+            };
+            assert!(mf.process(true).is_ok(), "process panicked/failed on {uri}");
+        }
+
+        // The usual `file:///` form still resolves to the bare local path.
+        let mut mf = MetaFile {
+            uri: "file:///Users/me/meta.dhall".to_string(),
+            crc32: None,
+        };
+        mf.process(true).unwrap();
+        assert_eq!(mf.uri, "/Users/me/meta.dhall");
     }
 
     #[test]


### PR DESCRIPTION
# Summary

**Fix a panic when resolving a malformed `file:` URI in `MetaFile::process`**

When a metafile URI has the `file` scheme, `process` recovers the local path by slicing the raw URI at a hard-coded byte offset (`self.uri[7..]`), on the assumption that it always looks like `file://` followed by the path. The `url` parser is more lenient though and also accepts shorter forms such as `file:`, `file:x` and `file:/path`. On those the slice reads past the end of the string and panics with an out-of-bounds index, and a multi-byte character landing on byte 7 (e.g. `file:/€`) makes it slice off a char boundary and panic as well. This is reachable whenever a `MetaAlmanac`/`MetaFile` is processed with an untrusted or hand-written file URI.

The fix strips the scheme and the optional `//` authority marker without a fixed offset, which keeps the existing `file:///path` behaviour intact while returning gracefully on the shorter and non-ASCII forms.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

`MetaFile::process` no longer panics on a short or non-ASCII `file:` URI; the local path is now derived from the parsed scheme length rather than a hard-coded byte index.

## Testing and validation

Added `short_and_non_ascii_file_uris`, which runs `process` over `file:`, `file:x`, `file:/€` and `file:aä` (all of which panicked before) and checks that the usual `file:///Users/me/meta.dhall` form still resolves to `/Users/me/meta.dhall`.

## Documentation

This PR does not primarily deal with documentation changes.