### PR TITLE
bound max phase degree before computing the nut prec chunk size

### DIFF
--- a/anise/src/naif/kpl/parser.rs
+++ b/anise/src/naif/kpl/parser.rs
@@ -334,26 +334,6 @@ pub fn convert_tpc_items(
                         if let Some(nut_prec_val) =
                             planetary_data.data.get(&Parameter::NutPrecAngles)
                         {
-                            let phase_deg =
-                                match planetary_data.data.get(&Parameter::MaxPhaseDegree) {
-                                    Some(val) => {
-                                        let deg =
-                                        (val.to_i32().map_err(|_| DataSetError::Conversion {
-                                            action: format!(
-                                                "MaxPhaseDegree must be an Integer but was {val:?}"
-                                            ),
-                                        })? + 1) as usize;
-
-                                        if deg == 0 {
-                                            return Err(DataSetError::Conversion {
-                                                action: "PhaseDegree must be non-zero".to_owned(),
-                                            });
-                                        }
-
-                                        deg
-                                    }
-                                    None => 2,
-                                };
                             let nut_prec_data = nut_prec_val.to_vec_f64().map_err(|_| {
                                 DataSetError::Conversion {
                                     action: format!(
@@ -361,6 +341,36 @@ pub fn convert_tpc_items(
                                     ),
                                 }
                             })?;
+
+                            let phase_deg = match planetary_data
+                                .data
+                                .get(&Parameter::MaxPhaseDegree)
+                            {
+                                Some(val) => {
+                                    let max_deg =
+                                        val.to_i32().map_err(|_| DataSetError::Conversion {
+                                            action: format!(
+                                                "MaxPhaseDegree must be an Integer but was {val:?}"
+                                            ),
+                                        })?;
+
+                                    // The chunk size is this degree plus one, so the degree
+                                    // has to be known good before the addition: the previous
+                                    // zero check only ever caught -1, and it sat behind an
+                                    // add that i32::MAX already overflowed.
+                                    if max_deg < 1 || max_deg as usize + 1 > nut_prec_data.len() {
+                                        return Err(DataSetError::Conversion {
+                                            action: format!(
+                                                "MaxPhaseDegree must be between 1 and {} but was {max_deg}",
+                                                nut_prec_data.len().saturating_sub(1)
+                                            ),
+                                        });
+                                    }
+
+                                    max_deg as usize + 1
+                                }
+                                None => 2,
+                            };
 
                             let mut coeffs = [PhaseAngle::<0>::default(); MAX_NUT_PREC_ANGLES];
                             let mut num = 0;
@@ -626,4 +636,72 @@ pub fn convert_fk_items(
     dataset.metadata.dataset_type = DataSetType::EulerParameterData;
 
     Ok(dataset)
+}
+
+#[cfg(test)]
+mod tpc_conversion_ut {
+    use super::*;
+
+    /// Builds the minimal TPC data for body 599 that reaches the nutation precession
+    /// angle conversion, with the provided MAX_PHASE_DEGREE.
+    fn tpc_items(max_phase_degree: i32) -> (HashMap<i32, TPCItem>, HashMap<i32, TPCItem>) {
+        let mut planetary = TPCItem {
+            body_id: Some(599),
+            ..Default::default()
+        };
+        planetary.data.insert(
+            Parameter::PoleRa,
+            KPLValue::Matrix(vec![268.056595, -0.006499, 0.0]),
+        );
+        planetary.data.insert(
+            Parameter::PoleDec,
+            KPLValue::Matrix(vec![64.495303, 0.002413, 0.0]),
+        );
+        planetary.data.insert(
+            Parameter::PrimeMeridian,
+            KPLValue::Matrix(vec![284.95, 870.536642, 0.0]),
+        );
+        planetary.data.insert(
+            Parameter::NutPrecAngles,
+            KPLValue::Matrix(vec![73.32, 91472.9]),
+        );
+        planetary.data.insert(
+            Parameter::MaxPhaseDegree,
+            KPLValue::Integer(max_phase_degree),
+        );
+
+        let mut gravity = TPCItem {
+            body_id: Some(599),
+            ..Default::default()
+        };
+        gravity.data.insert(
+            Parameter::GravitationalParameter,
+            KPLValue::Float(126686531.9),
+        );
+
+        (
+            HashMap::from([(599, planetary)]),
+            HashMap::from([(599, gravity)]),
+        )
+    }
+
+    #[test]
+    fn reject_out_of_range_max_phase_degree() {
+        // i32::MAX overflowed the `+ 1` that builds the chunk size, and the zero check
+        // that followed it only ever rejected -1.
+        for max_phase_degree in [i32::MAX, 0, -1, -5] {
+            let (planetary, gravity) = tpc_items(max_phase_degree);
+            assert!(
+                convert_tpc_items(planetary, gravity).is_err(),
+                "accepted MAX_PHASE_DEGREE of {max_phase_degree}"
+            );
+        }
+    }
+
+    #[test]
+    fn accept_in_range_max_phase_degree() {
+        let (planetary, gravity) = tpc_items(1);
+        let dataset = convert_tpc_items(planetary, gravity).unwrap();
+        assert_eq!(dataset.get_by_id(599).unwrap().num_nut_prec_angles, 1);
+    }
 }


### PR DESCRIPTION
# Summary

`convert_tpc_items` takes `BODY<id>_MAX_PHASE_DEGREE` straight from the TPC text kernel and computes `val + 1` to get the chunk size it walks the nutation/precession angles with, so a kernel declaring `MAX_PHASE_DEGREE = 2147483647` overflows that add and panics before anything looks at the value. The `deg == 0` check sitting behind the add was meant to catch a bad degree but only ever rejects `-1`, so `-5` casts to a huge `usize` and the angles get folded into one oversized chunk instead of being rejected. Validating the raw `i32` against the length of the angle data first fixes both, which needs the `nut_prec_data` decode moved up a few lines so the bound is known.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Rejects an out-of-range `MAX_PHASE_DEGREE` in `convert_tpc_items` rather than overflowing the chunk-size computation. Valid kernels are unaffected: `pck00011.tpc` declares `BODY4_MAX_PHASE_DEGREE = 2` against 15 angle values, well inside the new bound.

## Testing and validation

Added `reject_out_of_range_max_phase_degree` and `accept_in_range_max_phase_degree` in a new `tpc_conversion_ut` module. The first builds body 599 with `i32::MAX`, `0`, `-1` and `-5`; on the current code `i32::MAX` panics with `attempt to add with overflow` at `parser.rs:341` and `-5` is accepted, and with the fix all four return `DataSetError::Conversion`. The second confirms a degree of 1 still converts and yields one nutation/precession angle. `cargo test -p anise --lib naif::kpl` passes, including `test_parse_pck` and `test_anise_conversion` which run against the real `pck00011.tpc`. Also worth noting `convert_tpc_items` is already a libfuzzer target (`anise/fuzz/fuzz_targets/convert_tpc_items.rs`) and `ArbitraryTPCItem` feeds it arbitrary `i32` values, so this is reachable from the existing fuzz harness.

## Documentation

This PR does not primarily deal with documentation changes.
