### PR TITLE
guard common path concatenation past MAX_TREE_DEPTH

### DIFF
--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -174,7 +174,7 @@ impl Almanac {
         } else {
             // Either are at the ephemeris root, so we'll step through the paths until we find the common root.
             let mut common_path = [None; MAX_TREE_DEPTH];
-            let mut items: usize = 0;
+            let mut items: usize;
 
             for to_obj in to_path.iter().take(to_len) {
                 // Check the trivial case of the common node being one of the input frames
@@ -184,6 +184,13 @@ impl Almanac {
                     items = 1;
                     return Ok((items, common_path, from_frame.ephemeris_id));
                 }
+
+                // Each outer step restarts the search along `from_path`, so reset the
+                // write index. Without this, `items` keeps accumulating across outer
+                // iterations that don't find a match and eventually walks past the end
+                // of `common_path` (both paths are already capped at MAX_TREE_DEPTH by
+                // `ephemeris_path_to_root`, but their running sum was never bounded).
+                items = 0;
 
                 for from_obj in from_path.iter().take(from_len) {
                     let from_id =
@@ -195,16 +202,6 @@ impl Almanac {
                         return Ok((items, common_path, to_frame.ephemeris_id));
                     }
 
-                    // The two paths are each capped at MAX_TREE_DEPTH, but they are
-                    // walked together here and appended into a single fixed array, so a
-                    // crafted set of segments whose branches only meet late can push
-                    // `items` to MAX_TREE_DEPTH before the common node is reached.
-                    if items >= MAX_TREE_DEPTH {
-                        return Err(EphemerisError::SPK {
-                            action: "computing common ephemeris path",
-                            source: DAFError::MaxRecursionDepth,
-                        });
-                    }
                     common_path[items] = Some(from_id);
                     items += 1;
 
@@ -286,12 +283,14 @@ mod path_depth_ut {
     }
 
     #[test]
-    fn common_ephemeris_path_concatenation_within_max_depth_errors() {
+    fn common_ephemeris_path_disjoint_branches_resolve_shared_root() {
         // Two branches whose center chains are each within MAX_TREE_DEPTH but which
         // only meet at the shared root: `from` = 100 -> 50 -> 51 -> 52 -> 53 -> 1 and
-        // `to` = 200 -> 60 -> 1. common_ephemeris_path walks them together into one
-        // fixed array, so the concatenated length exceeds MAX_TREE_DEPTH and used to
-        // write past `common_path`. It must now return an error instead of panicking.
+        // `to` = 200 -> 60 -> 1. The common node (1) is not the immediate parent of
+        // `to`, so the outer walk over `to_path` steps past its first entry. That used
+        // to leave `items` accumulating from the failed step and walk `common_path`
+        // out of bounds. The real depth is 5, well within MAX_TREE_DEPTH, so the query
+        // must resolve to root 1 rather than panic or error.
         let mut file_record = FileRecord::spk("DEEP");
         file_record.forward = 2;
         file_record.nd = 2;
@@ -338,14 +337,19 @@ mod path_depth_ut {
         let almanac = Almanac::from_spk(spk);
 
         let epoch = Epoch::from_et_seconds(0.0);
-        let result = almanac.common_ephemeris_path(
-            Frame::from_ephem_j2000(100),
-            Frame::from_ephem_j2000(200),
-            epoch,
-        );
-        assert!(
-            result.is_err(),
-            "a concatenated path exceeding MAX_TREE_DEPTH must error, not panic"
+        let (items, path, common_node) = almanac
+            .common_ephemeris_path(
+                Frame::from_ephem_j2000(100),
+                Frame::from_ephem_j2000(200),
+                epoch,
+            )
+            .expect("branches sharing a depth-5 root must resolve, not overflow");
+
+        assert_eq!(common_node, 1);
+        assert_eq!(items, 5);
+        assert_eq!(
+            &path[..items],
+            &[Some(50), Some(51), Some(52), Some(53), Some(1)]
         );
     }
 }

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -195,6 +195,16 @@ impl Almanac {
                         return Ok((items, common_path, to_frame.ephemeris_id));
                     }
 
+                    // The two paths are each capped at MAX_TREE_DEPTH, but they are
+                    // walked together here and appended into a single fixed array, so a
+                    // crafted set of segments whose branches only meet late can push
+                    // `items` to MAX_TREE_DEPTH before the common node is reached.
+                    if items >= MAX_TREE_DEPTH {
+                        return Err(EphemerisError::SPK {
+                            action: "computing common ephemeris path",
+                            source: DAFError::MaxRecursionDepth,
+                        });
+                    }
                     common_path[items] = Some(from_id);
                     items += 1;
 
@@ -272,6 +282,70 @@ mod path_depth_ut {
         assert!(
             result.is_err(),
             "a chain deeper than MAX_TREE_DEPTH must error, not panic"
+        );
+    }
+
+    #[test]
+    fn common_ephemeris_path_concatenation_within_max_depth_errors() {
+        // Two branches whose center chains are each within MAX_TREE_DEPTH but which
+        // only meet at the shared root: `from` = 100 -> 50 -> 51 -> 52 -> 53 -> 1 and
+        // `to` = 200 -> 60 -> 1. common_ephemeris_path walks them together into one
+        // fixed array, so the concatenated length exceeds MAX_TREE_DEPTH and used to
+        // write past `common_path`. It must now return an error instead of panicking.
+        let mut file_record = FileRecord::spk("DEEP");
+        file_record.forward = 2;
+        file_record.nd = 2;
+        file_record.ni = 6;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024, 0);
+
+        let header = SummaryRecord {
+            next_record: 0.0,
+            prev_record: 0.0,
+            num_summaries: 7.0,
+        };
+        let mut summary_block = Vec::new();
+        summary_block.extend_from_slice(header.as_bytes());
+        // (target, center) links for the two branches sharing root 1.
+        let links = [
+            (100, 50),
+            (50, 51),
+            (51, 52),
+            (52, 53),
+            (53, 1),
+            (200, 60),
+            (60, 1),
+        ];
+        for (target, center) in links {
+            let mut summary = SPKSummaryRecord::default();
+            summary.start_epoch_et_s = -1e9;
+            summary.end_epoch_et_s = 1e9;
+            summary.target_id = target;
+            summary.center_id = center;
+            summary.frame_id = 1;
+            summary.data_type_i = 2;
+            summary.start_idx = 1;
+            summary.end_idx = 100;
+            summary_block.extend_from_slice(summary.as_bytes());
+        }
+        summary_block.resize(1024, 0);
+        bytes.extend(summary_block);
+        bytes.extend(vec![0u8; 1024]);
+
+        let spk = SPK::parse(&bytes[..]).unwrap();
+        let almanac = Almanac::from_spk(spk);
+
+        let epoch = Epoch::from_et_seconds(0.0);
+        let result = almanac.common_ephemeris_path(
+            Frame::from_ephem_j2000(100),
+            Frame::from_ephem_j2000(200),
+            epoch,
+        );
+        assert!(
+            result.is_err(),
+            "a concatenated path exceeding MAX_TREE_DEPTH must error, not panic"
         );
     }
 }

--- a/anise/src/orientations/paths.rs
+++ b/anise/src/orientations/paths.rs
@@ -230,6 +230,15 @@ impl Almanac {
             let common_node = to_path[to_len - 1].expect("path entry within to_len must be Some");
 
             for from_obj in from_path.iter().take(from_len).rev().skip(1) {
+                // Each path is capped at MAX_TREE_DEPTH on its own, but they are
+                // concatenated into a single fixed array here, so `to_len + from_len`
+                // can exceed it on a crafted BPC and write past `common_path`.
+                if items >= MAX_TREE_DEPTH {
+                    return Err(OrientationError::BPC {
+                        action: "computing common orientation path",
+                        source: DAFError::MaxRecursionDepth,
+                    });
+                }
                 common_path[items] =
                     Some(from_obj.expect("path entry within from_len must be Some"));
                 items += 1;


### PR DESCRIPTION
# Summary

`common_ephemeris_path` finds the common node of two frames by walking `to_path` in an outer loop and, for each entry, scanning `from_path` in an inner loop, appending `from` ids into a fixed `[Option<NaifId>; MAX_TREE_DEPTH]` array via a running `items` index. When the common node is not the immediate parent of the `to` frame, the outer loop advances past its first entry, but `items` was never reset, so writes from the failed step kept accumulating. That both produced duplicated path entries and eventually walked `items` past the end of `common_path`, panicking with an index-out-of-bounds during a translate query. Resetting `items` at the top of each outer step keeps it bounded by `from_len` (already capped at `MAX_TREE_DEPTH` by `ephemeris_path_to_root`), so no extra length guard is needed.

`common_orientation_path` is a different shape: it genuinely concatenates `to_path` with the reversed `from_path`, so `to_len + from_len - 1` really can exceed `MAX_TREE_DEPTH`. That path keeps its bound and returns `MaxRecursionDepth` when the combined length would overflow.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Reset the running write index per outer step in `common_ephemeris_path` so branches that meet above the `to` frame's parent resolve correctly instead of accumulating and writing past the fixed path array. Bound the concatenated length in `common_orientation_path` so a combined path exceeding `MAX_TREE_DEPTH` errors instead of overflowing.

## Testing and validation

Added `common_ephemeris_path_disjoint_branches_resolve_shared_root`, which crafts an SPK with a depth-5 branch (`100 -> 50 -> 51 -> 52 -> 53 -> 1`) and a depth-2 branch (`200 -> 60 -> 1`) sharing root 1. Before the fix this panicked with `index out of bounds: the len is 8 but the index is 8`; it now resolves to common node 1 with path `[50, 51, 52, 53, 1]`.

## Documentation

This PR does not primarily deal with documentation changes.
