### PR TITLE
Fix inverted LengthUnit conversion methods

### DIFF
--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -244,7 +244,7 @@ impl Almanac {
         distance_unit: LengthUnit,
         time_unit: TimeUnit,
     ) -> Result<CartesianState, EphemerisError> {
-        let dist_unit_factor = LengthUnit::Kilometer.from_meters() * distance_unit.to_meters();
+        let dist_unit_factor = LengthUnit::Kilometer.to_meters() * distance_unit.from_meters();
         let time_unit_factor = time_unit.in_seconds();
 
         let state = CartesianState {

--- a/anise/src/math/units.rs
+++ b/anise/src/math/units.rs
@@ -24,10 +24,10 @@ pub enum LengthUnit {
 }
 
 impl LengthUnit {
-    /// Returns the conversion factor of this distance unit to meters.
-    /// E.g. To convert Self::Kilometers into Self::Meters, multiply by 1e-3.
+    /// Returns the conversion factor of this distance unit from meters.
+    /// E.g. To convert Self::Meters into Self::Kilometers, multiply by 1e-3.
     #[must_use]
-    pub const fn to_meters(&self) -> f64 {
+    pub const fn from_meters(&self) -> f64 {
         match self {
             Self::Micrometer => 1e6,
             Self::Millimeter => 1e3,
@@ -37,10 +37,10 @@ impl LengthUnit {
         }
     }
 
-    /// Returns the conversion factor of this distance unit from meters.
+    /// Returns the conversion factor of this distance unit to meters.
     /// E.g. To convert Self::Kilometers into Self::Meters, multiply by 1e3.
     #[must_use]
-    pub const fn from_meters(&self) -> f64 {
+    pub const fn to_meters(&self) -> f64 {
         match self {
             Self::Micrometer => 1e-6,
             Self::Millimeter => 1e-3,

--- a/anise/src/orientations/rotations.rs
+++ b/anise/src/orientations/rotations.rs
@@ -216,7 +216,7 @@ impl Almanac {
         // Compute the frame translation
         let dcm = self.rotate(from_frame, to_frame, epoch)?;
 
-        let dist_unit_factor = LengthUnit::Kilometer.from_meters() * distance_unit.to_meters();
+        let dist_unit_factor = LengthUnit::Kilometer.to_meters() * distance_unit.from_meters();
         let time_unit_factor = time_unit.in_seconds();
 
         let input_state = CartesianState {


### PR DESCRIPTION
# Summary

Corrects the inverted semantics of `LengthUnit::to_meters()` and `LengthUnit::from_meters()`.

The conversion factors were previously associated with the opposite names. This also updates the affected ephemeris translation and orientation call sites to preserve correct distance conversions.

## Improvements

- Corrected the documentation and examples for length-unit conversions.

No change

## Bug Fixes

- Corrected `LengthUnit::from_meters()` to convert meters into the selected unit.
- Corrected `LengthUnit::to_meters()` to convert the selected unit into meters.
- Updated ephemeris translation and orientation conversion factors to use the corrected methods.


## Testing and validation

- `cargo fmt --check`
- `cargo check --workspace`
Both checks pass successfully.

The full test suite could not be executed locally because `ethnum 1.5.2`, pulled through a development dependency, does not compile with Rust 1.97.1 (`E0512`). This is unrelated to the changes in this pull request.

## Documentation

This PR does not primarily deal with documentation changes.