### PR TITLE
validate ellipsoid radii are positive and finite on decode

### DIFF
--- a/anise/src/structure/planetocentric/ellipsoid.rs
+++ b/anise/src/structure/planetocentric/ellipsoid.rs
@@ -346,10 +346,85 @@ impl Encode for Ellipsoid {
 
 impl<'a> Decode<'a> for Ellipsoid {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
+        let semi_major_equatorial_radius_km: f64 = decoder.decode()?;
+        let semi_minor_equatorial_radius_km: f64 = decoder.decode()?;
+        let polar_radius_km: f64 = decoder.decode()?;
+
+        // Every real body has strictly positive, finite radii; the surface, geodetic and
+        // eclipse routines divide by them (and by the mean/polar radius) without guarding
+        // against a zero, so a crafted kernel carrying a non-positive or non-finite radius
+        // would silently turn every query into a NaN. Reject it here like the other decoders
+        // reject their out-of-range values.
+        for radius_km in [
+            semi_major_equatorial_radius_km,
+            semi_minor_equatorial_radius_km,
+            polar_radius_km,
+        ] {
+            if !radius_km.is_finite() || radius_km <= 0.0 {
+                return Err(der::Error::new(
+                    der::ErrorKind::Value {
+                        tag: der::Tag::Real,
+                    },
+                    der::Length::ONE,
+                ));
+            }
+        }
+
         Ok(Self {
-            semi_major_equatorial_radius_km: decoder.decode()?,
-            semi_minor_equatorial_radius_km: decoder.decode()?,
-            polar_radius_km: decoder.decode()?,
+            semi_major_equatorial_radius_km,
+            semi_minor_equatorial_radius_km,
+            polar_radius_km,
         })
+    }
+}
+
+#[cfg(test)]
+mod ellipsoid_ut {
+    use super::Ellipsoid;
+    use der::{Decode, Encode};
+
+    #[test]
+    fn reject_non_positive_or_non_finite_radii() {
+        for bad in [
+            Ellipsoid {
+                semi_major_equatorial_radius_km: 0.0,
+                semi_minor_equatorial_radius_km: 0.0,
+                polar_radius_km: 0.0,
+            },
+            Ellipsoid {
+                semi_major_equatorial_radius_km: 6378.0,
+                semi_minor_equatorial_radius_km: -1.0,
+                polar_radius_km: 6356.0,
+            },
+            Ellipsoid {
+                semi_major_equatorial_radius_km: f64::NAN,
+                semi_minor_equatorial_radius_km: 6378.0,
+                polar_radius_km: 6356.0,
+            },
+            Ellipsoid {
+                semi_major_equatorial_radius_km: f64::INFINITY,
+                semi_minor_equatorial_radius_km: 6378.0,
+                polar_radius_km: 6356.0,
+            },
+        ] {
+            let mut buf = vec![];
+            bad.encode_to_vec(&mut buf).unwrap();
+            assert!(
+                Ellipsoid::from_der(&buf).is_err(),
+                "decoded an ellipsoid with a non-positive or non-finite radius: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_radii_round_trip() {
+        let earth = Ellipsoid {
+            semi_major_equatorial_radius_km: 6378.1366,
+            semi_minor_equatorial_radius_km: 6378.1366,
+            polar_radius_km: 6356.7519,
+        };
+        let mut buf = vec![];
+        earth.encode_to_vec(&mut buf).unwrap();
+        assert_eq!(Ellipsoid::from_der(&buf).unwrap(), earth);
     }
 }


### PR DESCRIPTION
# Summary

the tri-axial radii in `Ellipsoid` are read straight from a PCA/PCK planetary-constants kernel in `Ellipsoid::decode` and stored with no check, while the sibling DAF decoders already reject out-of-range values as they decode. a crafted kernel carrying `RADII = ( 0 0 0 )`, a negative radius, or a NaN/inf therefore loads cleanly, and since `surface_normal`, `intersect`, `flattening`, `mean_equatorial_radius_km` and the AER/eclipse routines all divide by these radii with no zero guard, every query on that body then quietly returns NaN rather than erroring. rejecting a non-finite or non-positive radius at decode stops the invalid kernel from being built at all, and reuses the same `der` value-error shape that `DataSetType::decode` and `Metadata::decode` already return. `shape` is an `Option<Ellipsoid>`, so bodies defined by GM alone (barycenters) carry no ellipsoid and are untouched.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

reject non-finite or non-positive radii in `Ellipsoid::decode`.

## Testing and validation

added `reject_non_positive_or_non_finite_radii` (zero, negative, NaN and inf radii all fail to decode) and `valid_radii_round_trip` (a normal Earth ellipsoid still round-trips). the existing planetary-constants encode/decode tests still pass.

## Documentation

This PR does not primarily deal with documentation changes.
