### PR TITLE
2.5x perf increase: Switched SPK functions to use Ephemeris Time directly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [env]
 CSPICE_DIR = {value = "./cspice/", relative = true}
 
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
 # For flamegraph -- https://github.com/flamegraph-rs/flamegraph
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-Clink-arg=-Wl,--no-rosegment"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,9 @@
 [env]
 CSPICE_DIR = {value = "./cspice/", relative = true}
 
-# [target.x86_64-unknown-linux-gnu]
 # For flamegraph -- https://github.com/flamegraph-rs/flamegraph
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Clink-arg=-Wl,--no-rosegment"]
 # linker = "/usr/bin/clang"
+# [target.x86_64-unknown-linux-gnu]
 # rustflags = ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,6 @@
 [env]
 CSPICE_DIR = {value = "./cspice/", relative = true}
 
-[build]
-rustflags = ["-C", "target-cpu=native"]
-
 # For flamegraph -- https://github.com/flamegraph-rs/flamegraph
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-Clink-arg=-Wl,--no-rosegment"]

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -2,7 +2,7 @@ name: "Intelligent Code Review"
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
   issue_comment:
     types: [created]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py", "anise/fuzz", "anise-cpp"]
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."
@@ -27,8 +27,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-# hifitime = "4.3.0"
-hifitime = {git = "https://github.com/nyx-space/hifitime", branch="perf-changes"}
+hifitime = "4.3.1"
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ exclude = [
 ]
 
 [workspace.dependencies]
-hifitime = "4.3.0"
+# hifitime = "4.3.0"
+hifitime = {path = "../hifitime"}
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }
@@ -41,9 +42,9 @@ zerocopy = { version = "0.8.0", features = ["derive"] }
 bytes = "1.6.0"
 snafu = { version = "0.9.0", features = ["backtrace"] }
 rstest = "0.26.1"
-pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
-pyo3-log = "0.13.3"
-numpy = "0.28"
+pyo3 = { version = "0.29", features = ["multiple-pymethods"] }
+pyo3-log = "0.13.4"
+numpy = "0.29"
 ndarray = ">= 0.17, < 0.18"
 rayon = "1.10.0"
 cxx = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 
 [workspace.dependencies]
 # hifitime = "4.3.0"
-hifitime = {path = "../hifitime"}
+hifitime = {git = "https://github.com/nyx-space/hifitime", branch="perf-changes"}
 memmap2 = "0.9.4"
 crc32fast = "1.4.2"
 der = { version = "0.7.8", features = ["derive", "alloc", "real"] }

--- a/anise/fuzz/fuzz_targets/common_ephemeris_path.rs
+++ b/anise/fuzz/fuzz_targets/common_ephemeris_path.rs
@@ -17,7 +17,7 @@ fuzz_target!(
 
         let bytes = BytesMut::from(data.0);
         if let Ok(almanac) = almanac.load_from_bytes(bytes) {
-            let _ = almanac.common_ephemeris_path(from_frame, to_frame, epoch);
+            let _ = almanac.common_ephemeris_path(from_frame, to_frame, epoch.to_et_seconds());
         }
     }
 );

--- a/anise/src/almanac/bpc.rs
+++ b/anise/src/almanac/bpc.rs
@@ -96,7 +96,9 @@ impl Almanac {
         epoch: Epoch,
     ) -> Result<(&BPCSummaryRecord, usize, Option<usize>, usize), OrientationError> {
         for (no, bpc) in self.bpc_data.values().rev().enumerate() {
-            if let Ok((summary, daf_idx, idx_in_bpc)) = bpc.summary_from_id_at_epoch(id, epoch) {
+            if let Ok((summary, daf_idx, idx_in_bpc)) =
+                bpc.summary_from_id_at_epoch(id, epoch.to_et_seconds())
+            {
                 // NOTE: We're iterating backward, so the correct BPC number is "total loaded" minus "current iteration".
                 return Ok((summary, self.num_loaded_bpc() - no - 1, daf_idx, idx_in_bpc));
             }

--- a/anise/src/almanac/python.rs
+++ b/anise/src/almanac/python.rs
@@ -326,7 +326,7 @@ impl Almanac {
                         )
                 })
                 .collect::<Vec<AzElRange>>();
-            rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
+            rslt.sort_by_key(|aer| aer.epoch);
             rslt
         })
     }
@@ -469,7 +469,7 @@ impl Almanac {
                         )
                 })
                 .collect::<Vec<Occultation>>();
-            rslt.sort_by(|aer_a, aer_b| aer_a.epoch.cmp(&aer_b.epoch));
+            rslt.sort_by_key(|aer| aer.epoch);
             rslt
         })
     }
@@ -567,7 +567,7 @@ impl Almanac {
                         )
                 })
                 .collect::<Vec<CartesianState>>();
-            states.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
+            states.sort_by_key(|state| state.epoch);
             states
         })
     }
@@ -628,7 +628,7 @@ impl Almanac {
                         )
                 })
                 .collect::<Vec<CartesianState>>();
-            rslt.sort_by(|state_a, state_b| state_a.epoch.cmp(&state_b.epoch));
+            rslt.sort_by_key(|state| state.epoch);
             rslt
         })
     }

--- a/anise/src/almanac/spk.rs
+++ b/anise/src/almanac/spk.rs
@@ -105,10 +105,11 @@ impl Almanac {
     pub fn spk_summary_at_epoch(
         &self,
         id: i32,
-        epoch: Epoch,
+        epoch_et_s: f64,
     ) -> Result<(&SPKSummaryRecord, usize, Option<usize>, usize), EphemerisError> {
         for (spk_no, spk) in self.spk_data.values().rev().enumerate() {
-            if let Ok((summary, daf_idx, idx_in_spk)) = spk.summary_from_id_at_epoch(id, epoch) {
+            if let Ok((summary, daf_idx, idx_in_spk)) = spk.summary_from_id_at_epoch(id, epoch_et_s)
+            {
                 // NOTE: We're iterating backward, so the correct SPK number is "total loaded" minus "current iteration".
                 return Ok((
                     summary,
@@ -121,14 +122,16 @@ impl Almanac {
 
         // If the ID is not present at all, spk_domain will report it.
         let (start, end) = self.spk_domain(id)?;
-        error!("Almanac: summary {id} valid from {start} to {end} but not at requested {epoch}");
+        error!(
+            "Almanac: summary {id} valid from {start} to {end} but not at requested {epoch_et_s}"
+        );
         // If we're reached this point, there is no relevant summary at this epoch.
         Err(EphemerisError::SPK {
             action: "searching for SPK summary",
             source: DAFError::SummaryIdAtEpochError {
                 kind: "SPK",
                 id,
-                epoch,
+                epoch: Epoch::from_et_seconds(epoch_et_s),
                 start,
                 end,
             },
@@ -298,7 +301,7 @@ mod ut_almanac_spk {
             "empty Almanac should report an error"
         );
         assert!(
-            almanac.spk_summary_at_epoch(0, e).is_err(),
+            almanac.spk_summary_at_epoch(0, e.to_et_seconds()).is_err(),
             "empty Almanac should report an error"
         );
         assert!(
@@ -324,13 +327,15 @@ mod ut_almanac_spk {
         );
 
         assert!(
-            almanac.ephemeris_path_to_root(MOON_J2000, e).is_err(),
+            almanac
+                .ephemeris_path_to_root(MOON_J2000, e.to_et_seconds())
+                .is_err(),
             "empty Almanac should report an error"
         );
 
         assert!(
             almanac
-                .common_ephemeris_path(MOON_J2000, EARTH_J2000, e)
+                .common_ephemeris_path(MOON_J2000, EARTH_J2000, e.to_et_seconds())
                 .is_err(),
             "empty Almanac should report an error"
         );

--- a/anise/src/astro/orbit_equinoctial.rs
+++ b/anise/src/astro/orbit_equinoctial.rs
@@ -154,6 +154,7 @@ impl Orbit {
     /// :rtype: Orbit
     #[cfg(feature = "python")]
     #[classmethod]
+    #[allow(clippy::too_many_arguments)]
     pub fn from_equinoctial(
         _cls: &Bound<'_, PyType>,
         sma_km: f64,

--- a/anise/src/ephemerides/ephemeris/spk.rs
+++ b/anise/src/ephemerides/ephemeris/spk.rs
@@ -180,6 +180,7 @@ impl Ephemeris {
 
         // Finally, builds the DAF!
         let mut spk = SPK {
+            file_record: FileRecord::default(),
             bytes: BytesMut::from(&padded_bytes[..]),
             crc32: None,
             index: HashMap::new(),

--- a/anise/src/ephemerides/ephemeris/spk.rs
+++ b/anise/src/ephemerides/ephemeris/spk.rs
@@ -22,6 +22,7 @@ use log::warn;
 use snafu::ensure;
 use std::collections::HashMap;
 use std::{fs::File, io::Write};
+use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 
 use super::Ephemeris;
@@ -180,7 +181,8 @@ impl Ephemeris {
 
         // Finally, builds the DAF!
         let mut spk = SPK {
-            file_record: FileRecord::default(),
+            file_record: FileRecord::read_from_bytes(&padded_bytes[..1024])
+                .expect("failed to parse FileRecord"),
             bytes: BytesMut::from(&padded_bytes[..]),
             crc32: None,
             index: HashMap::new(),

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -247,15 +247,17 @@ mod path_depth_ut {
         let mut summary_block = Vec::new();
         summary_block.extend_from_slice(header.as_bytes());
         for target in (2..=10).rev() {
-            let mut summary = SPKSummaryRecord::default();
-            summary.start_epoch_et_s = -1e9;
-            summary.end_epoch_et_s = 1e9;
-            summary.target_id = target;
-            summary.center_id = target - 1;
-            summary.frame_id = 1;
-            summary.data_type_i = 2;
-            summary.start_idx = 1;
-            summary.end_idx = 100;
+            let summary = SPKSummaryRecord {
+                start_epoch_et_s: -1e9,
+                end_epoch_et_s: 1e9,
+                target_id: target,
+                center_id: target - 1,
+                frame_id: 1,
+                data_type_i: 2,
+                start_idx: 1,
+                end_idx: 100,
+            };
+
             summary_block.extend_from_slice(summary.as_bytes());
         }
         summary_block.resize(1024, 0);

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -63,7 +63,7 @@ impl Almanac {
     pub fn ephemeris_path_to_root(
         &self,
         source: Frame,
-        epoch: Epoch,
+        epoch_et_s: f64,
     ) -> Result<(usize, [Option<NaifId>; MAX_TREE_DEPTH]), EphemerisError> {
         let common_center = self.try_find_ephemeris_root()?;
         // Build a tree, set a fixed depth to avoid allocations
@@ -76,7 +76,9 @@ impl Almanac {
         }
 
         // Grab the summary data, which we use to find the paths
-        let summary = self.spk_summary_at_epoch(source.ephemeris_id, epoch)?.0;
+        let summary = self
+            .spk_summary_at_epoch(source.ephemeris_id, epoch_et_s)?
+            .0;
 
         let mut center_id = summary.center_id;
 
@@ -89,7 +91,7 @@ impl Almanac {
         }
 
         for _ in 0..MAX_TREE_DEPTH {
-            let summary = self.spk_summary_at_epoch(center_id, epoch)?.0;
+            let summary = self.spk_summary_at_epoch(center_id, epoch_et_s)?.0;
             center_id = summary.center_id;
             if of_path_len >= MAX_TREE_DEPTH {
                 return Err(EphemerisError::SPK {
@@ -144,7 +146,7 @@ impl Almanac {
         &self,
         from_frame: Frame,
         to_frame: Frame,
-        epoch: Epoch,
+        epoch_et_s: f64,
     ) -> Result<(usize, [Option<NaifId>; MAX_TREE_DEPTH], NaifId), EphemerisError> {
         if from_frame == to_frame {
             // Both frames match, return this frame's hash (i.e. no need to go higher up).
@@ -152,8 +154,8 @@ impl Almanac {
         }
 
         // Grab the paths
-        let (from_len, from_path) = self.ephemeris_path_to_root(from_frame, epoch)?;
-        let (to_len, to_path) = self.ephemeris_path_to_root(to_frame, epoch)?;
+        let (from_len, from_path) = self.ephemeris_path_to_root(from_frame, epoch_et_s)?;
+        let (to_len, to_path) = self.ephemeris_path_to_root(to_frame, epoch_et_s)?;
 
         // Now that we have the paths, we can find the matching origin.
 
@@ -163,7 +165,7 @@ impl Almanac {
             Err(EphemerisError::TranslationOrigin {
                 from: from_frame.into(),
                 to: to_frame.into(),
-                epoch,
+                epoch: Epoch::from_et_seconds(epoch_et_s),
             })
         } else if from_len != 0 && to_len == 0 {
             // One has an empty path but not the other, so the root is at the empty path
@@ -268,7 +270,7 @@ mod path_depth_ut {
         let source = Frame::from_ephem_j2000(10);
         let epoch = Epoch::from_et_seconds(0.0);
 
-        let result = almanac.ephemeris_path_to_root(source, epoch);
+        let result = almanac.ephemeris_path_to_root(source, epoch.to_et_seconds());
         assert!(
             result.is_err(),
             "a chain deeper than MAX_TREE_DEPTH must error, not panic"

--- a/anise/src/ephemerides/translate_to_parent.rs
+++ b/anise/src/ephemerides/translate_to_parent.rs
@@ -39,11 +39,11 @@ impl Almanac {
     pub(crate) fn translation_parts_to_parent(
         &self,
         source: Frame,
-        epoch: Epoch,
+        epoch_et_s: f64,
     ) -> Result<(Vector3, Vector3, Frame), EphemerisError> {
         // First, let's find the SPK summary for this frame.
         let (summary, spk_no, daf_idx, idx_in_spk) =
-            self.spk_summary_at_epoch(source.ephemeris_id, epoch)?;
+            self.spk_summary_at_epoch(source.ephemeris_id, epoch_et_s)?;
 
         let new_frame = source.with_ephem(summary.center_id);
 
@@ -62,7 +62,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type2ChebyshevTriplet => {
@@ -71,7 +71,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type3ChebyshevSextuplet => {
@@ -80,7 +80,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type8LagrangeEqualStep => {
@@ -89,7 +89,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type9LagrangeUnequalStep => {
@@ -98,7 +98,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type12HermiteEqualStep => {
@@ -107,7 +107,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             DafDataType::Type13HermiteUnequalStep => {
@@ -116,7 +116,7 @@ impl Almanac {
                     .context(SPKSnafu {
                         action: "fetching data for interpolation",
                     })?;
-                data.evaluate(epoch, summary)
+                data.evaluate(epoch_et_s, summary)
                     .context(EphemInterpolationSnafu)?
             }
             dtype => {
@@ -146,7 +146,8 @@ impl Almanac {
         source: Frame,
         epoch: Epoch,
     ) -> Result<CartesianState, EphemerisError> {
-        let (radius_km, velocity_km_s, frame) = self.translation_parts_to_parent(source, epoch)?;
+        let (radius_km, velocity_km_s, frame) =
+            self.translation_parts_to_parent(source, epoch.to_et_seconds())?;
 
         Ok(CartesianState {
             radius_km,

--- a/anise/src/ephemerides/translations.rs
+++ b/anise/src/ephemerides/translations.rs
@@ -67,11 +67,13 @@ impl Almanac {
             observer_frame = obs_frame_info;
         }
 
+        let epoch_et_s = epoch.to_et_seconds();
+
         match ab_corr {
             None => {
                 // Geometric case (no aberration correction)
                 let (node_count, _path, common_node) =
-                    self.common_ephemeris_path(observer_frame, target_frame, epoch)?;
+                    self.common_ephemeris_path(observer_frame, target_frame, epoch_et_s)?;
 
                 // The `fwrd` variables store the state of the observer frame relative to the common ancestor.
                 let (mut pos_fwrd, mut vel_fwrd, mut frame_fwrd) =
@@ -79,7 +81,7 @@ impl Almanac {
                         // Observer is the common ancestor, so state is zero.
                         (Vector3::zeros(), Vector3::zeros(), observer_frame)
                     } else {
-                        self.translation_parts_to_parent(observer_frame, epoch)?
+                        self.translation_parts_to_parent(observer_frame, epoch_et_s)?
                     };
 
                 // The `bwrd` variables store the state of the target frame relative to the common ancestor.
@@ -88,7 +90,7 @@ impl Almanac {
                         // Target is the common ancestor, so state is zero.
                         (Vector3::zeros(), Vector3::zeros(), target_frame)
                     } else {
-                        self.translation_parts_to_parent(target_frame, epoch)?
+                        self.translation_parts_to_parent(target_frame, epoch_et_s)?
                     };
 
                 // Traverse the ephemeris tree from both the observer and target up to the common ancestor.
@@ -96,7 +98,7 @@ impl Almanac {
                     if !frame_fwrd.ephem_origin_id_match(common_node) {
                         // Accumulate the state from the current forward frame to its parent.
                         let (cur_pos_fwrd, cur_vel_fwrd, cur_frame_fwrd) =
-                            self.translation_parts_to_parent(frame_fwrd, epoch)?;
+                            self.translation_parts_to_parent(frame_fwrd, epoch_et_s)?;
 
                         pos_fwrd += cur_pos_fwrd;
                         vel_fwrd += cur_vel_fwrd;
@@ -106,7 +108,7 @@ impl Almanac {
                     if !frame_bwrd.ephem_origin_id_match(common_node) {
                         // Accumulate the state from the current backward frame to its parent.
                         let (cur_pos_bwrd, cur_vel_bwrd, cur_frame_bwrd) =
-                            self.translation_parts_to_parent(frame_bwrd, epoch)?;
+                            self.translation_parts_to_parent(frame_bwrd, epoch_et_s)?;
 
                         pos_bwrd += cur_pos_bwrd;
                         vel_bwrd += cur_vel_bwrd;

--- a/anise/src/frames/dynamic.rs
+++ b/anise/src/frames/dynamic.rs
@@ -186,6 +186,7 @@ impl DynamicFrame {
         Self::try_from(frame_id as u32).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_frame_id(&self) -> i32 {
         Into::<i32>::into(*self)
     }

--- a/anise/src/frames/frame.rs
+++ b/anise/src/frames/frame.rs
@@ -707,7 +707,7 @@ mod frame_ut {
     #[test]
     fn mars_centered_inertial() {
         use crate::constants::frames::MARS_INERTIAL_FRAME;
-        assert!(MARS_INERTIAL_FRAME.force_inertial);
+        const { assert!(MARS_INERTIAL_FRAME.force_inertial) };
         assert_eq!(
             MARS_INERTIAL_FRAME.frozen_epoch.unwrap(),
             Epoch::from_et_seconds(0.0)

--- a/anise/src/math/interpolation/chebyshev.rs
+++ b/anise/src/math/interpolation/chebyshev.rs
@@ -22,7 +22,7 @@ pub fn chebyshev_eval(
     normalized_time: f64,
     spline_coeffs: &[f64],
     spline_radius_s: f64,
-    eval_epoch: Epoch,
+    eval_epoch_et_s: f64,
     degree: usize,
 ) -> Result<(f64, f64), InterpolationError> {
     if spline_radius_s.abs() < f64::EPSILON {
@@ -41,7 +41,9 @@ pub fn chebyshev_eval(
         w[1] = w[0];
         w[0] = (spline_coeffs
             .get(j - 1)
-            .ok_or(InterpolationError::MissingInterpolationData { epoch: eval_epoch })?)
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?)
             + (2.0 * normalized_time * w[1] - w[2]);
 
         dw[2] = dw[1];
@@ -51,7 +53,9 @@ pub fn chebyshev_eval(
 
     let val = (spline_coeffs
         .first()
-        .ok_or(InterpolationError::MissingInterpolationData { epoch: eval_epoch })?)
+        .ok_or(InterpolationError::MissingInterpolationData {
+            epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+        })?)
         + (normalized_time * w[0] - w[1]);
 
     let deriv = (w[0] + normalized_time * dw[0] - dw[1]) / spline_radius_s;
@@ -65,7 +69,7 @@ pub fn chebyshev_eval(
 pub fn chebyshev_eval_poly(
     normalized_time: f64,
     spline_coeffs: &[f64],
-    eval_epoch: Epoch,
+    eval_epoch_et_s: f64,
     degree: usize,
 ) -> Result<f64, InterpolationError> {
     // Workspace array
@@ -76,7 +80,9 @@ pub fn chebyshev_eval_poly(
         w[1] = w[0];
         w[0] = (spline_coeffs
             .get(j - 1)
-            .ok_or(InterpolationError::MissingInterpolationData { epoch: eval_epoch })?)
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?)
             + (2.0 * normalized_time * w[1] - w[2]);
     }
 
@@ -87,7 +93,9 @@ pub fn chebyshev_eval_poly(
     let val = (normalized_time * w[0]) - w[1]
         + (spline_coeffs
             .first()
-            .ok_or(InterpolationError::MissingInterpolationData { epoch: eval_epoch })?);
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?);
 
     Ok(val)
 }

--- a/anise/src/math/interpolation/chebyshev.rs
+++ b/anise/src/math/interpolation/chebyshev.rs
@@ -11,6 +11,7 @@
 use crate::errors::MathError;
 
 use hifitime::Epoch;
+use nalgebra::{Vector3, Vector4};
 
 use super::InterpolationError;
 
@@ -20,11 +21,13 @@ use super::InterpolationError;
 /// 1. At this point, the splines are expected to be in Chebyshev format and no verification is done.
 pub fn chebyshev_eval(
     normalized_time: f64,
-    spline_coeffs: &[f64],
+    spline_coeffs_x: &[f64],
+    spline_coeffs_y: &[f64],
+    spline_coeffs_z: &[f64],
     spline_radius_s: f64,
     eval_epoch_et_s: f64,
     degree: usize,
-) -> Result<(f64, f64), InterpolationError> {
+) -> Result<(Vector3<f64>, Vector3<f64>), InterpolationError> {
     if spline_radius_s.abs() < f64::EPSILON {
         return Err(InterpolationError::InterpMath {
             source: MathError::DivisionByZero {
@@ -32,33 +35,67 @@ pub fn chebyshev_eval(
             },
         });
     }
-    // Workspace arrays
-    let mut w = [0.0_f64; 3];
-    let mut dw = [0.0_f64; 3];
+
+    // Workspace arrays, all in Vector4 to force SIMD where possible.
+    let mut w = [Vector4::zeros(); 3];
+    let mut dw = [Vector4::zeros(); 3];
 
     for j in (2..=degree + 1).rev() {
         w[2] = w[1];
         w[1] = w[0];
-        w[0] = (spline_coeffs
-            .get(j - 1)
-            .ok_or(InterpolationError::MissingInterpolationData {
-                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
-            })?)
-            + (2.0 * normalized_time * w[1] - w[2]);
+
+        let c = Vector4::new(
+            *spline_coeffs_x
+                .get(j - 1)
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+                })?,
+            *spline_coeffs_y
+                .get(j - 1)
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+                })?,
+            *spline_coeffs_z
+                .get(j - 1)
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+                })?,
+            0.0,
+        );
+
+        w[0] = c + (2.0 * normalized_time * w[1] - w[2]);
 
         dw[2] = dw[1];
         dw[1] = dw[0];
         dw[0] = w[1] * 2. + dw[1] * 2.0 * normalized_time - dw[2];
     }
 
-    let val = (spline_coeffs
-        .first()
-        .ok_or(InterpolationError::MissingInterpolationData {
-            epoch: Epoch::from_et_seconds(eval_epoch_et_s),
-        })?)
-        + (normalized_time * w[0] - w[1]);
+    let c0 = Vector4::new(
+        *spline_coeffs_x
+            .first()
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?,
+        *spline_coeffs_y
+            .first()
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?,
+        *spline_coeffs_z
+            .first()
+            .ok_or(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(eval_epoch_et_s),
+            })?,
+        0.0,
+    );
 
-    let deriv = (w[0] + normalized_time * dw[0] - dw[1]) / spline_radius_s;
+    let val = (c0 + (normalized_time * w[0] - w[1]))
+        .fixed_rows::<3>(0)
+        .into_owned();
+
+    let deriv = ((w[0] + normalized_time * dw[0] - dw[1]) / spline_radius_s)
+        .fixed_rows::<3>(0)
+        .into_owned();
     Ok((val, deriv))
 }
 

--- a/anise/src/math/rotation/dcm_py.rs
+++ b/anise/src/math/rotation/dcm_py.rs
@@ -303,6 +303,7 @@ impl DCM {
         self.to = to_id;
     }
 
+    #[allow(clippy::wrong_self_convention)]
     /// :rtype: Quaternion
     fn to_quaternion(&self) -> Quaternion {
         Quaternion::from(*self)

--- a/anise/src/math/rotation/quaternion_py.rs
+++ b/anise/src/math/rotation/quaternion_py.rs
@@ -146,6 +146,7 @@ impl EulerParameter {
         PyArray1::<f64>::from_owned_array(py, vec)
     }
 
+    #[allow(clippy::wrong_self_convention)]
     /// Convert this quaterion to a DCM
     /// :rtype: DCM
     fn to_dcm(&self) -> DCM {

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -958,10 +958,12 @@ mod daf_ut {
                 prev_record: 0.0,
                 num_summaries: 1.0,
             };
-            let mut summary = SPKSummaryRecord::default();
-            summary.data_type_i = 13;
-            summary.start_idx = 1;
-            summary.end_idx = 5;
+            let summary = SPKSummaryRecord {
+                data_type_i: 13,
+                start_idx: 1,
+                end_idx: 5,
+                ..Default::default()
+            };
 
             bytes.extend_from_slice(summary_header.as_bytes());
             bytes.extend_from_slice(summary.as_bytes());
@@ -1035,10 +1037,12 @@ mod daf_ut {
             prev_record: 0.0,
             num_summaries: 1.0,
         };
-        let mut summary = SPKSummaryRecord::default();
-        summary.data_type_i = 13;
-        summary.start_idx = 0; // 1-based index, so 0 is malformed
-        summary.end_idx = 5;
+        let summary = SPKSummaryRecord {
+            data_type_i: 13,
+            start_idx: 0,
+            end_idx: 5,
+            ..Default::default()
+        };
 
         let mut summary_record = Vec::new();
         summary_record.extend_from_slice(summary_header.as_bytes());

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -56,7 +56,7 @@ fn file_record<R: NAIFSummaryRecord>(bytes: &[u8]) -> Result<FileRecord, DAFErro
     let file_record = FileRecord::read_from_bytes(
         bytes
             .get(..FileRecord::SIZE)
-            .ok_or_else(|| DecodingError::InaccessibleBytes {
+            .ok_or(DecodingError::InaccessibleBytes {
                 start: 0,
                 end: FileRecord::SIZE,
                 size: bytes.len(),
@@ -92,8 +92,7 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     /// 2.  The CRC32 checksum of the bytes is computed.
     /// 3.  The `file_record` and `name_record` are parsed to ensure the file is a valid DAF.
     pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
-        // Parse file record
-
+        // Parse file record once.
         let mut me = Self {
             file_record: file_record::<R>(&bytes[..])?,
             bytes: BytesMut::from(&bytes[..]),

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -43,10 +43,39 @@ pub(crate) const RCRD_LEN: usize = 1024;
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct DAF<R: NAIFSummaryRecord> {
     pub bytes: BytesMut,
+    pub file_record: FileRecord,
     /// CRC32 field enables memory scrubbing, reducing memory errors in a radiation-laden environment.
     pub crc32: Option<u32>,
     /// Index of the NAIF ID to its summary record only if all of the summaries for this ID are chronologically ordered. Enables binary search for that ID.
     pub index: HashMap<i32, Vec<(R, Option<usize>, usize)>>,
+}
+
+/// Reads and parses the file record from the DAF bytes.
+/// The file record is always the first 1024 bytes of the file.
+fn file_record<R: NAIFSummaryRecord>(bytes: &[u8]) -> Result<FileRecord, DAFError> {
+    let file_record = FileRecord::read_from_bytes(
+        bytes
+            .get(..FileRecord::SIZE)
+            .ok_or_else(|| DecodingError::InaccessibleBytes {
+                start: 0,
+                end: FileRecord::SIZE,
+                size: bytes.len(),
+            })
+            .context(DecodingDataSnafu {
+                idx: 0_usize,
+                kind: R::NAME,
+            })?,
+    )
+    .map_err(|_| DAFError::DecodingData {
+        kind: R::NAME,
+        idx: 0,
+        source: DecodingError::Casting,
+    })?;
+    // Check that the endian-ness is compatible with this platform.
+    file_record
+        .endianness()
+        .context(FileRecordSnafu { kind: R::NAME })?;
+    Ok(file_record)
 }
 
 impl<R: NAIFSummaryRecord> DAF<R> {
@@ -63,14 +92,17 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     /// 2.  The CRC32 checksum of the bytes is computed.
     /// 3.  The `file_record` and `name_record` are parsed to ensure the file is a valid DAF.
     pub fn parse<B: Deref<Target = [u8]>>(bytes: B) -> Result<Self, DAFError> {
+        // Parse file record
+
         let mut me = Self {
+            file_record: file_record::<R>(&bytes[..])?,
             bytes: BytesMut::from(&bytes[..]),
             crc32: None,
             index: HashMap::new(),
         };
         // Check that the file record and name record can be parsed successfully.
         // This validates that the file is a DAF and that the endianness is correct.
-        me.file_record()?;
+        // me.file_record()?;
         // Ensure tha twe can parse the first name record.
         me.name_record(None)?;
         // Build the index for all of the NAIF IDs which are ordered in the file.
@@ -174,29 +206,30 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     /// Reads and parses the file record from the DAF bytes.
     /// The file record is always the first 1024 bytes of the file.
     pub fn file_record(&self) -> Result<FileRecord, DAFError> {
-        let file_record = FileRecord::read_from_bytes(
-            self.bytes
-                .get(..FileRecord::SIZE)
-                .ok_or_else(|| DecodingError::InaccessibleBytes {
-                    start: 0,
-                    end: FileRecord::SIZE,
-                    size: self.bytes.len(),
-                })
-                .context(DecodingDataSnafu {
-                    idx: 0_usize,
-                    kind: R::NAME,
-                })?,
-        )
-        .map_err(|_| DAFError::DecodingData {
-            kind: R::NAME,
-            idx: 0,
-            source: DecodingError::Casting,
-        })?;
-        // Check that the endian-ness is compatible with this platform.
-        file_record
-            .endianness()
-            .context(FileRecordSnafu { kind: R::NAME })?;
-        Ok(file_record)
+        Ok(self.file_record)
+        // let file_record = FileRecord::read_from_bytes(
+        //     self.bytes
+        //         .get(..FileRecord::SIZE)
+        //         .ok_or_else(|| DecodingError::InaccessibleBytes {
+        //             start: 0,
+        //             end: FileRecord::SIZE,
+        //             size: self.bytes.len(),
+        //         })
+        //         .context(DecodingDataSnafu {
+        //             idx: 0_usize,
+        //             kind: R::NAME,
+        //         })?,
+        // )
+        // .map_err(|_| DAFError::DecodingData {
+        //     kind: R::NAME,
+        //     idx: 0,
+        //     source: DecodingError::Casting,
+        // })?;
+        // // Check that the endian-ness is compatible with this platform.
+        // file_record
+        //     .endianness()
+        //     .context(FileRecordSnafu { kind: R::NAME })?;
+        // Ok(file_record)
     }
 
     /// Reads and parses the name record from the DAF bytes.

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -401,28 +401,28 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     pub fn summary_from_id_at_epoch(
         &self,
         id: i32,
-        epoch: Epoch,
+        epoch_et_s: f64,
     ) -> Result<(&R, Option<usize>, usize), DAFError> {
         // If the summaries are ordered in the DAF file, then they are in the index, so we can run a binary search to find the proper index.
         if let Some(idx_data) = self.index.get(&id) {
             let idx = idx_data.partition_point(|(summary, _blk_idx, _summary_idx)| {
-                summary.start_epoch() - Unit::Nanosecond * 100 <= epoch
+                summary.start_epoch_et_s() - 100e-9 <= epoch_et_s
             });
             if idx == 0 {
                 Err(DAFError::InterpolationDataErrorFromId {
                     kind: R::NAME,
                     id,
-                    epoch,
+                    epoch: Epoch::from_et_seconds(epoch_et_s),
                 })
             } else {
                 let (summary, blk_idx, summary_idx) = &idx_data[idx - 1];
-                if epoch <= summary.end_epoch() + Unit::Nanosecond * 100 {
+                if epoch_et_s <= summary.end_epoch_et_s() + 100e-9 {
                     Ok((summary, *blk_idx, *summary_idx))
                 } else {
                     Err(DAFError::InterpolationDataErrorFromId {
                         kind: R::NAME,
                         id,
-                        epoch,
+                        epoch: Epoch::from_et_seconds(epoch_et_s),
                     })
                 }
             }
@@ -433,8 +433,8 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             loop {
                 for (summary_idx, summary) in self.data_summaries(blk_idx)?.iter().enumerate() {
                     if summary.id() == id
-                        && epoch >= summary.start_epoch() - Unit::Nanosecond * 100
-                        && epoch <= summary.end_epoch() + Unit::Nanosecond * 100
+                        && epoch_et_s >= summary.start_epoch_et_s() - 100e-9
+                        && epoch_et_s <= summary.end_epoch_et_s() + 100e-9
                     {
                         return Ok((summary, blk_idx, summary_idx));
                     }
@@ -449,7 +449,7 @@ impl<R: NAIFSummaryRecord> DAF<R> {
             Err(DAFError::InterpolationDataErrorFromId {
                 kind: R::NAME,
                 id,
-                epoch,
+                epoch: Epoch::from_et_seconds(epoch_et_s),
             })
         }
     }

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -207,8 +207,8 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         let (state, rate) = chebyshev_eval(
             normalized_time,
             record.x_coeffs,
-            record.x_coeffs,
-            record.x_coeffs,
+            record.y_coeffs,
+            record.z_coeffs,
             radius_s,
             epoch_et_s,
             self.degree(),

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -37,15 +37,15 @@ impl Type2ChebyshevSet<'_> {
 
     fn spline_idx<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<usize, InterpolationError> {
-        if epoch < summary.start_epoch() - 1_i64.nanoseconds()
-            || epoch > summary.end_epoch() + 1_i64.nanoseconds()
+        if epoch_et_s < summary.start_epoch_et_s() - 1.0
+            || epoch_et_s > summary.end_epoch_et_s() + 1.0
         {
             // No need to go any further.
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: summary.start_epoch(),
                 end: summary.end_epoch(),
             });
@@ -55,7 +55,7 @@ impl Type2ChebyshevSet<'_> {
 
         // For trimmed kernels, the summary bounds may no longer align exactly with the
         // dataset footer epoch. Use the dataset init epoch for record selection.
-        let ephem_start_delta_s = epoch.to_et_seconds() - self.init_epoch.to_et_seconds();
+        let ephem_start_delta_s = epoch_et_s - self.init_epoch.to_et_seconds();
 
         // A tiny interval length makes this ratio saturate the usize cast, so add with
         // saturation to avoid an overflow panic before the clamp to num_records.
@@ -189,10 +189,10 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<(Vector3, Vector3), InterpolationError> {
-        let spline_idx = self.spline_idx(epoch, summary)?;
+        let spline_idx = self.spline_idx(epoch_et_s, summary)?;
 
         let window_duration_s = self.interval_length.to_seconds();
         let radius_s = window_duration_s / 2.0;
@@ -202,7 +202,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
             .nth_record(spline_idx - 1)
             .context(InterpDecodingSnafu)?;
 
-        let normalized_time = (epoch.to_et_seconds() - record.midpoint_et_s) / radius_s;
+        let normalized_time = (epoch_et_s - record.midpoint_et_s) / radius_s;
 
         let mut state = Vector3::zeros();
         let mut rate = Vector3::zeros();
@@ -212,7 +212,7 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
             .enumerate()
         {
             let (val, deriv) =
-                chebyshev_eval(normalized_time, coeffs, radius_s, epoch, self.degree())?;
+                chebyshev_eval(normalized_time, coeffs, radius_s, epoch_et_s, self.degree())?;
             state[cno] = val;
             rate[cno] = deriv;
         }
@@ -241,13 +241,13 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
         new_end: Option<Epoch>,
     ) -> Result<Self, InterpolationError> {
         let start_idx = if let Some(start) = new_start {
-            self.spline_idx(start, summary)? - 1
+            self.spline_idx(start.to_et_seconds(), summary)? - 1
         } else {
             0
         };
 
         let end_idx = if let Some(end) = new_end {
-            self.spline_idx(end, summary)? - 1
+            self.spline_idx(end.to_et_seconds(), summary)? - 1
         } else {
             self.num_records - 1
         };
@@ -504,7 +504,7 @@ mod chebyshev_ut {
             end_idx: 19,
         };
 
-        let epoch = Epoch::from_et_seconds(12.0);
+        let epoch = 12.0;
         assert_eq!(dataset.spline_idx(epoch, &shifted_summary).unwrap(), 2);
 
         let (state, _) = dataset.evaluate(epoch, &shifted_summary).unwrap();
@@ -533,7 +533,7 @@ mod chebyshev_ut {
             start_idx: 1,
             end_idx: 9,
         };
-        let epoch = Epoch::from_et_seconds(1000.0);
+        let epoch = 1000.0;
         assert_eq!(dataset.spline_idx(epoch, &summary).unwrap(), 1);
         // The full evaluate path must not panic on this input.
         let _ = dataset.evaluate(epoch, &summary);

--- a/anise/src/naif/daf/datatypes/chebyshev.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev.rs
@@ -40,8 +40,8 @@ impl Type2ChebyshevSet<'_> {
         epoch_et_s: f64,
         summary: &S,
     ) -> Result<usize, InterpolationError> {
-        if epoch_et_s < summary.start_epoch_et_s() - 1.0
-            || epoch_et_s > summary.end_epoch_et_s() + 1.0
+        if epoch_et_s < summary.start_epoch_et_s().next_down()
+            || epoch_et_s > summary.end_epoch_et_s().next_up()
         {
             // No need to go any further.
             return Err(InterpolationError::NoInterpolationData {
@@ -204,18 +204,15 @@ impl<'a> NAIFDataSet<'a> for Type2ChebyshevSet<'a> {
 
         let normalized_time = (epoch_et_s - record.midpoint_et_s) / radius_s;
 
-        let mut state = Vector3::zeros();
-        let mut rate = Vector3::zeros();
-
-        for (cno, coeffs) in [record.x_coeffs, record.y_coeffs, record.z_coeffs]
-            .iter()
-            .enumerate()
-        {
-            let (val, deriv) =
-                chebyshev_eval(normalized_time, coeffs, radius_s, epoch_et_s, self.degree())?;
-            state[cno] = val;
-            rate[cno] = deriv;
-        }
+        let (state, rate) = chebyshev_eval(
+            normalized_time,
+            record.x_coeffs,
+            record.x_coeffs,
+            record.x_coeffs,
+            radius_s,
+            epoch_et_s,
+            self.degree(),
+        )?;
 
         Ok((state, rate))
     }

--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -37,15 +37,15 @@ impl Type3ChebyshevSet<'_> {
 
     fn spline_idx<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<usize, InterpolationError> {
-        if epoch < summary.start_epoch() - 1_i64.nanoseconds()
-            || epoch > summary.end_epoch() + 1_i64.nanoseconds()
+        if epoch_et_s < summary.start_epoch_et_s() - 1.0
+            || epoch_et_s > summary.end_epoch_et_s() + 1.0
         {
             // No need to go any further.
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: summary.start_epoch(),
                 end: summary.end_epoch(),
             });
@@ -55,7 +55,7 @@ impl Type3ChebyshevSet<'_> {
 
         // For trimmed kernels, the summary bounds may no longer align exactly with the
         // dataset footer epoch. Use the dataset init epoch for record selection.
-        let ephem_start_delta_s = epoch.to_et_seconds() - self.init_epoch.to_et_seconds();
+        let ephem_start_delta_s = epoch_et_s - self.init_epoch.to_et_seconds();
 
         // A tiny interval length makes this ratio saturate the usize cast, so add with
         // saturation to avoid an overflow panic before the clamp to num_records.
@@ -190,10 +190,10 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<(Vector3, Vector3), InterpolationError> {
-        let spline_idx = self.spline_idx(epoch, summary)?;
+        let spline_idx = self.spline_idx(epoch_et_s, summary)?;
 
         let window_duration_s = self.interval_length.to_seconds();
         let radius_s = window_duration_s / 2.0;
@@ -202,7 +202,7 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
             .nth_record(spline_idx - 1)
             .context(InterpDecodingSnafu)?;
 
-        let normalized_time = (epoch.to_et_seconds() - record.midpoint_et_s) / radius_s;
+        let normalized_time = (epoch_et_s - record.midpoint_et_s) / radius_s;
 
         let mut state = Vector3::zeros();
         let mut rate = Vector3::zeros();
@@ -211,7 +211,7 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
             .iter()
             .enumerate()
         {
-            let val = chebyshev_eval_poly(normalized_time, coeffs, epoch, self.degree())?;
+            let val = chebyshev_eval_poly(normalized_time, coeffs, epoch_et_s, self.degree())?;
             state[cno] = val;
         }
 
@@ -219,7 +219,7 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
             .iter()
             .enumerate()
         {
-            let val = chebyshev_eval_poly(normalized_time, coeffs, epoch, self.degree())?;
+            let val = chebyshev_eval_poly(normalized_time, coeffs, epoch_et_s, self.degree())?;
             rate[cno] = val;
         }
 
@@ -247,13 +247,13 @@ impl<'a> NAIFDataSet<'a> for Type3ChebyshevSet<'a> {
         new_end: Option<Epoch>,
     ) -> Result<Self, InterpolationError> {
         let start_idx = if let Some(start) = new_start {
-            self.spline_idx(start, summary)? - 1
+            self.spline_idx(start.to_et_seconds(), summary)? - 1
         } else {
             0
         };
 
         let end_idx = if let Some(end) = new_end {
-            self.spline_idx(end, summary)? - 1
+            self.spline_idx(end.to_et_seconds(), summary)? - 1
         } else {
             self.num_records - 1
         };
@@ -353,7 +353,6 @@ mod chebyshev_ut {
         errors::{DecodingError, IntegrityError},
         naif::{daf::NAIFDataSet, spk::summary::SPKSummaryRecord},
     };
-    use hifitime::Epoch;
 
     use super::Type3ChebyshevSet;
 
@@ -527,7 +526,7 @@ mod chebyshev_ut {
             end_idx: 28,
         };
 
-        let epoch = Epoch::from_et_seconds(12.0);
+        let epoch = 12.0;
         assert_eq!(dataset.spline_idx(epoch, &shifted_summary).unwrap(), 2);
 
         let (state, rate) = dataset.evaluate(epoch, &shifted_summary).unwrap();
@@ -559,7 +558,7 @@ mod chebyshev_ut {
             start_idx: 1,
             end_idx: 12,
         };
-        let epoch = Epoch::from_et_seconds(1000.0);
+        let epoch = 1000.0;
         assert_eq!(dataset.spline_idx(epoch, &summary).unwrap(), 1);
         // The full evaluate path must not panic on this input.
         let _ = dataset.evaluate(epoch, &summary);

--- a/anise/src/naif/daf/datatypes/chebyshev3.rs
+++ b/anise/src/naif/daf/datatypes/chebyshev3.rs
@@ -40,8 +40,8 @@ impl Type3ChebyshevSet<'_> {
         epoch_et_s: f64,
         summary: &S,
     ) -> Result<usize, InterpolationError> {
-        if epoch_et_s < summary.start_epoch_et_s() - 1.0
-            || epoch_et_s > summary.end_epoch_et_s() + 1.0
+        if epoch_et_s < summary.start_epoch_et_s().next_down()
+            || epoch_et_s > summary.end_epoch_et_s().next_up()
         {
             // No need to go any further.
             return Err(InterpolationError::NoInterpolationData {

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -153,20 +153,20 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
-        if epoch < summary.start_epoch() - 1e-7.seconds()
-            || epoch > summary.end_epoch() + 1e-7.seconds()
+        if epoch_et_s < summary.start_epoch_et_s() - 1e-7
+            || epoch_et_s > summary.end_epoch_et_s() + 1e-7
         {
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: summary.start_epoch(),
                 end: summary.end_epoch(),
             });
         }
 
-        let delta_t_s = (epoch - self.first_state_epoch).to_seconds();
+        let delta_t_s = epoch_et_s - self.first_state_epoch.to_et_seconds();
         let step_size_s = self.step_size.to_seconds();
         // A zero step size comes straight from the footer, which from_f64_slice only checks
         // for finiteness, so the division below yields an infinite index that saturates the
@@ -218,21 +218,21 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
             &epochs[..self.samples],
             &xs[..self.samples],
             &vxs[..self.samples],
-            epoch.to_et_seconds(),
+            epoch_et_s,
         )?;
 
         let (y_km, vy_km_s) = hermite_eval(
             &epochs[..self.samples],
             &ys[..self.samples],
             &vys[..self.samples],
-            epoch.to_et_seconds(),
+            epoch_et_s,
         )?;
 
         let (z_km, vz_km_s) = hermite_eval(
             &epochs[..self.samples],
             &zs[..self.samples],
             &vzs[..self.samples],
-            epoch.to_et_seconds(),
+            epoch_et_s,
         )?;
 
         // And build the result
@@ -411,23 +411,26 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         _: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
         // Start by doing a binary search on the epoch registry to limit the search space in the total number of epochs.
         if self.epoch_data.is_empty() {
-            return Err(InterpolationError::MissingInterpolationData { epoch });
+            return Err(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(epoch_et_s),
+            });
         }
         // Check that we even have interpolation data for that time
-        let last_epoch = *self
-            .epoch_data
-            .last()
-            .ok_or(InterpolationError::MissingInterpolationData { epoch })?;
-        if epoch.to_et_seconds() < self.epoch_data[0] - 1e-7
-            || epoch.to_et_seconds() > last_epoch + 1e-7
-        {
+        let last_epoch =
+            *self
+                .epoch_data
+                .last()
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(epoch_et_s),
+                })?;
+        if epoch_et_s < self.epoch_data[0] - 1e-7 || epoch_et_s > last_epoch + 1e-7 {
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: Epoch::from_et_seconds(self.epoch_data[0]),
                 end: Epoch::from_et_seconds(last_epoch),
             });
@@ -442,7 +445,7 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
             // dir_idx is the index of the first registry epoch such that epoch_registry[dir_idx] >= et_target.
             let dir_idx = self
                 .epoch_registry
-                .partition_point(|&reg_epoch| reg_epoch < epoch.to_et_seconds());
+                .partition_point(|&reg_epoch| reg_epoch < epoch_et_s);
 
             let sub_array_start_idx = if dir_idx == 0 {
                 // et_target <= self.epoch_registry[0] (i.e., et_target is before or at the first directory epoch, E_100).
@@ -480,7 +483,7 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
 
         match search_data_slice.binary_search_by(|epoch_et| {
             epoch_et
-                .partial_cmp(&epoch.to_et_seconds())
+                .partial_cmp(&epoch_et_s)
                 .expect("epochs in Hermite data is now NaN or infinite but was not before")
         }) {
             Ok(idx) => {
@@ -530,21 +533,21 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
                     &epochs[..self.samples],
                     &xs[..self.samples],
                     &vxs[..self.samples],
-                    epoch.to_et_seconds(),
+                    epoch_et_s,
                 )?;
 
                 let (y_km, vy_km_s) = hermite_eval(
                     &epochs[..self.samples],
                     &ys[..self.samples],
                     &vys[..self.samples],
-                    epoch.to_et_seconds(),
+                    epoch_et_s,
                 )?;
 
                 let (z_km, vz_km_s) = hermite_eval(
                     &epochs[..self.samples],
                     &zs[..self.samples],
                     &vzs[..self.samples],
-                    epoch.to_et_seconds(),
+                    epoch_et_s,
                 )?;
 
                 // And build the result
@@ -763,7 +766,6 @@ mod hermite_ut {
         use super::HermiteSetType13;
         use crate::math::interpolation::InterpolationError;
         use crate::naif::spk::summary::SPKSummaryRecord;
-        use hifitime::Epoch;
 
         // Two records (12 state doubles + 2 epochs), one epoch-registry entry, window size 2.
         // The registry entry sits below an in-range query epoch, so the directory search yields
@@ -776,7 +778,7 @@ mod hermite_ut {
         slice[16] = 2.0; // num_records
         let set = HermiteSetType13::from_f64_slice(&slice).unwrap();
         let summary = SPKSummaryRecord::default();
-        match set.evaluate(Epoch::from_et_seconds(50.0), &summary) {
+        match set.evaluate(50.0, &summary) {
             Ok(_) => panic!("an out-of-range epoch directory must be rejected"),
             Err(e) => assert_eq!(
                 e,
@@ -845,7 +847,6 @@ mod hermite_ut {
         use super::HermiteSetType12;
         use crate::naif::daf::NAIFDataSet;
         use crate::naif::spk::summary::SPKSummaryRecord;
-        use hifitime::Epoch;
 
         // A Type 12 segment whose footer declares a zero step size decodes fine (the size is
         // only checked for finiteness). Evaluating at an interior epoch used to divide the
@@ -866,9 +867,7 @@ mod hermite_ut {
         summary.end_epoch_et_s = 100.0;
 
         assert!(
-            dataset
-                .evaluate(Epoch::from_et_seconds(50.0), &summary)
-                .is_err(),
+            dataset.evaluate(50.0, &summary).is_err(),
             "zero step size must error, not panic"
         );
     }
@@ -877,7 +876,6 @@ mod hermite_ut {
     fn test_hermite_type12() {
         use super::HermiteSetType12;
         use crate::naif::spk::summary::SPKSummaryRecord;
-        use hifitime::Epoch;
 
         // Construct a synthetic HermiteSetType12
         let num_records = 10;
@@ -913,26 +911,26 @@ mod hermite_ut {
         summary.end_epoch_et_s = first_epoch_s + (num_records as f64 - 1.0) * step_size_s;
 
         // Test exact match
-        let epoch = Epoch::from_et_seconds(120.0);
+        let epoch = 120.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - 120.0).abs() < 1e-12);
         assert!((result.0.y - 240.0).abs() < 1e-12);
         assert!((result.1.x - 1.0).abs() < 1e-12);
 
         // Test interpolation
-        let epoch = Epoch::from_et_seconds(125.0);
+        let epoch = 125.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - 125.0).abs() < 1e-12);
         assert!((result.0.y - 250.0).abs() < 1e-12);
         assert!((result.1.x - 1.0).abs() < 1e-12);
 
         // Test boundary case: near start
-        let epoch = Epoch::from_et_seconds(105.0);
+        let epoch = 105.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - 105.0).abs() < 1e-12);
 
         // Test boundary case: near end
-        let epoch = Epoch::from_et_seconds(185.0);
+        let epoch = 185.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - 185.0).abs() < 1e-12);
     }

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -862,9 +862,11 @@ mod hermite_ut {
 
         let dataset = HermiteSetType12::from_f64_slice(&slice).unwrap();
 
-        let mut summary = SPKSummaryRecord::default();
-        summary.start_epoch_et_s = 0.0;
-        summary.end_epoch_et_s = 100.0;
+        let summary = SPKSummaryRecord {
+            start_epoch_et_s: 0.0,
+            end_epoch_et_s: 100.0,
+            ..Default::default()
+        };
 
         assert!(
             dataset.evaluate(50.0, &summary).is_err(),
@@ -906,9 +908,11 @@ mod hermite_ut {
         assert_eq!(dataset.samples, samples);
         assert_eq!(dataset.num_records, num_records);
 
-        let mut summary = SPKSummaryRecord::default();
-        summary.start_epoch_et_s = first_epoch_s;
-        summary.end_epoch_et_s = first_epoch_s + (num_records as f64 - 1.0) * step_size_s;
+        let summary = SPKSummaryRecord {
+            start_epoch_et_s: first_epoch_s,
+            end_epoch_et_s: first_epoch_s + (num_records as f64 - 1.0) * step_size_s,
+            ..Default::default()
+        };
 
         // Test exact match
         let epoch = 120.0;

--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -156,8 +156,8 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
         epoch_et_s: f64,
         summary: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
-        if epoch_et_s < summary.start_epoch_et_s() - 1e-7
-            || epoch_et_s > summary.end_epoch_et_s() + 1e-7
+        if epoch_et_s < summary.start_epoch_et_s().next_down()
+            || epoch_et_s > summary.end_epoch_et_s().next_up()
         {
             return Err(InterpolationError::NoInterpolationData {
                 req: Epoch::from_et_seconds(epoch_et_s),
@@ -428,7 +428,7 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
                 .ok_or(InterpolationError::MissingInterpolationData {
                     epoch: Epoch::from_et_seconds(epoch_et_s),
                 })?;
-        if epoch_et_s < self.epoch_data[0] - 1e-7 || epoch_et_s > last_epoch + 1e-7 {
+        if epoch_et_s < self.epoch_data[0].next_down() || epoch_et_s > last_epoch.next_up() {
             return Err(InterpolationError::NoInterpolationData {
                 req: Epoch::from_et_seconds(epoch_et_s),
                 start: Epoch::from_et_seconds(self.epoch_data[0]),

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -136,10 +136,9 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         _: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
-        let et = epoch.to_et_seconds();
         let t0 = self.first_state_epoch.to_et_seconds();
         let h = self.step_size.to_seconds();
 
@@ -150,7 +149,7 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
         }
 
         // Find the index such that t0 + idx * h <= et < t0 + (idx + 1) * h
-        let idx_f = (et - t0) / h;
+        let idx_f = (epoch_et_s - t0) / h;
 
         // Exact match check
         if (idx_f - idx_f.round()).abs() < 1e-12 {
@@ -197,15 +196,36 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
             epochs[cno] = t0 + (cur_idx as f64) * h;
         }
 
-        let (x_km, _) = lagrange_eval(&epochs[..actual_group_size], &xs[..actual_group_size], et)?;
-        let (y_km, _) = lagrange_eval(&epochs[..actual_group_size], &ys[..actual_group_size], et)?;
-        let (z_km, _) = lagrange_eval(&epochs[..actual_group_size], &zs[..actual_group_size], et)?;
-        let (vx_km_s, _) =
-            lagrange_eval(&epochs[..actual_group_size], &vxs[..actual_group_size], et)?;
-        let (vy_km_s, _) =
-            lagrange_eval(&epochs[..actual_group_size], &vys[..actual_group_size], et)?;
-        let (vz_km_s, _) =
-            lagrange_eval(&epochs[..actual_group_size], &vzs[..actual_group_size], et)?;
+        let (x_km, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &xs[..actual_group_size],
+            epoch_et_s,
+        )?;
+        let (y_km, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &ys[..actual_group_size],
+            epoch_et_s,
+        )?;
+        let (z_km, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &zs[..actual_group_size],
+            epoch_et_s,
+        )?;
+        let (vx_km_s, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &vxs[..actual_group_size],
+            epoch_et_s,
+        )?;
+        let (vy_km_s, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &vys[..actual_group_size],
+            epoch_et_s,
+        )?;
+        let (vz_km_s, _) = lagrange_eval(
+            &epochs[..actual_group_size],
+            &vzs[..actual_group_size],
+            epoch_et_s,
+        )?;
 
         Ok((
             Vector3::new(x_km, y_km, z_km),
@@ -346,23 +366,26 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         _: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
         // Start by doing a binary search on the epoch registry to limit the search space in the total number of epochs.
         if self.epoch_data.is_empty() {
-            return Err(InterpolationError::MissingInterpolationData { epoch });
+            return Err(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(epoch_et_s),
+            });
         }
         // Check that we even have interpolation data for that time
-        let last_epoch = *self
-            .epoch_data
-            .last()
-            .ok_or(InterpolationError::MissingInterpolationData { epoch })?;
-        if epoch.to_et_seconds() < self.epoch_data[0] - 1e-7
-            || epoch.to_et_seconds() > last_epoch + 1e-7
-        {
+        let last_epoch =
+            *self
+                .epoch_data
+                .last()
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(epoch_et_s),
+                })?;
+        if epoch_et_s < self.epoch_data[0] - 1e-7 || epoch_et_s > last_epoch + 1e-7 {
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: Epoch::from_et_seconds(self.epoch_data[0]),
                 end: Epoch::from_et_seconds(last_epoch),
             });
@@ -377,7 +400,7 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
             // dir_idx is the index of the first registry epoch such that epoch_registry[dir_idx] >= et_target.
             let dir_idx = self
                 .epoch_registry
-                .partition_point(|&reg_epoch| reg_epoch < epoch.to_et_seconds());
+                .partition_point(|&reg_epoch| reg_epoch < epoch_et_s);
 
             let sub_array_start_idx = if dir_idx == 0 {
                 // et_target <= self.epoch_registry[0] (i.e., et_target is before or at the first directory epoch, E_100).
@@ -416,7 +439,7 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
         // Now, perform a binary search on the epochs themselves.
         match search_data_slice.binary_search_by(|epoch_et| {
             epoch_et
-                .partial_cmp(&epoch.to_et_seconds())
+                .partial_cmp(&epoch_et_s)
                 .expect("epochs in Lagrange data is now NaN or infinite but was not before")
         }) {
             Ok(idx) => {
@@ -465,41 +488,23 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
 
                 // Build the interpolation polynomials making sure to limit the slices to exactly the number of items we actually used
                 // The other ones are zeros, which would cause the interpolation function to fail.
-                let (x_km, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &xs[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (x_km, _) =
+                    lagrange_eval(&epochs[..group_size], &xs[..group_size], epoch_et_s)?;
 
-                let (y_km, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &ys[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (y_km, _) =
+                    lagrange_eval(&epochs[..group_size], &ys[..group_size], epoch_et_s)?;
 
-                let (z_km, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &zs[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (z_km, _) =
+                    lagrange_eval(&epochs[..group_size], &zs[..group_size], epoch_et_s)?;
 
-                let (vx_km_s, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &vxs[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (vx_km_s, _) =
+                    lagrange_eval(&epochs[..group_size], &vxs[..group_size], epoch_et_s)?;
 
-                let (vy_km_s, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &vys[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (vy_km_s, _) =
+                    lagrange_eval(&epochs[..group_size], &vys[..group_size], epoch_et_s)?;
 
-                let (vz_km_s, _) = lagrange_eval(
-                    &epochs[..group_size],
-                    &vzs[..group_size],
-                    epoch.to_et_seconds(),
-                )?;
+                let (vz_km_s, _) =
+                    lagrange_eval(&epochs[..group_size], &vzs[..group_size], epoch_et_s)?;
 
                 // And build the result
                 let pos_km = Vector3::new(x_km, y_km, z_km);
@@ -629,7 +634,7 @@ mod ut_lagrange {
         slice[16] = 2.0; // num_records
         let set = LagrangeSetType9::from_f64_slice(&slice).unwrap();
         let summary = SPKSummaryRecord::default();
-        match set.evaluate(Epoch::from_et_seconds(50.0), &summary) {
+        match set.evaluate(50.0, &summary) {
             Ok(_) => panic!("an out-of-range epoch directory must be rejected"),
             Err(e) => assert_eq!(
                 e,
@@ -670,25 +675,25 @@ mod ut_lagrange {
         let summary = SPKSummaryRecord::default();
 
         // Test exact match
-        let epoch = Epoch::from_et_seconds(60.0);
+        let epoch = 60.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - (60.0 * 60.0 + 60.0 + 1.0)).abs() < 1e-12);
         assert!((result.1.x - (2.0 * 60.0 + 1.0)).abs() < 1e-12);
 
         // Test interpolation (mid-point of an interval)
-        let epoch = Epoch::from_et_seconds(90.0);
+        let epoch = 90.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         // Since motion is quadratic and degree is 3, Lagrange should be exact.
         assert!((result.0.x - (90.0 * 90.0 + 90.0 + 1.0)).abs() < 1e-12);
         assert!((result.1.x - (2.0 * 90.0 + 1.0)).abs() < 1e-12);
 
         // Test near start
-        let epoch = Epoch::from_et_seconds(10.0);
+        let epoch = 10.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - (10.0 * 10.0 + 10.0 + 1.0)).abs() < 1e-12);
 
         // Test near end
-        let epoch = Epoch::from_et_seconds((num_records as f64 - 1.5) * h);
+        let epoch = (num_records as f64 - 1.5) * h;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         let et = (num_records as f64 - 1.5) * h;
         assert!((result.0.x - (et * et + et + 1.0)).abs() < 1e-12);
@@ -731,12 +736,12 @@ mod ut_lagrange {
         let summary = SPKSummaryRecord::default();
 
         // Test exact match
-        let epoch = Epoch::from_et_seconds(10.0);
+        let epoch = 10.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 10.0);
 
         // Test interpolation
-        let epoch = Epoch::from_et_seconds(10.5);
+        let epoch = 10.5;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 10.5);
         assert_eq!(result.0.y, 21.0);
@@ -748,14 +753,14 @@ mod ut_lagrange {
         // sub_array_start_idx = 99.
         // Slice: 99..=198.
         // 99.5 is > epoch_data[99] (99.0).
-        let epoch = Epoch::from_et_seconds(99.5);
+        let epoch = 99.5;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 99.5);
 
         // Target: 100.5.
         // partition_point(|x| x < 100.5): 1.
         // Same slice. 100.5 is in 99..=198.
-        let epoch = Epoch::from_et_seconds(100.5);
+        let epoch = 100.5;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 100.5);
 
@@ -764,7 +769,7 @@ mod ut_lagrange {
         // dir_idx = 2.
         // start = 199.
         // Slice 199..=249.
-        let epoch = Epoch::from_et_seconds(200.5);
+        let epoch = 200.5;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 200.5);
     }

--- a/anise/src/naif/daf/datatypes/modified_diff.rs
+++ b/anise/src/naif/daf/datatypes/modified_diff.rs
@@ -112,23 +112,26 @@ impl<'a> NAIFDataSet<'a> for ModifiedDiffType1<'a> {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         _: &S,
     ) -> Result<Self::StateKind, InterpolationError> {
         // Start by doing a binary search on the epoch registry to limit the search space in the total number of epochs.
         if self.epoch_data.is_empty() {
-            return Err(InterpolationError::MissingInterpolationData { epoch });
+            return Err(InterpolationError::MissingInterpolationData {
+                epoch: Epoch::from_et_seconds(epoch_et_s),
+            });
         }
         // Check that we even have interpolation data for that time
-        let last_epoch = *self
-            .epoch_data
-            .last()
-            .ok_or(InterpolationError::MissingInterpolationData { epoch })?;
-        if epoch.to_et_seconds() < self.epoch_data[0] - 1e-2
-            || epoch.to_et_seconds() > last_epoch + 1e-2
-        {
+        let last_epoch =
+            *self
+                .epoch_data
+                .last()
+                .ok_or(InterpolationError::MissingInterpolationData {
+                    epoch: Epoch::from_et_seconds(epoch_et_s),
+                })?;
+        if epoch_et_s < self.epoch_data[0] - 1e-2 || epoch_et_s > last_epoch + 1e-2 {
             return Err(InterpolationError::NoInterpolationData {
-                req: epoch,
+                req: Epoch::from_et_seconds(epoch_et_s),
                 start: Epoch::from_et_seconds(self.epoch_data[0]),
                 end: Epoch::from_et_seconds(last_epoch),
             });
@@ -140,7 +143,7 @@ impl<'a> NAIFDataSet<'a> for ModifiedDiffType1<'a> {
         // We want the index of the first element that is > epoch.
         let rcrd_idx = self
             .epoch_data
-            .partition_point(|&epoch_et| epoch_et <= epoch.to_et_seconds());
+            .partition_point(|&epoch_et| epoch_et <= epoch_et_s);
 
         let record = self.nth_record(rcrd_idx).context(InterpDecodingSnafu)?;
 
@@ -165,7 +168,7 @@ impl<'a> NAIFDataSet<'a> for ModifiedDiffType1<'a> {
             });
         }
 
-        Ok(record.to_pos_vel(epoch))
+        Ok(record.to_pos_vel(epoch_et_s))
     }
 
     fn check_integrity(&self) -> Result<(), IntegrityError> {
@@ -227,9 +230,9 @@ pub struct ModifiedDiffRecord<'a> {
 }
 
 impl<'a> ModifiedDiffRecord<'a> {
-    pub fn to_pos_vel(&self, epoch: Epoch) -> (Vector3, Vector3) {
+    pub fn to_pos_vel(&self, epoch_et_s: f64) -> (Vector3, Vector3) {
         //  Set up for the computation of the various differences.
-        let delta = epoch.to_et_seconds() - self.ref_epoch; // Time delta from reference epoch
+        let delta = epoch_et_s - self.ref_epoch; // Time delta from reference epoch
         let mut tp = delta;
 
         // The maximum degree of the polynomials we might need to evaluate.
@@ -409,14 +412,14 @@ mod ut_spk1 {
 
         let summary = SPKSummaryRecord::default();
         // Query just inside the lower bound so record index 0 is selected.
-        let epoch = Epoch::from_et_seconds(-1e-3);
+        // let epoch = Epoch::from_et_seconds(-1e-3);
 
         let oversized_kqmax1 = build(100.0, 1.0);
         let set = ModifiedDiffType1::from_f64_slice(&oversized_kqmax1).unwrap();
-        assert!(set.evaluate(epoch, &summary).is_err());
+        assert!(set.evaluate(-1e-3, &summary).is_err());
 
         let oversized_kq = build(2.0, 100.0);
         let set = ModifiedDiffType1::from_f64_slice(&oversized_kq).unwrap();
-        assert!(set.evaluate(epoch, &summary).is_err());
+        assert!(set.evaluate(-1e-3, &summary).is_err());
     }
 }

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -44,7 +44,7 @@ pub enum FileRecordError {
     EmptyRecord,
 }
 
-#[derive(Debug, Clone, FromBytes, KnownLayout, Immutable, IntoBytes, PartialEq)]
+#[derive(Debug, Copy, Clone, FromBytes, KnownLayout, Immutable, IntoBytes, PartialEq)]
 #[repr(C)]
 pub struct FileRecord {
     pub id_str: [u8; 8],

--- a/anise/src/naif/daf/file_record.rs
+++ b/anise/src/naif/daf/file_record.rs
@@ -175,27 +175,6 @@ impl FileRecord {
     }
 }
 
-#[cfg(test)]
-mod ut_file_record {
-    use super::{FileRecord, FileRecordError};
-
-    #[test]
-    fn identification_non_ascii_id_str() {
-        // First eight bytes are valid UTF-8 but start with a 4-byte character, so
-        // slicing the decoded string at byte offset 3 or 4 would land inside it.
-        let mut rec = FileRecord::default();
-        rec.id_str = [0xF0, 0x9F, 0x98, 0x80, 0x20, 0x20, 0x20, 0x20];
-        assert_eq!(rec.identification(), Err(FileRecordError::NotDAF));
-    }
-
-    #[test]
-    fn identification_spk() {
-        let mut rec = FileRecord::default();
-        rec.id_str = *b"DAF/SPK ";
-        assert_eq!(rec.identification(), Ok("SPK"));
-    }
-}
-
 impl fmt::Display for FileRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let id = self.identification().unwrap_or("invalid identifier");
@@ -205,5 +184,30 @@ impl fmt::Display for FileRecord {
             "invalid endian".to_string()
         };
         write!(f, "FileRecord for {id} in {endian}",)
+    }
+}
+
+#[cfg(test)]
+mod ut_file_record {
+    use super::{FileRecord, FileRecordError};
+
+    #[test]
+    fn identification_non_ascii_id_str() {
+        // First eight bytes are valid UTF-8 but start with a 4-byte character, so
+        // slicing the decoded string at byte offset 3 or 4 would land inside it.
+        let rec = FileRecord {
+            id_str: [0xF0, 0x9F, 0x98, 0x80, 0x20, 0x20, 0x20, 0x20],
+            ..Default::default()
+        };
+        assert_eq!(rec.identification(), Err(FileRecordError::NotDAF));
+    }
+
+    #[test]
+    fn identification_spk() {
+        let rec = FileRecord {
+            id_str: *b"DAF/SPK ",
+            ..Default::default()
+        };
+        assert_eq!(rec.identification(), Ok("SPK"));
     }
 }

--- a/anise/src/naif/daf/mod.rs
+++ b/anise/src/naif/daf/mod.rs
@@ -97,7 +97,7 @@ pub trait NAIFDataSet<'a>: Sized + Display + PartialEq {
 
     fn evaluate<S: NAIFSummaryRecord>(
         &self,
-        epoch: Epoch,
+        epoch_et_s: f64,
         summary: &S,
     ) -> Result<Self::StateKind, InterpolationError>;
 

--- a/anise/src/naif/daf/mut_daf.rs
+++ b/anise/src/naif/daf/mut_daf.rs
@@ -299,10 +299,12 @@ mod mut_daf_ut {
             prev_record: 0.0,
             num_summaries: 1.0,
         };
-        let mut summary = SPKSummaryRecord::default();
-        summary.data_type_i = 13;
-        summary.start_idx = start_idx;
-        summary.end_idx = end_idx;
+        let summary = SPKSummaryRecord {
+            data_type_i: 13,
+            start_idx,
+            end_idx,
+            ..Default::default()
+        };
 
         let mut summary_record = Vec::new();
         summary_record.extend_from_slice(summary_header.as_bytes());

--- a/anise/src/orientations/rotate_to_parent.rs
+++ b/anise/src/orientations/rotate_to_parent.rs
@@ -102,7 +102,7 @@ impl Almanac {
                             .context(BPCSnafu {
                                 action: "fetching data for interpolation",
                             })?;
-                        data.evaluate(epoch, summary)
+                        data.evaluate(epoch.to_et_seconds(), summary)
                             .context(OrientationInterpolationSnafu)?
                     }
                     dtype => {

--- a/anise/tests/ephemerides/paths.rs
+++ b/anise/tests/ephemerides/paths.rs
@@ -52,14 +52,14 @@ fn common_root_verif() {
             PLUTO_BARYCENTER_J2000,
         ] {
             assert_eq!(
-                ctx.common_ephemeris_path(*planet_ctr, MOON_J2000, epoch)
+                ctx.common_ephemeris_path(*planet_ctr, MOON_J2000, epoch.to_et_seconds())
                     .unwrap()
                     .2,
                 SOLAR_SYSTEM_BARYCENTER
             );
 
             assert_eq!(
-                ctx.common_ephemeris_path(MOON_J2000, *planet_ctr, epoch)
+                ctx.common_ephemeris_path(MOON_J2000, *planet_ctr, epoch.to_et_seconds())
                     .unwrap()
                     .2,
                 SOLAR_SYSTEM_BARYCENTER
@@ -68,13 +68,13 @@ fn common_root_verif() {
 
         // Common root between Earth and Moon should be EMB
         assert_eq!(
-            ctx.common_ephemeris_path(MOON_J2000, EARTH_J2000, epoch)
+            ctx.common_ephemeris_path(MOON_J2000, EARTH_J2000, epoch.to_et_seconds())
                 .unwrap()
                 .2,
             EARTH_MOON_BARYCENTER
         );
         assert_eq!(
-            ctx.common_ephemeris_path(EARTH_J2000, MOON_J2000, epoch)
+            ctx.common_ephemeris_path(EARTH_J2000, MOON_J2000, epoch.to_et_seconds())
                 .unwrap()
                 .2,
             EARTH_MOON_BARYCENTER
@@ -82,15 +82,23 @@ fn common_root_verif() {
 
         // Common root between EMB and Moon should be EMB
         assert_eq!(
-            ctx.common_ephemeris_path(MOON_J2000, EARTH_MOON_BARYCENTER_J2000, epoch)
-                .unwrap()
-                .2,
+            ctx.common_ephemeris_path(
+                MOON_J2000,
+                EARTH_MOON_BARYCENTER_J2000,
+                epoch.to_et_seconds()
+            )
+            .unwrap()
+            .2,
             EARTH_MOON_BARYCENTER
         );
         assert_eq!(
-            ctx.common_ephemeris_path(EARTH_MOON_BARYCENTER_J2000, MOON_J2000, epoch)
-                .unwrap()
-                .2,
+            ctx.common_ephemeris_path(
+                EARTH_MOON_BARYCENTER_J2000,
+                MOON_J2000,
+                epoch.to_et_seconds()
+            )
+            .unwrap()
+            .2,
             EARTH_MOON_BARYCENTER
         );
     }

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -237,7 +237,7 @@ fn validate_gh_283_multi_barycenter_and_los(almanac: Almanac) {
     let gh346_epoch = Epoch::from_gregorian_utc_at_midnight(2023, 12, 15);
     assert!(
         almanac
-            .common_ephemeris_path(lro_frame, SUN_J2000, gh346_epoch)
+            .common_ephemeris_path(lro_frame, SUN_J2000, gh346_epoch.to_et_seconds())
             .is_ok()
     );
     assert!(
@@ -250,7 +250,7 @@ fn validate_gh_283_multi_barycenter_and_los(almanac: Almanac) {
 
     // First, let's test that the common ephemeris path is correct
     let (node_count, path, common_node) = almanac
-        .common_ephemeris_path(lro_frame, SUN_J2000, epoch)
+        .common_ephemeris_path(lro_frame, SUN_J2000, epoch.to_et_seconds())
         .unwrap();
 
     assert_eq!(common_node, 0, "common node should be the SSB");

--- a/anise/tests/ephemerides/transform.rs
+++ b/anise/tests/ephemerides/transform.rs
@@ -409,14 +409,14 @@ fn validate_gh_283_multi_barycenter_and_los(almanac: Almanac) {
                 println!("{occult} @ {rx_lro:x}");
                 printed_visible = true;
             }
-            if let Some(prev_occult) = &prev_occult {
-                if prev_occult.is_partial() {
-                    assert_eq!(
-                        epoch,
-                        Epoch::from_gregorian_utc_hms(2024, 1, 1, 0, 46, 36),
-                        "wrong post-penumbra state"
-                    );
-                }
+            if let Some(prev_occult) = &prev_occult
+                && prev_occult.is_partial()
+            {
+                assert_eq!(
+                    epoch,
+                    Epoch::from_gregorian_utc_hms(2024, 1, 1, 0, 46, 36),
+                    "wrong post-penumbra state"
+                );
             }
         } else if occult.is_obstructed() {
             if !printed_umbra {

--- a/anise/tests/lib.rs
+++ b/anise/tests/lib.rs
@@ -21,7 +21,7 @@ mod orientations;
 /// Single query for timing purposes
 #[test]
 fn flamegraph() {
-    use anise::constants::frames::{EARTH_J2000, MOON_J2000, SUN_J2000};
+    use anise::constants::frames::{MOON_J2000, SUN_J2000};
     use anise::prelude::Almanac;
     use hifitime::{Epoch, TimeSeries, Unit};
     let almanac = Almanac::new("../data/de440s.bsp").unwrap();

--- a/anise/tests/lib.rs
+++ b/anise/tests/lib.rs
@@ -17,3 +17,19 @@ mod frames;
 #[cfg(feature = "analysis")]
 mod instrument;
 mod orientations;
+
+/// Single query for timing purposes
+#[test]
+fn flamegraph() {
+    use anise::constants::frames::{EARTH_J2000, MOON_J2000, SUN_J2000};
+    use anise::prelude::Almanac;
+    use hifitime::{Epoch, TimeSeries, Unit};
+    let almanac = Almanac::new("../data/de440s.bsp").unwrap();
+    let epoch = Epoch::from_gregorian_utc_at_noon(2024, 2, 29);
+    for epoch in TimeSeries::inclusive(epoch, epoch + Unit::Hour * 1, Unit::Second * 1) {
+        let orbit = almanac
+            .transform(SUN_J2000, MOON_J2000, epoch, None)
+            .unwrap();
+        println!("{orbit}")
+    }
+}


### PR DESCRIPTION
# Summary

Switch SPK querying to rely on epoch in ephemeris time seconds past J2000. This should speed up things considerably. Opening this PR to test that hypothesis on the github benchmark runner.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

**Detail the changes in tests, including new tests and validations**

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->