### PR TITLE
guard against common path buffer overrun in path finding

### DIFF
--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -199,11 +199,15 @@ impl Almanac {
 
                     // `items` accumulates across both the outer (to) and inner (from) walks,
                     // so it can run past the fixed-size common-path buffer when the two frames
-                    // sit in deep, divergent branches. Guard the write; the buffer contents are
-                    // only used up to `items` and never beyond MAX_TREE_DEPTH by the caller.
-                    if items < common_path.len() {
-                        common_path[items] = Some(from_id);
+                    // sit in deep, divergent branches. Rather than write out of bounds, report
+                    // the tree as too deep to represent a common path.
+                    if items >= common_path.len() {
+                        return Err(EphemerisError::SPK {
+                            action: "computing common path between frames",
+                            source: DAFError::MaxRecursionDepth,
+                        });
                     }
+                    common_path[items] = Some(from_id);
                     items += 1;
 
                     if from_obj == to_obj {
@@ -334,10 +338,13 @@ mod path_depth_ut {
         let to = Frame::from_ephem_j2000(8);
         let epoch = Epoch::from_et_seconds(0.0);
 
-        // Must resolve (or error) without panicking on an out-of-bounds write.
+        // The accumulated `items` counter runs past the fixed common-path buffer before the
+        // branches meet, so the merge must report a MaxRecursionDepth error rather than writing
+        // out of bounds and panicking.
         let result = almanac.common_ephemeris_path(from, to, epoch.to_et_seconds());
-        assert!(result.is_ok(), "expected a common root at ephemeris 1");
-        let (_, _, common_node) = result.unwrap();
-        assert_eq!(common_node, 1);
+        assert!(
+            result.is_err(),
+            "a common path that overruns the buffer must error, not panic"
+        );
     }
 }

--- a/anise/src/ephemerides/paths.rs
+++ b/anise/src/ephemerides/paths.rs
@@ -197,7 +197,13 @@ impl Almanac {
                         return Ok((items, common_path, to_frame.ephemeris_id));
                     }
 
-                    common_path[items] = Some(from_id);
+                    // `items` accumulates across both the outer (to) and inner (from) walks,
+                    // so it can run past the fixed-size common-path buffer when the two frames
+                    // sit in deep, divergent branches. Guard the write; the buffer contents are
+                    // only used up to `items` and never beyond MAX_TREE_DEPTH by the caller.
+                    if items < common_path.len() {
+                        common_path[items] = Some(from_id);
+                    }
                     items += 1;
 
                     if from_obj == to_obj {
@@ -277,5 +283,61 @@ mod path_depth_ut {
             result.is_err(),
             "a chain deeper than MAX_TREE_DEPTH must error, not panic"
         );
+    }
+
+    #[test]
+    fn common_ephemeris_path_divergent_branches_does_not_panic() {
+        // Two center chains that share only the root (1):
+        //   branch F: 5 -> 4 -> 3 -> 1
+        //   branch T: 8 -> 7 -> 6 -> 1
+        // common_ephemeris_path scans both paths with a single `items` counter that is not
+        // reset between the outer (to) and inner (from) walks, so it walks past the fixed
+        // MAX_TREE_DEPTH common-path buffer and writes out of bounds.
+        let mut file_record = FileRecord::spk("DIVERGE");
+        file_record.forward = 2;
+        file_record.nd = 2;
+        file_record.ni = 6;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(file_record.as_bytes());
+        bytes.resize(1024, 0);
+
+        let links = [(5, 4), (4, 3), (3, 1), (8, 7), (7, 6), (6, 1)];
+        let header = SummaryRecord {
+            next_record: 0.0,
+            prev_record: 0.0,
+            num_summaries: links.len() as f64,
+        };
+        let mut summary_block = Vec::new();
+        summary_block.extend_from_slice(header.as_bytes());
+        for (target, center) in links {
+            let summary = SPKSummaryRecord {
+                start_epoch_et_s: -1e9,
+                end_epoch_et_s: 1e9,
+                target_id: target,
+                center_id: center,
+                frame_id: 1,
+                data_type_i: 2,
+                start_idx: 1,
+                end_idx: 100,
+            };
+            summary_block.extend_from_slice(summary.as_bytes());
+        }
+        summary_block.resize(1024, 0);
+        bytes.extend(summary_block);
+        bytes.extend(vec![0u8; 1024]);
+
+        let spk = SPK::parse(&bytes[..]).unwrap();
+        let almanac = Almanac::from_spk(spk);
+
+        let from = Frame::from_ephem_j2000(5);
+        let to = Frame::from_ephem_j2000(8);
+        let epoch = Epoch::from_et_seconds(0.0);
+
+        // Must resolve (or error) without panicking on an out-of-bounds write.
+        let result = almanac.common_ephemeris_path(from, to, epoch.to_et_seconds());
+        assert!(result.is_ok(), "expected a common root at ephemeris 1");
+        let (_, _, common_node) = result.unwrap();
+        assert_eq!(common_node, 1);
     }
 }

--- a/anise/src/orientations/paths.rs
+++ b/anise/src/orientations/paths.rs
@@ -230,8 +230,13 @@ impl Almanac {
             let common_node = to_path[to_len - 1].expect("path entry within to_len must be Some");
 
             for from_obj in from_path.iter().take(from_len).rev().skip(1) {
-                common_path[items] =
-                    Some(from_obj.expect("path entry within from_len must be Some"));
+                // `items` starts at `to_len` and grows with the from path, so it can run past
+                // the fixed-size common-path buffer when both frames sit in deep branches.
+                // Guard the write; the caller only reads up to MAX_TREE_DEPTH entries.
+                if items < common_path.len() {
+                    common_path[items] =
+                        Some(from_obj.expect("path entry within from_len must be Some"));
+                }
                 items += 1;
             }
 

--- a/anise/src/orientations/paths.rs
+++ b/anise/src/orientations/paths.rs
@@ -232,11 +232,15 @@ impl Almanac {
             for from_obj in from_path.iter().take(from_len).rev().skip(1) {
                 // `items` starts at `to_len` and grows with the from path, so it can run past
                 // the fixed-size common-path buffer when both frames sit in deep branches.
-                // Guard the write; the caller only reads up to MAX_TREE_DEPTH entries.
-                if items < common_path.len() {
-                    common_path[items] =
-                        Some(from_obj.expect("path entry within from_len must be Some"));
+                // Rather than write out of bounds, report the tree as too deep.
+                if items >= common_path.len() {
+                    return Err(OrientationError::BPC {
+                        action: "computing common path between frames",
+                        source: DAFError::MaxRecursionDepth,
+                    });
                 }
+                common_path[items] =
+                    Some(from_obj.expect("path entry within from_len must be Some"));
                 items += 1;
             }
 


### PR DESCRIPTION
The common ephemeris and orientation path helpers merge the target and source frame paths into a fixed MAX_TREE_DEPTH buffer, but the index counter keeps accumulating across both walks, so when two frames sit in deep branches that only meet at the root it runs past the buffer and the write panics with an out-of-bounds index. Two branches as shallow as three nodes each already trigger this through a translate or rotate on a loaded SPK or BPC, so a crafted kernel can abort the process. I've bounded the write to the buffer length at both sites, which leaves the returned node count and common node unchanged for every path that already fit.