### PR TITLE
bound name record entry lookup to the record length

### DIFF
--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -849,6 +849,54 @@ mod daf_ut {
     }
 
     #[test]
+    fn oversized_summary_size_describe() {
+        use crate::naif::daf::FileRecord;
+        use crate::naif::daf::summary_record::SummaryRecord;
+        use crate::naif::pretty_print::NAIFPrettyPrint;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use zerocopy::IntoBytes;
+
+        let craft = |nd: u32, ni: u32| {
+            let mut file_record = FileRecord::spk("TEST");
+            file_record.forward = 2;
+            file_record.nd = nd;
+            file_record.ni = ni;
+
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(file_record.as_bytes());
+            bytes.resize(1024, 0);
+
+            // Summary record (record 2): one non-empty summary, so describe emits a row for it.
+            let summary_header = SummaryRecord {
+                next_record: 0.0,
+                prev_record: 0.0,
+                num_summaries: 1.0,
+            };
+            let mut summary = SPKSummaryRecord::default();
+            summary.data_type_i = 13;
+            summary.start_idx = 1;
+            summary.end_idx = 5;
+
+            bytes.extend_from_slice(summary_header.as_bytes());
+            bytes.extend_from_slice(summary.as_bytes());
+            bytes.resize(1024 * 3, 0);
+            bytes
+        };
+
+        // The number of summaries is derived from the size of the summary record, but the name of
+        // each one is looked up with the file record's own summary size: an `nd` that makes an
+        // entry larger than the 1024 byte name record used to slice past it.
+        let bytes = craft(200, 6);
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        assert!(daf.describe().contains("MALFORMED NAME"));
+
+        // An `nd` of u32::MAX used to overflow the addition in summary_size itself.
+        let bytes = craft(u32::MAX, 6);
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        assert!(daf.describe().contains("MALFORMED NAME"));
+    }
+
+    #[test]
     fn zero_forward_pointer() {
         use crate::naif::daf::FileRecord;
         use crate::naif::spk::summary::SPKSummaryRecord;

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -894,6 +894,12 @@ mod daf_ut {
         let bytes = craft(u32::MAX, 6);
         let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
         assert!(daf.describe().contains("MALFORMED NAME"));
+
+        // A zero summary size makes every entry zero bytes wide, so any index would otherwise
+        // resolve to an empty range and be reported as a valid, blank name.
+        let bytes = craft(0, 0);
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        assert!(daf.describe().contains("MALFORMED NAME"));
     }
 
     #[test]

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -94,7 +94,9 @@ impl FileRecord {
     }
 
     pub fn summary_size(&self) -> usize {
-        (self.nd + self.ni.div_ceil(2)) as usize
+        // `nd` and `ni` are read straight from the file, so widen before summing: this addition
+        // overflows in u32 on a crafted record (e.g. an `nd` of u32::MAX).
+        (self.nd as usize).saturating_add((self.ni as usize).div_ceil(2))
     }
 
     pub fn identification(&self) -> Result<&str, FileRecordError> {

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use core::ops::Range;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::DBL_SIZE;
@@ -45,9 +46,28 @@ impl NameRecord {
         RCRD_LEN / entry_size
     }
 
+    /// Returns the byte range of the n-th entry, or None if it does not fit in this record.
+    ///
+    /// The summary size is derived from the `nd` and `ni` fields of the file record, which are
+    /// read straight from the file, so the range is computed with checked arithmetic and bounded
+    /// against the record rather than trusting it to address a valid entry.
+    fn entry_range(n: usize, summary_size: usize) -> Option<Range<usize>> {
+        let entry_size = summary_size.checked_mul(DBL_SIZE)?;
+        let start = n.checked_mul(entry_size)?;
+        let end = start.checked_add(entry_size)?;
+        if end > RCRD_LEN {
+            None
+        } else {
+            Some(start..end)
+        }
+    }
+
     pub fn nth_name(&self, n: usize, summary_size: usize) -> &str {
-        let this_name =
-            &self.raw_names[n * summary_size * DBL_SIZE..(n + 1) * summary_size * DBL_SIZE];
+        let Some(this_name) = Self::entry_range(n, summary_size).map(|rng| &self.raw_names[rng])
+        else {
+            warn!("malformed name record: entry {n} of {summary_size} words is out of bounds!");
+            return "MALFORMED NAME";
+        };
         match core::str::from_utf8(this_name) {
             Ok(name) => name.trim(),
             Err(e) => {
@@ -59,8 +79,11 @@ impl NameRecord {
 
     /// Changes the name of the n-th record
     pub fn set_nth_name(&mut self, n: usize, summary_size: usize, new_name: &str) {
-        let this_name =
-            &mut self.raw_names[n * summary_size * DBL_SIZE..(n + 1) * summary_size * DBL_SIZE];
+        let Some(rng) = Self::entry_range(n, summary_size) else {
+            warn!("malformed name record: entry {n} of {summary_size} words is out of bounds!");
+            return;
+        };
+        let this_name = &mut self.raw_names[rng];
 
         // Copy the name (thanks Clippy)
         let cur_len = this_name.len();

--- a/anise/src/naif/daf/name_record.rs
+++ b/anise/src/naif/daf/name_record.rs
@@ -53,6 +53,11 @@ impl NameRecord {
     /// against the record rather than trusting it to address a valid entry.
     fn entry_range(n: usize, summary_size: usize) -> Option<Range<usize>> {
         let entry_size = summary_size.checked_mul(DBL_SIZE)?;
+        if entry_size == 0 {
+            // A zero entry size would make every index compute an empty 0..0 range, which
+            // would silently succeed for any n instead of reporting a malformed record.
+            return None;
+        }
         let start = n.checked_mul(entry_size)?;
         let end = start.checked_add(entry_size)?;
         if end > RCRD_LEN {


### PR DESCRIPTION
# Summary

`NameRecord::nth_name` slices the fixed 1024 byte `raw_names` array as `raw_names[n * summary_size * DBL_SIZE..(n + 1) * summary_size * DBL_SIZE]`, where `summary_size` is `nd + ni.div_ceil(2)` read straight from the file record and never validated between parsing and that slice. The number of summaries walked by `describe` comes from `size_of::<R>()` in `data_summaries`, so the two sizes are derived independently and a crafted SPK or BPC can make them disagree: with `nd = 200`, describing the file slices `raw_names[0..1624]` and panics with `range end index 1624 out of range for slice of length 1024`. The name is looked up before the `summary.is_empty()` check, so zeroed summaries still reach it. `FileRecord::summary_size` has the same trust issue one step earlier, where an `nd` of `u32::MAX` overflows the `u32` addition before `nth_name` is even called.

`num_entries` already bounds the name-lookup paths (#748), which is why this only shows up through `describe`, and `nth_name` already degrades to `MALFORMED NAME` for an entry it cannot decode, so the fix keeps that behavior rather than changing the signature.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Bound the name record entry range against `RCRD_LEN` with checked arithmetic in `nth_name` and its sibling `set_nth_name`, so an entry that does not fit the record reports `MALFORMED NAME` instead of slicing past it. The checked multiplies also cover 32 bit targets, where `summary_size * DBL_SIZE` alone can wrap. Widened `summary_size` to a saturating `usize` add so a crafted `nd`/`ni` pair cannot overflow it.

## Testing and validation

Added `oversized_summary_size_describe` alongside the other crafted-DAF tests in `daf.rs`. It builds an in-memory SPK with one non-empty summary and describes it with `nd = 200` and with `nd = u32::MAX`. On the unpatched code the first case panics at `name_record.rs:50` with `range end index 1624 out of range for slice of length 1024` and the second panics with `attempt to add with overflow`; with the fix both describe cleanly and report `MALFORMED NAME`. Ran `cargo test -p anise --lib`, `cargo fmt --all -- --check` and `cargo clippy -p anise -- -D warnings`.

## Documentation

This PR does not primarily deal with documentation changes.
