### PR TITLE
reject inverted truncation window in chebyshev decoders

### DIFF
--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -252,6 +252,15 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
             self.num_records - 1
         };
 
+        // A new start epoch that is later than the new end epoch selects a first record past
+        // the last one, so the byte range below is reversed and the slice panics. Reject the
+        // inverted window rather than letting it abort.
+        if start_idx > end_idx {
+            return Err(InterpolationError::CorruptedData {
+                what: "truncation start epoch is after its end epoch",
+            });
+        }
+
         self.record_data = &self.record_data[start_idx * self.rsize..(end_idx + 1) * self.rsize];
         self.num_records = self.record_data.len() / self.rsize;
         self.init_epoch = self
@@ -528,5 +537,36 @@ mod chebyshev_ut {
         assert_eq!(dataset.spline_idx(epoch, &summary).unwrap(), 1);
         // The full evaluate path must not panic on this input.
         let _ = dataset.evaluate(epoch, &summary);
+    }
+
+    #[test]
+    fn truncate_rejects_reversed_window() {
+        let dataset = Type2ChebyshevSet::from_f64_slice(&[
+            5.0, 5.0, 1.0, 0.0, 0.0, // record 0 (midpoint, radius, x, y, z)
+            15.0, 5.0, 1.0, 0.0, 0.0, // record 1
+            25.0, 5.0, 1.0, 0.0, 0.0, // record 2
+            0.0, 10.0, 5.0, 3.0, // init_epoch, interval, rsize, num_records
+        ])
+        .unwrap();
+        let summary = SPKSummaryRecord {
+            start_epoch_et_s: 0.0,
+            end_epoch_et_s: 30.0,
+            target_id: 301,
+            center_id: 3,
+            frame_id: 1,
+            data_type_i: 2,
+            start_idx: 1,
+            end_idx: 13,
+        };
+        // new_start (25 s) is later than new_end (5 s): both in bounds but inverted.
+        let res = dataset.truncate(
+            &summary,
+            Some(Epoch::from_et_seconds(25.0)),
+            Some(Epoch::from_et_seconds(5.0)),
+        );
+        assert!(
+            res.is_err(),
+            "reversed truncation window must error, not panic"
+        );
     }
 }

--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -258,6 +258,15 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
             self.num_records - 1
         };
 
+        // A new start epoch that is later than the new end epoch selects a first record past
+        // the last one, so the byte range below is reversed and the slice panics. Reject the
+        // inverted window rather than letting it abort.
+        if start_idx > end_idx {
+            return Err(InterpolationError::CorruptedData {
+                what: "truncation start epoch is after its end epoch",
+            });
+        }
+
         self.record_data = &self.record_data[start_idx * self.rsize..(end_idx + 1) * self.rsize];
         self.num_records = self.record_data.len() / self.rsize;
         self.init_epoch = self
@@ -554,5 +563,37 @@ mod chebyshev_ut {
         assert_eq!(dataset.spline_idx(epoch, &summary).unwrap(), 1);
         // The full evaluate path must not panic on this input.
         let _ = dataset.evaluate(epoch, &summary);
+    }
+
+    #[test]
+    fn truncate_rejects_reversed_window() {
+        use hifitime::Epoch;
+        let dataset = Type3ChebyshevSet::from_f64_slice(&[
+            5.0, 5.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // record 0
+            15.0, 5.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // record 1
+            25.0, 5.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // record 2
+            0.0, 10.0, 8.0, 3.0, // init_epoch, interval, rsize, num_records
+        ])
+        .unwrap();
+        let summary = SPKSummaryRecord {
+            start_epoch_et_s: 0.0,
+            end_epoch_et_s: 30.0,
+            target_id: 301,
+            center_id: 3,
+            frame_id: 1,
+            data_type_i: 3,
+            start_idx: 1,
+            end_idx: 28,
+        };
+        // new_start (25 s) is later than new_end (5 s): both in bounds but inverted.
+        let res = dataset.truncate(
+            &summary,
+            Some(Epoch::from_et_seconds(25.0)),
+            Some(Epoch::from_et_seconds(5.0)),
+        );
+        assert!(
+            res.is_err(),
+            "reversed truncation window must error, not panic"
+        );
     }
 }


### PR DESCRIPTION
# Summary

The Chebyshev type 2 and type 3 `truncate` methods pick a first and last record from the requested `new_start` and `new_end` epochs (via `spline_idx`) and then slice `record_data[start_idx * rsize..(end_idx + 1) * rsize]`. If the caller passes a start epoch that is later than the end epoch, with both still inside the segment bounds, `start_idx` ends up greater than `end_idx` and that byte range is reversed, so the slice panics with `slice index starts at N but ends at M`. This is reachable from `anise truncate-daf-by-id <in> <out> <id> <start> <end>` on any multi-record Chebyshev SPK/BPC when the two epochs are given the wrong way round. Both decoders return an `InterpolationError` already, so the fix rejects an inverted window before slicing rather than aborting.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Guard `Type2ChebyshevSet::truncate` and `Type3ChebyshevSet::truncate` against a start index past the end index, returning an error instead of panicking on an inverted truncation window.

## Testing and validation

Added a regression test to each decoder that builds a small three-record segment and calls `truncate` with the start epoch after the end epoch; both panic on the current code and now return an error. Existing datatype tests still pass.

## Documentation

This PR does not primarily deal with documentation changes.