### PR TITLE
reject non-finite epochs in type 9 and type 13 evaluate

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -481,11 +481,22 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
             )
         };
 
-        match search_data_slice.binary_search_by(|epoch_et| {
-            epoch_et
-                .partial_cmp(&epoch_et_s)
-                .expect("epochs in Hermite data is now NaN or infinite but was not before")
-        }) {
+        // A crafted segment can hold a non-finite epoch that check_integrity would reject, but
+        // that check is not run on the query path, so guard the comparison rather than
+        // unwrapping a failed partial_cmp.
+        let mut non_finite_epoch = false;
+        let search = search_data_slice.binary_search_by(|epoch_et| {
+            epoch_et.partial_cmp(&epoch_et_s).unwrap_or_else(|| {
+                non_finite_epoch = true;
+                core::cmp::Ordering::Equal
+            })
+        });
+        if non_finite_epoch {
+            return Err(InterpolationError::CorruptedData {
+                what: "epoch data contains a non-finite value",
+            });
+        }
+        match search {
             Ok(idx) => {
                 // Oh wow, this state actually exists, no interpolation needed!
                 Ok(self
@@ -937,5 +948,27 @@ mod hermite_ut {
         let epoch = 185.0;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert!((result.0.x - 185.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn non_finite_epoch_data_is_rejected() {
+        use crate::naif::spk::summary::SPKSummaryRecord;
+        // A crafted Type 13 segment whose epoch directory holds a NaN reaches the binary search
+        // with a non-finite comparand. check_integrity would catch it, but it is not run on the
+        // query path, so the comparator used to panic on the failed partial_cmp.
+        let state_data = [0.0_f64; 7];
+        let epoch_data = [f64::NAN];
+        let dataset = HermiteSetType13 {
+            samples: 1,
+            num_records: 1,
+            state_data: &state_data,
+            epoch_data: &epoch_data,
+            epoch_registry: &[],
+        };
+        let summary = SPKSummaryRecord::default();
+        assert!(
+            dataset.evaluate(0.0, &summary).is_err(),
+            "a non-finite epoch must error, not panic"
+        );
     }
 }

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -436,12 +436,22 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
             )
         };
 
-        // Now, perform a binary search on the epochs themselves.
-        match search_data_slice.binary_search_by(|epoch_et| {
-            epoch_et
-                .partial_cmp(&epoch_et_s)
-                .expect("epochs in Lagrange data is now NaN or infinite but was not before")
-        }) {
+        // Now, perform a binary search on the epochs themselves. A crafted segment can hold a
+        // non-finite epoch that check_integrity would reject, but that check is not run on the
+        // query path, so guard the comparison rather than unwrapping a failed partial_cmp.
+        let mut non_finite_epoch = false;
+        let search = search_data_slice.binary_search_by(|epoch_et| {
+            epoch_et.partial_cmp(&epoch_et_s).unwrap_or_else(|| {
+                non_finite_epoch = true;
+                core::cmp::Ordering::Equal
+            })
+        });
+        if non_finite_epoch {
+            return Err(InterpolationError::CorruptedData {
+                what: "epoch data contains a non-finite value",
+            });
+        }
+        match search {
             Ok(idx) => {
                 // Oh wow, this state actually exists, no interpolation needed!
                 Ok(self
@@ -772,5 +782,26 @@ mod ut_lagrange {
         let epoch = 200.5;
         let result = dataset.evaluate(epoch, &summary).unwrap();
         assert_eq!(result.0.x, 200.5);
+    }
+
+    #[test]
+    fn non_finite_epoch_data_is_rejected() {
+        // A crafted Type 9 segment whose epoch directory holds a NaN reaches the binary search
+        // with a non-finite comparand. check_integrity would catch it, but it is not run on the
+        // query path, so the comparator used to panic on the failed partial_cmp.
+        let state_data = [0.0_f64; 6];
+        let epoch_data = [f64::NAN];
+        let dataset = LagrangeSetType9 {
+            degree: 0,
+            num_records: 1,
+            state_data: &state_data,
+            epoch_data: &epoch_data,
+            epoch_registry: &[],
+        };
+        let summary = SPKSummaryRecord::default();
+        assert!(
+            dataset.evaluate(0.0, &summary).is_err(),
+            "a non-finite epoch must error, not panic"
+        );
     }
 }


### PR DESCRIPTION
# Summary

`LagrangeSetType9::evaluate` and `HermiteSetType13::evaluate` binary-search the epoch directory and unwrap `partial_cmp`, so a crafted SPK or BPC segment carrying a NaN or infinite epoch panics during a translate or rotate query. The per-segment `check_integrity` that rejects non-finite epoch data only runs in tests, not on the query path, so the value reaches the comparator unchecked, and the summary epoch finiteness check in `daf.rs` covers only the summary start/end epochs rather than the per-record directory.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Return `CorruptedData` when the epoch comparison is undefined in the Type 9 Lagrange and Type 13 Hermite `evaluate` decoders, matching the other integrity guards there, instead of unwrapping `partial_cmp` and panicking on a non-finite epoch.

## Testing and validation

Added a regression test to each decoder that builds a one-record segment with a NaN epoch and checks the query returns an error. Both tests panic at the old `expect` on the current code and pass after the change; the rest of the suite is unaffected.

## Documentation

This PR does not primarily deal with documentation changes.
