### PR TITLE
bound interpolation window size before casting it to usize

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -86,17 +86,21 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
 
         let step_size = step_size_s.seconds();
         // NOTE: The Type 12 and 13 specify that the windows size minus one is stored!
-        let samples = slice[slice.len() - 2] as usize + 1;
-        if samples > MAX_SAMPLES {
+        // Bound this on the raw f64 rather than after the cast: a large value in the footer
+        // saturates the usize cast, so the `+ 1` overflows before the sample count is
+        // compared to MAX_SAMPLES, and a negative or NaN value would land on zero instead.
+        let samples_m1 = slice[slice.len() - 2];
+        if !(0.0..MAX_SAMPLES as f64).contains(&samples_m1) {
             return Err(DecodingError::Integrity {
                 source: IntegrityError::InvalidValue {
                     dataset: Self::DATASET_NAME,
                     variable: "number of interpolation samples",
-                    value: samples as f64,
-                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                    value: samples_m1,
+                    reason: "window size minus one must be positive and yield at most MAX_SAMPLES (32) samples",
                 },
             });
         }
+        let samples = samples_m1 as usize + 1;
         let num_records_f64 = slice[slice.len() - 1];
         if !num_records_f64.is_finite() || num_records_f64 <= 0.0 {
             return Err(DecodingError::Integrity {
@@ -319,17 +323,21 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
             });
         }
 
-        let samples = num_samples_f64 as usize + 1;
-        if samples > MAX_SAMPLES {
+        // Bound this on the raw f64 rather than after the cast: a large value in the footer
+        // saturates the usize cast, so the `+ 1` overflows before the sample count is
+        // compared to MAX_SAMPLES, and a negative value would land on zero instead.
+        if !(0.0..MAX_SAMPLES as f64).contains(&num_samples_f64) {
             return Err(DecodingError::Integrity {
                 source: IntegrityError::InvalidValue {
                     dataset: Self::DATASET_NAME,
                     variable: "number of interpolation samples",
-                    value: samples as f64,
-                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                    value: num_samples_f64,
+                    reason: "window size minus one must be positive and yield at most MAX_SAMPLES (32) samples",
                 },
             });
         }
+
+        let samples = num_samples_f64 as usize + 1;
         // A non-empty segment must carry at least a full interpolation window of states.
         // With fewer, evaluate() recentres the window with `last_idx - 2 * num_left`, which
         // underflows and panics when the segment is queried at an interior epoch.
@@ -579,7 +587,50 @@ mod hermite_ut {
         naif::daf::NAIFDataSet,
     };
 
-    use super::HermiteSetType13;
+    use super::{HermiteSetType12, HermiteSetType13};
+
+    #[test]
+    fn rejects_oversized_window_without_overflow() {
+        // A huge finite window size in the footer saturates the `as usize` cast, so the sample
+        // count used to be computed as `usize::MAX + 1` and overflowed before the MAX_SAMPLES
+        // bound was applied.
+        let mut slice = vec![0.0_f64; 16];
+        slice[14] = 1e300; // window size minus one
+        slice[15] = 2.0; // num_records
+        match HermiteSetType13::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized interpolation window must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Hermite Type 13",
+                        variable: "number of interpolation samples",
+                        value: 1e300,
+                        reason: "window size minus one must be positive and yield at most MAX_SAMPLES (32) samples",
+                    },
+                }
+            ),
+        }
+
+        // Same footer field on the equal-step Type 12 decoder.
+        let mut slice = vec![0.0_f64; 10];
+        slice[8] = 1e300; // window size minus one
+        slice[9] = 1.0; // num_records
+        match HermiteSetType12::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized interpolation window must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Hermite Type 12",
+                        variable: "number of interpolation samples",
+                        value: 1e300,
+                        reason: "window size minus one must be positive and yield at most MAX_SAMPLES (32) samples",
+                    },
+                }
+            ),
+        }
+    }
 
     #[test]
     fn too_small() {

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -85,17 +85,21 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
         }
 
         let step_size = step_size_s.seconds();
-        let degree = slice[slice.len() - 2] as usize;
-        if degree + 1 > MAX_SAMPLES {
+        // Bound the degree on the raw f64 rather than after the cast: a large value in the
+        // footer saturates the usize cast, so `degree + 1` overflows before the window size
+        // is compared to MAX_SAMPLES, and a negative or NaN value would land on zero instead.
+        let degree_f64 = slice[slice.len() - 2];
+        if !(0.0..MAX_SAMPLES as f64).contains(&degree_f64) {
             return Err(DecodingError::Integrity {
                 source: IntegrityError::InvalidValue {
                     dataset: Self::DATASET_NAME,
                     variable: "interpolation window size",
-                    value: (degree + 1) as f64,
-                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                    value: degree_f64,
+                    reason: "degree must be positive and its window size (degree + 1) at most MAX_SAMPLES (32)",
                 },
             });
         }
+        let degree = degree_f64 as usize;
         let num_records = slice[slice.len() - 1] as usize;
 
         let record_data = &slice[0..slice.len() - 4];
@@ -263,17 +267,21 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
 
         // For this kind of record, the metadata is stored at the very end of the dataset
         let num_records = slice[slice.len() - 1] as usize;
-        let degree = slice[slice.len() - 2] as usize;
-        if degree + 1 > MAX_SAMPLES {
+        // Bound the degree on the raw f64 rather than after the cast: a large value in the
+        // footer saturates the usize cast, so `degree + 1` overflows before the window size
+        // is compared to MAX_SAMPLES, and a negative or NaN value would land on zero instead.
+        let degree_f64 = slice[slice.len() - 2];
+        if !(0.0..MAX_SAMPLES as f64).contains(&degree_f64) {
             return Err(DecodingError::Integrity {
                 source: IntegrityError::InvalidValue {
                     dataset: Self::DATASET_NAME,
                     variable: "interpolation window size",
-                    value: (degree + 1) as f64,
-                    reason: "must be less than or equal to MAX_SAMPLES (32)",
+                    value: degree_f64,
+                    reason: "degree must be positive and its window size (degree + 1) at most MAX_SAMPLES (32)",
                 },
             });
         }
+        let degree = degree_f64 as usize;
         // A non-empty segment must carry at least a full interpolation window of states.
         // With fewer, evaluate() recentres the window with `last_idx - 2 * num_left`, which
         // underflows and panics when the segment is queried at an interior epoch.
@@ -540,6 +548,49 @@ mod ut_lagrange {
     use super::*;
     use crate::naif::spk::summary::SPKSummaryRecord;
     use hifitime::Epoch;
+
+    #[test]
+    fn rejects_oversized_window_without_overflow() {
+        // A huge finite degree in the footer saturates the `as usize` cast, so the window size
+        // used to be computed as `usize::MAX + 1` and overflowed before the MAX_SAMPLES bound
+        // was applied.
+        let mut slice = vec![0.0_f64; 20];
+        slice[18] = 1e300; // degree
+        slice[19] = 2.0; // num_records
+        match LagrangeSetType9::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized interpolation window must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Lagrange Type 9",
+                        variable: "interpolation window size",
+                        value: 1e300,
+                        reason: "degree must be positive and its window size (degree + 1) at most MAX_SAMPLES (32)",
+                    },
+                }
+            ),
+        }
+
+        // Same footer field on the equal-step Type 8 decoder.
+        let mut slice = vec![0.0_f64; 10];
+        slice[8] = 1e300; // degree
+        slice[9] = 1.0; // num_records
+        match LagrangeSetType8::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized interpolation window must be rejected"),
+            Err(e) => assert_eq!(
+                e,
+                DecodingError::Integrity {
+                    source: IntegrityError::InvalidValue {
+                        dataset: "Lagrange Type 8",
+                        variable: "interpolation window size",
+                        value: 1e300,
+                        reason: "degree must be positive and its window size (degree + 1) at most MAX_SAMPLES (32)",
+                    },
+                }
+            ),
+        }
+    }
 
     #[test]
     fn rejects_window_larger_than_records_type9() {


### PR DESCRIPTION
# Summary

The Lagrange Type 8/9 and Hermite Type 12/13 decoders read the interpolation window size from the segment footer of an untrusted SPK and cast it to `usize` before bounding it against `MAX_SAMPLES`. A large finite value saturates the `f64 -> usize` cast at `usize::MAX`, so the `+ 1` that turns the stored value into a window size overflows and panics before the `MAX_SAMPLES` comparison ever runs. A crafted segment whose footer holds `1e300` in that field panics with `attempt to add with overflow` while the file is being decoded, and in release the add wraps to zero so the bound is skipped instead. Negative and NaN values land on zero through the same cast.

Checking the raw `f64` before the cast keeps the bound meaningful for every value the field can hold. The Type 1 modified difference decoder already validates its `kqmax1`/`kq` orders this way, with a comment noting that casting first lets a NaN or negative value slip past, so the four sibling decoders now follow the same shape.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Validate the stored window size against `0.0..MAX_SAMPLES` on the raw `f64` before casting to `usize`, in `LagrangeSetType8::from_f64_slice`, `LagrangeSetType9::from_f64_slice`, `HermiteSetType12::from_f64_slice`, and `HermiteSetType13::from_f64_slice`. All four report the same `InvalidValue` integrity error they already raised for an oversized window, so valid segments decode exactly as before. Type 13 keeps its existing non-finite check ahead of the new bound.

## Testing and validation

Added `rejects_oversized_window_without_overflow` to both `ut_lagrange` and `hermite_ut`, each covering its equal-step and unequal-step decoder. Confirmed the crafted footers panic on the current tree with `attempt to add with overflow` at `lagrange.rs:89` (Type 8), `lagrange.rs:267` (Type 9), `hermite.rs:89` (Type 12) and `hermite.rs:322` (Type 13), and return the integrity error afterwards. The rest of the suite is unchanged in debug and release.

## Documentation

This PR does not primarily deal with documentation changes.
