### PR TITLE
bound name-derived summary index in summary_from_name

### DIFF
--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -331,7 +331,18 @@ impl<R: NAIFSummaryRecord> DAF<R> {
                 .index_from_name::<R>(name, self.file_record()?.summary_size())
             {
                 Ok(summary_idx) => {
-                    return Ok((&self.data_summaries(idx)?[summary_idx], idx, summary_idx));
+                    // The name record is walked with the summary size declared in the file
+                    // record, but the number of summaries the record holds is fixed by the
+                    // size of R, so those two disagree on a crafted nd/ni pair and the name
+                    // entry can sit past the last summary. Guard the lookup the same way
+                    // `nth_data` does rather than indexing out of bounds.
+                    let data_summary = self.data_summaries(idx)?.get(summary_idx).ok_or(
+                        DAFError::InvalidIndex {
+                            idx: summary_idx,
+                            kind: R::NAME,
+                        },
+                    )?;
+                    return Ok((data_summary, idx, summary_idx));
                 }
                 Err(e) => {
                     if summary.is_final_record() {
@@ -844,6 +855,37 @@ mod daf_ut {
         match daf.data_from_name::<crate::naif::daf::datatypes::HermiteSetType13>("anything") {
             Err(DAFError::NameError { name, .. }) => assert_eq!(name, "anything"),
             Ok(_) => panic!("unexpected data for a zero summary-size record"),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn name_entry_past_last_summary() {
+        use crate::naif::daf::FileRecord;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        use zerocopy::IntoBytes;
+
+        // An nd of 1 and an ni of 2 declare a two-word summary, so the name record is walked
+        // as 64 entries of 16 bytes while the summary record still only holds 25 SPK summaries.
+        let mut file_record = FileRecord::spk("TEST");
+        file_record.forward = 2;
+        file_record.nd = 1;
+        file_record.ni = 2;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(3 * super::RCRD_LEN, 0);
+
+        // Name record (record 3), with the queried name planted at entry 30.
+        let name_rcrd = 2 * super::RCRD_LEN;
+        bytes[name_rcrd..name_rcrd + super::RCRD_LEN].fill(b' ');
+        bytes[name_rcrd + 30 * 16..name_rcrd + 30 * 16 + 4].copy_from_slice(b"BOOM");
+
+        let daf = super::DAF::<SPKSummaryRecord>::parse(&bytes[..]).unwrap();
+        // Before the guard this indexed the 25 summaries with entry 30 and panicked.
+        match daf.summary_from_name("BOOM") {
+            Err(DAFError::InvalidIndex { idx, .. }) => assert_eq!(idx, 30),
+            Ok(_) => panic!("unexpected summary for a name past the last one"),
             Err(e) => panic!("unexpected error: {e}"),
         }
     }


### PR DESCRIPTION
# Summary

`DAF::summary_from_name` finds the requested name with `NameRecord::index_from_name` and then indexes the data summary slice directly with the entry index it gets back. Those two sides do not come from the same place: the name record is walked with `num_entries(summary_size)`, where `summary_size` is `nd + ni.div_ceil(2)` read straight from the file record, while the length of the slice returned by `data_summaries` is fixed by `size_of::<R>()`. A crafted SPK that declares a smaller summary than it really uses makes the name record look longer than the summary record, so a name planted in one of the extra entries resolves to an index past the last summary. With `nd = 1` and `ni = 2` the name record is walked as 64 entries of 16 bytes against 25 real `SPKSummaryRecord`s, and a name at entry 30 panics with `index out of bounds: the len is 25 but the index is 30`. This is reachable from `Almanac::spk_summary_from_name` and `bpc_summary_from_name`, and from `data_from_name` through the same call.

`nth_data` already resolves its summary with `get(idx)` and reports `DAFError::InvalidIndex`, so the fix keeps `summary_from_name` consistent with it rather than adding a new error. The bound in #770 covers the slice into `raw_names` itself, which is why entry 30 decodes fine here and only the summary lookup goes out of range.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Resolve the summary in `summary_from_name` with `data_summaries(idx)?.get(summary_idx)` and return `DAFError::InvalidIndex` when the name entry sits past the last summary, instead of indexing out of bounds.

## Testing and validation

Added `name_entry_past_last_summary` next to the other crafted-DAF tests in `daf.rs`. It builds an in-memory SPK with `nd = 1`, `ni = 2` and the queried name at name-record entry 30, then looks it up by name. On the unpatched code it panics at `daf.rs:334` with `index out of bounds: the len is 25 but the index is 30`; with the fix the lookup returns `InvalidIndex`. Ran `cargo test --workspace --exclude anise-gui --exclude anise-py`, `cargo fmt --all -- --check` and `cargo clippy -p anise -- -D warnings`.

## Documentation

This PR does not primarily deal with documentation changes.
