### PR TITLE
fix out-of-bounds location index in report_visibility_arcs

### DIFF
--- a/anise/src/analysis/mod.rs
+++ b/anise/src/analysis/mod.rs
@@ -1169,4 +1169,66 @@ mod ut_analysis {
 
         // assert_eq!(events_ric2, events);
     }
+
+    #[test]
+    fn report_visibility_arcs_out_of_bounds_location_index() {
+        // A location dataset whose lookup-table entry points past its `data` vector (which a
+        // crafted or truncated location kernel can produce, since the index is not checked
+        // against the data length when decoding) must not panic the visibility search.
+        // report_event_arcs already tolerates this through location_from_id's fall-through;
+        // this checks report_visibility_arcs does too.
+        use std::path::PathBuf;
+
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string()));
+
+        let almanac = Almanac::new(
+            &manifest_dir
+                .clone()
+                .join("../data/de440s.bsp")
+                .to_string_lossy(),
+        )
+        .unwrap()
+        .load(&manifest_dir.join("../data/pck08.pca").to_string_lossy())
+        .unwrap();
+
+        let ground = Location {
+            latitude_deg: 40.427_222,
+            longitude_deg: 4.250_556,
+            height_km: 0.834_939,
+            frame: IAU_EARTH_FRAME.into(),
+            terrain_mask: vec![],
+            terrain_mask_ignored: true,
+        };
+
+        // A well-formed dataset that resolves location 42 to a valid entry.
+        let mut good = LocationDataSet::default();
+        good.push(ground, Some(42), Some("Ground")).unwrap();
+
+        // A malformed dataset that also claims location 42 but whose lookup-table index (7)
+        // points past its empty `data` vector.
+        let mut corrupt = LocationDataSet::default();
+        corrupt.lut.append_id(42, 7).unwrap();
+
+        // `corrupt` is inserted last, so the reverse iteration in report_visibility_arcs hits
+        // it first, which is exactly the case that used to panic.
+        let almanac = almanac
+            .with_location_data_as(good, Some("good".to_string()))
+            .with_location_data_as(corrupt, Some("corrupt".to_string()));
+
+        let state_spec = StateSpec {
+            target_frame: FrameSpec::Loaded(MOON_J2000),
+            observer_frame: FrameSpec::Loaded(EME2000),
+            ab_corr: Aberration::NONE,
+        };
+
+        let start = Epoch::from_gregorian_utc_at_midnight(2025, 1, 1);
+        let end = start + Unit::Day * 1;
+
+        // Before the fix this panicked with an out-of-bounds index; now it resolves against
+        // the valid dataset instead.
+        almanac
+            .report_visibility_arcs(&state_spec, 42, start, end, Unit::Minute * 10, None)
+            .unwrap();
+    }
 }

--- a/anise/src/analysis/search.rs
+++ b/anise/src/analysis/search.rs
@@ -436,12 +436,19 @@ impl Almanac {
                 if let Some(id) = opt_id
                     && id == location_id
                 {
-                    match opt_name {
-                        Some(name) => location_ref = Some(format!("{name} (#{id})")),
-                        None => location_ref = Some(format!("#{id}")),
-                    };
-                    location = Some(location_data.data[idx as usize].clone());
-                    break 'outer;
+                    // The stored index comes from the loaded dataset's lookup table and is not
+                    // cross-checked against the data length when decoding, so indexing directly
+                    // panics on a dataset whose entry points past `data`. Match location_from_id
+                    // and skip this hit so a later dataset holding the id at a valid index still
+                    // resolves.
+                    if let Some(datum) = location_data.data.get(idx as usize) {
+                        match opt_name {
+                            Some(name) => location_ref = Some(format!("{name} (#{id})")),
+                            None => location_ref = Some(format!("#{id}")),
+                        };
+                        location = Some(datum.clone());
+                        break 'outer;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Summary

`report_visibility_arcs` resolves the queried location by walking each loaded location dataset's lookup table and indexing its `data` vector directly with the stored index. That index comes from the loaded location kernel and is never cross-checked against `data.len()` when the dataset is decoded, so a dataset whose lookup-table entry points past its data panics with an out-of-bounds index. `location_from_id` already tolerates this by falling through to the next dataset when `get_by_id` fails, so a valid dataset placed behind a corrupt one still crashed the visibility search. The fix resolves the entry with a checked `get` and skips it when out of bounds, mirroring `location_from_id`.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Avoids an index-out-of-bounds panic in `report_visibility_arcs` when a loaded location dataset's lookup-table index is larger than its `data` length. The loop now uses `data.get(idx)` and falls through to the next dataset, matching how `location_from_id` handles the same case, so the query resolves against a valid dataset instead of aborting.

## Testing and validation

Added `report_visibility_arcs_out_of_bounds_location_index` in the analysis tests: it loads a corrupt location dataset (lookup-table entry pointing past an empty `data`) ahead of a well-formed one and confirms the visibility query resolves instead of panicking. On the unpatched code this test panics at `search.rs:443` with `index out of bounds: the len is 0 but the index is 7`; with the fix it passes. Ran with `cargo test -p anise --lib`.

## Documentation

This PR does not primarily deal with documentation changes.
