### PR TITLE
Better conditioning of Argument of Latitude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py", "anise/fuzz", "anise-cpp"]
 
 [workspace.package]
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."

--- a/anise-py/anise/astro.pyi
+++ b/anise-py/anise/astro.pyi
@@ -1123,8 +1123,9 @@ class Orbit:
     def aol_deg(self) -> float:
         """Returns the argument of latitude in degrees
 
-        NOTE: If the orbit is near circular, the AoL will be computed from the true longitude
-        instead of relying on the ill-defined true anomaly."""
+        NOTE: This computation uses vector geometry, ensuring proper conditioning with circular orbits.
+        NOTE: If the orbit is near equatorial (inclination < 1e-6 deg), then the AoL is ill-defined
+        and an error will be returned."""
 
     def aop_brouwer_short_deg(self) -> float:
         """Returns the Brouwer-short mean Argument of Perigee in degrees."""

--- a/anise/src/astro/aberration.rs
+++ b/anise/src/astro/aberration.rs
@@ -48,6 +48,7 @@ use crate::errors::PhysicsError;
 /// :rtype: Aberration
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "analysis", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 #[cfg_attr(feature = "python", pyclass(from_py_object))]
 #[cfg_attr(feature = "python", pyo3(module = "anise"))]
 pub struct Aberration {
@@ -343,5 +344,29 @@ mod ut_aberration {
         assert_eq!(format!("{:?}", Aberration::XLT_S.unwrap()), "XLT+S");
         assert_eq!(format!("{:?}", Aberration::XCN.unwrap()), "XCN");
         assert_eq!(format!("{:?}", Aberration::XCN_S.unwrap()), "XCN+S");
+    }
+    #[cfg(feature = "metaload")]
+    #[test]
+    fn test_ab_corr_static_type() {
+        use super::Aberration;
+
+        for ab_corr in [
+            Aberration::NONE,
+            Aberration::LT,
+            Aberration::LT_S,
+            Aberration::CN_S,
+            Aberration::XCN,
+            Aberration::XCN_S,
+            Aberration::XLT,
+            Aberration::XLT_S,
+        ] {
+            let as_dhall = serde_dhall::serialize(&ab_corr)
+                .static_type_annotation()
+                .to_string()
+                .unwrap();
+            let from_dhall: Option<Aberration> = serde_dhall::from_str(&as_dhall).parse().unwrap();
+
+            assert_eq!(from_dhall, ab_corr);
+        }
     }
 }

--- a/anise/src/astro/orbit.rs
+++ b/anise/src/astro/orbit.rs
@@ -41,6 +41,8 @@ use pyo3::types::PyType;
 
 /// If an orbit has an eccentricity below the following value, it is considered circular.
 pub const ECC_EPSILON: f64 = 1e-11;
+/// If an orbit has an inclination below the following valie, it is considered equatorial.
+pub const INC_EPSILON_DEG: f64 = 1e-6;
 
 /// A helper type alias, but no assumptions are made on the underlying validity of the frame.
 pub type Orbit = CartesianState;
@@ -1143,16 +1145,31 @@ impl Orbit {
 
     /// Returns the argument of latitude in degrees
     ///
-    /// NOTE: If the orbit is near circular, the AoL will be computed from the true longitude
-    /// instead of relying on the ill-defined true anomaly.
+    /// NOTE: This computation uses vector geometry, ensuring proper conditioning with circular orbits.
+    /// NOTE: If the orbit is near equatorial (inclination < 1e-6 deg), then the AoL is ill-defined
+    /// and an error will be returned.
     ///
     /// :rtype: float
     pub fn aol_deg(&self) -> PhysicsResult<f64> {
-        Ok(between_0_360(if self.ecc()? < ECC_EPSILON {
-            self.tlong_deg()? - self.raan_deg()?
-        } else {
-            self.aop_deg()? + self.ta_deg()?
-        }))
+        let h_hat = self.h_hat()?;
+        let mut n_hat = Vector3::new(0.0, 0.0, 1.0).cross(&h_hat);
+
+        if n_hat.norm() < INC_EPSILON_DEG.to_radians() {
+            return Err(PhysicsError::AppliedMath {
+                source: MathError::DomainError {
+                    value: n_hat.norm_squared(),
+                    msg: "orbit is equatorial",
+                },
+            });
+        }
+
+        n_hat /= n_hat.norm();
+
+        let m_hat = h_hat.cross(&n_hat);
+        let sin_u = self.r_hat().dot(&m_hat);
+        let cos_u = self.r_hat().dot(&n_hat);
+
+        Ok(between_0_360(sin_u.atan2(cos_u).to_degrees()))
     }
 
     /// Returns the radius of periapsis (or perigee around Earth), in kilometers.


### PR DESCRIPTION
The previous implementation used orbital element summations. This implementation uses vector math, which is accurate regardless of eccentricity, and ill-conditioned only on equatorial orbits.

This also implements StaticType on Aberration, enabling a few new features in the next version of Nyx.

