### PR TITLE
validate the summary data range before splicing daf bytes

### DIFF
--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -80,6 +80,21 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         let orig_data_start = orig_index_start.saturating_mul(DBL_SIZE);
         let orig_data_end = orig_index_end.saturating_mul(DBL_SIZE);
 
+        // The end pointer is read verbatim from the file as well, so it may sit before the start
+        // pointer or past the end of the data: `nth_data` rejects both because it reads through
+        // `bytes.get`, but the splice below would panic on either.
+        if orig_data_end < orig_data_start || orig_data_end > self.bytes.len() {
+            return Err(DAFError::DecodingData {
+                kind: R::NAME,
+                idx,
+                source: DecodingError::InaccessibleBytes {
+                    start: orig_data_start,
+                    end: orig_data_end,
+                    size: self.bytes.len(),
+                },
+            });
+        }
+
         let original_size = ((orig_data_end - orig_data_start) / DBL_SIZE) as isize;
 
         let new_data_bytes = new_data
@@ -124,9 +139,22 @@ impl<R: NAIFSummaryRecord> DAF<R> {
 
         let rcrd_idx = (self.file_record()?.fwrd_idx() - 1) * RCRD_LEN;
         // Note: we use copy_from_slice here because we have the guarantee that the summary bytes are the same length as the original version.
+        // The splice above may have shrunk the data, so the summary record is no longer
+        // necessarily within the new bytes.
+        let new_size = new_bytes.len();
         let orig_summary_bytes =
-            &mut new_bytes[rcrd_idx..rcrd_idx + RCRD_LEN][SummaryRecord::SIZE..];
-        orig_summary_bytes.copy_from_slice(&summary_bytes);
+            new_bytes
+                .get_mut(rcrd_idx..rcrd_idx + RCRD_LEN)
+                .ok_or(DAFError::DecodingData {
+                    kind: R::NAME,
+                    idx,
+                    source: DecodingError::InaccessibleBytes {
+                        start: rcrd_idx,
+                        end: rcrd_idx + RCRD_LEN,
+                        size: new_size,
+                    },
+                })?;
+        orig_summary_bytes[SummaryRecord::SIZE..].copy_from_slice(&summary_bytes);
 
         self.bytes = BytesMut::from_iter(new_bytes);
 
@@ -168,6 +196,21 @@ impl<R: NAIFSummaryRecord> DAF<R> {
         let orig_data_start = orig_index_start.saturating_mul(DBL_SIZE);
         let orig_data_end = orig_index_end.saturating_mul(DBL_SIZE);
 
+        // The end pointer is read verbatim from the file as well, so it may sit before the start
+        // pointer or past the end of the data: `nth_data` rejects both because it reads through
+        // `bytes.get`, but the drain below would panic on either.
+        if orig_data_end < orig_data_start || orig_data_end > self.bytes.len() {
+            return Err(DAFError::DecodingData {
+                kind: R::NAME,
+                idx,
+                source: DecodingError::InaccessibleBytes {
+                    start: orig_data_start,
+                    end: orig_data_end,
+                    size: self.bytes.len(),
+                },
+            });
+        }
+
         let original_size = ((orig_data_end - orig_data_start) / DBL_SIZE) as isize;
 
         // Size change will be positive if the new data is _smaller_ than the previous one, and vice versa.
@@ -208,12 +251,96 @@ impl<R: NAIFSummaryRecord> DAF<R> {
 
         let rcrd_idx = (self.file_record()?.fwrd_idx() - 1) * RCRD_LEN;
         // Note: we use copy_from_slice here because we have the guarantee that the summary bytes are the same length as the original version.
+        // The drain above may have shrunk the data, so the summary record is no longer
+        // necessarily within the new bytes.
+        let new_size = new_bytes.len();
         let orig_summary_bytes =
-            &mut new_bytes[rcrd_idx..rcrd_idx + RCRD_LEN][SummaryRecord::SIZE..];
-        orig_summary_bytes.copy_from_slice(&summary_bytes);
+            new_bytes
+                .get_mut(rcrd_idx..rcrd_idx + RCRD_LEN)
+                .ok_or(DAFError::DecodingData {
+                    kind: R::NAME,
+                    idx,
+                    source: DecodingError::InaccessibleBytes {
+                        start: rcrd_idx,
+                        end: rcrd_idx + RCRD_LEN,
+                        size: new_size,
+                    },
+                })?;
+        orig_summary_bytes[SummaryRecord::SIZE..].copy_from_slice(&summary_bytes);
 
         self.bytes = BytesMut::from_iter(new_bytes);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod mut_daf_ut {
+    use crate::naif::daf::summary_record::SummaryRecord;
+    use crate::naif::daf::{DAFError, FileRecord};
+    use crate::naif::spk::summary::SPKSummaryRecord;
+    use bytes::BytesMut;
+    use zerocopy::IntoBytes;
+
+    /// Builds a three record SPK whose single summary has the provided data pointers.
+    fn craft(start_idx: i32, end_idx: i32) -> BytesMut {
+        let mut file_record = FileRecord::spk("TEST");
+        file_record.forward = 2;
+        file_record.nd = 2;
+        file_record.ni = 6;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024, 0);
+
+        // Summary record (record 2): a single summary.
+        let summary_header = SummaryRecord {
+            next_record: 0.0,
+            prev_record: 0.0,
+            num_summaries: 1.0,
+        };
+        let mut summary = SPKSummaryRecord::default();
+        summary.data_type_i = 13;
+        summary.start_idx = start_idx;
+        summary.end_idx = end_idx;
+
+        let mut summary_record = Vec::new();
+        summary_record.extend_from_slice(summary_header.as_bytes());
+        summary_record.extend_from_slice(summary.as_bytes());
+        summary_record.resize(1024, 0);
+        bytes.extend(summary_record);
+
+        // Name record (record 3).
+        bytes.extend(vec![0u8; 1024]);
+
+        BytesMut::from_iter(bytes)
+    }
+
+    #[test]
+    fn malformed_data_range_delete() {
+        // Each of these summaries is malformed in a different way: the end pointer is before the
+        // start pointer, it is negative and so sign extends to a huge index on the cast to usize,
+        // and it is past the end of the file. All three used to panic in the drain.
+        for (start_idx, end_idx) in [(5, 2), (1, -3), (1, 100_000)] {
+            let mut daf = super::DAF::<SPKSummaryRecord>::parse(craft(start_idx, end_idx)).unwrap();
+            match daf.delete_nth_data(0) {
+                Err(DAFError::DecodingData { .. }) => {}
+                Ok(_) => panic!("unexpected success for summary ({start_idx}, {end_idx})"),
+                Err(e) => panic!("unexpected error for summary ({start_idx}, {end_idx}): {e}"),
+            }
+        }
+    }
+
+    #[test]
+    fn data_range_over_summary_record_delete() {
+        // This summary points at 1600 bytes of data starting at the very beginning of the file, so
+        // deleting it leaves fewer bytes than the offset of the summary record that then has to be
+        // written back, which used to panic.
+        let mut daf = super::DAF::<SPKSummaryRecord>::parse(craft(1, 200)).unwrap();
+        match daf.delete_nth_data(0) {
+            Err(DAFError::DecodingData { .. }) => {}
+            Ok(_) => panic!("unexpected success for a segment overlapping the summary record"),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
     }
 }


### PR DESCRIPTION
# Summary

mutating a crafted DAF can panic the whole process. `DAF::set_nth_data` and `DAF::delete_nth_data` turn a segment summary's start and end pointers into a byte range and hand it straight to `splice`/`drain` on the file bytes. both pointers are `i32` fields read verbatim from the kernel, and only the start one is currently checked (for the 1-based zero case), so a crafted summary can put the end before the start, make it negative so it sign extends to an enormous index on the cast to `usize`, or point it past the end of the file. all three panic, the first on the arithmetic that computes the original segment size and the other two inside the range operation itself, in release as well as debug. the read path in `DAF::nth_data` already copes with exactly these summaries because it goes through `bytes.get(start..end)`, so this looks like an oversight on the mutation side rather than an invariant the summaries actually carry.

there is a second, related site in the same two functions: after the data has been spliced or drained the summary record is written back at a fixed offset, but the buffer may have shrunk below that offset by then, so a summary whose data region overlaps the start of the file panics there too even when the range itself was fine.

both are reachable from an untrusted kernel through the CLI, which calls `delete_nth_data` from `rmsegment` and `set_nth_data` from `truncate` after loading whatever file was passed in. the fix validates the data range against the file before the splice and reads the summary record back through `get_mut`, in both functions, returning a `DecodingData` error the way the surrounding code already does.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

`DAF::set_nth_data` and `DAF::delete_nth_data` now reject a summary whose data range is inverted, sign extended or past the end of the file, and no longer index past the end of the resized buffer when writing the summary record back.

## Testing and validation

added `malformed_data_range_delete`, which builds an in-memory SPK for each of the three malformed ranges (end before start, negative end, end past the file) and checks that `delete_nth_data` returns a `DecodingData` error instead of panicking, and `data_range_over_summary_record_delete` for the shrunk-buffer case. all four panicked before this change in both debug and release.

## Documentation

This PR does not primarily deal with documentation changes.
