### PR TITLE
reject a zero interpolation degree before the spk window subtraction

### DIFF
--- a/anise/src/ephemerides/ephemeris/mod.rs
+++ b/anise/src/ephemerides/ephemeris/mod.rs
@@ -544,11 +544,13 @@ impl IntoIterator for Ephemeris {
 
 #[cfg(test)]
 mod ut_oem {
-    use super::{Almanac, DataType, Ephemeris, LocalFrame};
+    use super::{Almanac, DataType, Ephemeris, EphemerisRecord, LocalFrame};
     use crate::analysis::prelude::OrbitalElement;
-    use crate::prelude::NAIFSummaryRecord;
+    use crate::constants::frames::EARTH_J2000;
+    use crate::prelude::{NAIFSummaryRecord, Orbit};
     use hifitime::{Epoch, TimeSeries, Unit};
     use nalgebra::{Matrix6, SymmetricEigen, Vector6};
+    use std::collections::BTreeMap;
     use std::{fs::File, io::Write};
 
     use rstest::*;
@@ -1022,5 +1024,47 @@ mod ut_oem {
         // Verify Symmetry
         assert!((mat0[(0, 1)] - 2.0).abs() < 1e-9);
         assert!((mat0[(5, 2)] - 18.0).abs() < 1e-9); // C[2][5] symmetric to C[5][2] (value 18)
+    }
+
+    #[test]
+    fn oem_rejects_zero_interpolation_degree() {
+        // A degree of zero leaves no samples to interpolate with, and it used to underflow the
+        // window size computation when the parsed ephemeris was written back out as a BSP.
+        let path = std::env::temp_dir().join("anise_oem_zero_degree.oem");
+        let mut file = File::create(&path).unwrap();
+        file.write_all(
+            b"CCSDS_OEM_VERS = 2.0\n\
+              OBJECT_ID = TEST\n\
+              CENTER_NAME = EARTH\n\
+              REF_FRAME = EME2000\n\
+              TIME_SYSTEM = UTC\n\
+              INTERPOLATION = HERMITE\n\
+              INTERPOLATION_DEGREE = 0\n\
+              META_STOP\n\
+              2020-06-01T12:00:00 7000.0 0.0 0.0 0.0 7.5 0.0\n",
+        )
+        .unwrap();
+        drop(file);
+
+        assert!(Ephemeris::from_ccsds_oem_file(path.to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn bsp_writer_rejects_zero_degree() {
+        let epoch = Epoch::from_gregorian_utc_at_noon(2020, 6, 1);
+        let orbit = Orbit::from_cartesian_pos_vel(
+            Vector6::new(7000.0, 0.0, 0.0, 0.0, 7.5, 0.0),
+            epoch,
+            EARTH_J2000,
+        );
+        let mut state_data = BTreeMap::new();
+        state_data.insert(epoch, EphemerisRecord { orbit, covar: None });
+        let ephem = Ephemeris {
+            object_id: "TEST".to_string(),
+            degree: 0,
+            interpolation: DataType::Type13HermiteUnequalStep,
+            state_data,
+        };
+        assert!(ephem.to_spice_bsp(-999, None).is_err());
     }
 }

--- a/anise/src/ephemerides/ephemeris/oem.rs
+++ b/anise/src/ephemerides/ephemeris/oem.rs
@@ -126,6 +126,14 @@ impl Ephemeris {
                     parse_one_val(lno, line, "no value for INTERPOLATION_DEGREE")?.to_lowercase();
 
                 match interp_str.parse::<usize>() {
+                    // A degree of zero leaves no samples to interpolate with, and the SPK
+                    // writer subtracts one from it, so reject it here like the Python setter does.
+                    Ok(0) => {
+                        return Err(EphemerisError::OEMParsingError {
+                            lno,
+                            details: "INTERPOLATION_DEGREE must be strictly positive".to_string(),
+                        });
+                    }
                     Ok(ideg) => degree = ideg,
                     Err(_) => {
                         return Err(EphemerisError::OEMParsingError {

--- a/anise/src/ephemerides/ephemeris/spk.rs
+++ b/anise/src/ephemerides/ephemeris/spk.rs
@@ -38,6 +38,15 @@ impl Ephemeris {
             });
         }
 
+        // The Hermite branch below stores (degree - 1) / 2 as the window size, so a degree of
+        // zero underflows. Nothing can be interpolated with it either, so reject it up front.
+        ensure!(
+            self.degree > 0,
+            SPKWritingSnafu {
+                details: "interpolation degree must be strictly positive".to_string()
+            }
+        );
+
         if let Some(data_type) = data_type {
             ensure!(
                 [


### PR DESCRIPTION
# Summary

`to_spice_bsp` stores `(self.degree - 1) / 2` as the window size for the Hermite Type 12/13 branches, and that subtraction is unchecked, so an ephemeris with a degree of zero panics with `attempt to subtract with overflow` while writing the BSP (in release it wraps to `usize::MAX / 2` and that value lands in the SPK footer as the window size). A degree of zero comes straight out of a CCSDS OEM file: `INTERPOLATION_DEGREE` is parsed with `parse::<usize>()` and assigned with no lower bound, while the Python `degree` setter already refuses anything below 1. The guard belongs at both ends, so the writer refuses a zero degree and the OEM reader never builds an ephemeris that cannot be interpolated in the first place.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Avoids the subtract overflow in `Ephemeris::to_spice_bsp` when `degree` is zero, returning the existing `SPKWritingError` instead. `Ephemeris::from_ccsds_oem_file` now rejects `INTERPOLATION_DEGREE = 0` with the usual parse error and line number, matching the rule the Python setter enforces.

## Testing and validation

Added two tests in `ut_oem`. `bsp_writer_rejects_zero_degree` builds a single-state ephemeris with `degree = 0` and Type 13 interpolation and checks that `to_spice_bsp` errors; on the unpatched tree it panics at `spk.rs:142` with `attempt to subtract with overflow`. `oem_rejects_zero_interpolation_degree` writes a minimal OEM carrying `INTERPOLATION_DEGREE = 0` and checks the parse fails; unpatched, the parse succeeds and the resulting ephemeris reaches the same panic. Both fail before the change and pass after. Ran `cargo test -p anise --lib`, `cargo fmt --all -- --check` and `cargo clippy -p anise -- -D warnings`; the remaining test failures here are the ones that need the downloaded kernels under `data/`, unchanged from master.

## Documentation

This PR does not primarily deal with documentation changes.
