### PR TITLE
guard type 12 hermite window index against usize overflow

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -189,9 +189,12 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType12<'a> {
             nearest_i.saturating_sub((self.samples - 1) / 2)
         };
 
-        // Ensure we don't go past the end of the records
-        if first_idx + self.samples > self.num_records {
-            first_idx = self.num_records.saturating_sub(self.samples);
+        // Ensure we don't go past the end of the records. Compare against the last valid start
+        // index rather than `first_idx + self.samples`: a query far from the segment start
+        // saturates the usize cast of float_index, so the addition would overflow.
+        let max_first_idx = self.num_records.saturating_sub(self.samples);
+        if first_idx > max_first_idx {
+            first_idx = max_first_idx;
         }
 
         // Statically allocated arrays of the maximum number of samples
@@ -883,6 +886,37 @@ mod hermite_ut {
             dataset.evaluate(50.0, &summary).is_err(),
             "zero step size must error, not panic"
         );
+    }
+
+    #[test]
+    fn type12_large_offset_does_not_overflow() {
+        use super::HermiteSetType12;
+        use crate::naif::daf::NAIFDataSet;
+        use crate::naif::spk::summary::SPKSummaryRecord;
+
+        // The step size is nonzero and finite, so the zero-step guard does not apply, yet a
+        // query epoch far from the segment start makes `float_index` a huge finite value that
+        // saturates the usize cast to usize::MAX. `first_idx + samples` then overflowed.
+        let num_records = 4;
+        let mut slice = vec![0.0_f64; num_records * 6 + 4];
+        let n = slice.len();
+        slice[n - 4] = 0.0; // first state epoch
+        slice[n - 3] = 1.0; // step size (nonzero, finite)
+        slice[n - 2] = 3.0; // window size - 1 => samples = 4
+        slice[n - 1] = num_records as f64;
+
+        let dataset = HermiteSetType12::from_f64_slice(&slice).unwrap();
+
+        let summary = SPKSummaryRecord {
+            start_epoch_et_s: 0.0,
+            end_epoch_et_s: 3e19,
+            ..Default::default()
+        };
+
+        // Must not panic: the offset is clamped to the last window like any past-the-end query.
+        let (pos, vel) = dataset.evaluate(2e19, &summary).unwrap();
+        assert!(pos.iter().all(|v| v.is_finite()));
+        assert!(vel.iter().all(|v| v.is_finite()));
     }
 
     #[test]


### PR DESCRIPTION
# Summary

`HermiteSetType12::evaluate` picks the interpolation window from `first_idx`, which comes from `float_index = (epoch - first_state_epoch) / step_size` cast to `usize`. The query epoch is only checked against the summary epochs, and those come from the same untrusted segment, so a Type 12 SPK/BPC segment with a nonzero finite step and a query far from the segment start makes `float_index` a huge finite value that saturates the `f64 -> usize` cast to `usize::MAX`. The next line, `if first_idx + self.samples > self.num_records`, then overflows (panic in debug, wraparound in release) before the clamp runs. The existing zero-step guard doesn't help here because the step is nonzero. I compared `first_idx` against the last valid start index instead of forming that sum, which is the same result for every in-range query and can't overflow.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Fixed the `usize` overflow in `HermiteSetType12::evaluate` described above. The equal-step Lagrange Type 8 path already computes this in `isize` with a clamp, and the Type 9 / Type 13 paths derive `first_idx` from a bounded binary-search insertion index, so this was the only affected site.

## Testing and validation

Added `type12_large_offset_does_not_overflow`, which builds a small Type 12 set with a nonzero step and queries an epoch past the `usize` range. It panics with `attempt to add with overflow` before the change and returns a finite (clamped) state after. `cargo test -p anise --lib` and `cargo clippy -p anise -- -D warnings` are clean.

## Documentation

This PR does not primarily deal with documentation changes.
