### PR TITLE
add light time orbital element and from-location scalar expr

### DIFF
--- a/anise/src/analysis/elements.rs
+++ b/anise/src/analysis/elements.rs
@@ -97,6 +97,8 @@ pub enum OrbitalElement {
     PeriapsisAltitude,
     /// Orbital period (s)
     Period,
+    /// One-way light time from the frame origin to the object (s)
+    LightTime,
     /// Right ascension (deg)
     RightAscension,
     /// Right ascension of the ascending node (deg)
@@ -232,6 +234,7 @@ impl OrbitalElement {
                 .period()
                 .context(PhysicsOrbitElSnafu { el: self, orbit })?
                 .to_seconds()),
+            Self::LightTime => Ok(orbit.light_time().to_seconds()),
             Self::RightAscension => Ok(orbit.right_ascension_deg()),
             Self::RAAN => orbit
                 .raan_deg()
@@ -350,7 +353,7 @@ impl OrbitalElement {
             | Self::EquinoctialP
             | Self::EquinoctialQ
             | Self::Custom => "unitless",
-            Self::Period => "s",
+            Self::Period | Self::LightTime => "s",
         }
     }
 }

--- a/anise/src/analysis/expr.rs
+++ b/anise/src/analysis/expr.rs
@@ -140,6 +140,11 @@ pub enum ScalarExpr {
         location_id: i32,
         obstructing_body: Option<Frame>,
     },
+    /// Compute the one-way light time from the location to the object, in seconds
+    LightTimeFromLocation {
+        location_id: i32,
+        obstructing_body: Option<Frame>,
+    },
     /// Compute the RIC diff with the provided state spec
     RicDiff(StateSpec),
     FovMargin {
@@ -412,6 +417,22 @@ impl ScalarExpr {
                     state: orbit,
                 })?
                 .range_rate_km_s),
+            Self::LightTimeFromLocation {
+                location_id,
+                obstructing_body,
+            } => Ok(almanac
+                .azimuth_elevation_range_sez_from_location_id(
+                    orbit,
+                    *location_id,
+                    *obstructing_body,
+                    ab_corr,
+                )
+                .context(AlmanacExprSnafu {
+                    expr: Box::new(self.clone()),
+                    state: orbit,
+                })?
+                .light_time
+                .to_seconds()),
             Self::RicDiff(spec) => {
                 let other = spec.evaluate(orbit.epoch, almanac)?;
 
@@ -602,6 +623,12 @@ impl fmt::Display for ScalarExpr {
                 obstructing_body: _,
             } => {
                 write!(f, "range-rate from location #{location_id} (km/s)")
+            }
+            Self::LightTimeFromLocation {
+                location_id,
+                obstructing_body: _,
+            } => {
+                write!(f, "light time from location #{location_id} (s)")
             }
             Self::Acos(v) => write!(f, "acos({v})"),
             Self::Asin(v) => write!(f, "asin({v})"),

--- a/anise/src/analysis/mod.rs
+++ b/anise/src/analysis/mod.rs
@@ -543,6 +543,55 @@ mod ut_analysis {
     }
 
     #[rstest]
+    fn light_time_from_location(almanac: Almanac) {
+        use crate::constants::SPEED_OF_LIGHT_KM_S;
+
+        // The one-way light time from a ground location is just the range to that
+        // location divided by the speed of light, so the two expressions must agree.
+        let state = StateSpec {
+            target_frame: FrameSpec::Loaded(Frame::from_ephem_j2000(-85)),
+            observer_frame: FrameSpec::Loaded(EME2000),
+            ab_corr: Aberration::NONE,
+        };
+
+        let light_time = ScalarExpr::LightTimeFromLocation {
+            location_id: 123,
+            obstructing_body: None,
+        };
+
+        assert_eq!(format!("{light_time}"), "light time from location #123 (s)");
+
+        let report = ReportScalars {
+            scalars: vec![
+                (
+                    ScalarExpr::RangeFromLocation {
+                        location_id: 123,
+                        obstructing_body: None,
+                    },
+                    None,
+                ),
+                (light_time, None),
+            ],
+            state_spec: state,
+        };
+
+        let start = almanac.spk_domain(-85).unwrap().0 + Unit::Hour * 1;
+        let data = almanac.report_scalars(
+            &report,
+            TimeSeries::inclusive(start, start + Unit::Hour * 2, Unit::Hour * 1),
+        );
+
+        assert!(!data.is_empty());
+
+        for row in data.values() {
+            let row = row.as_ref().unwrap();
+            let range_km = row["range from location #123 (km)"].as_ref().unwrap();
+            let lt_s = row["light time from location #123 (s)"].as_ref().unwrap();
+            assert!((lt_s - range_km / SPEED_OF_LIGHT_KM_S).abs() < 1e-9);
+        }
+    }
+
+    #[rstest]
     fn test_analysis_event(mut almanac: Almanac) {
         use crate::analysis::event_ops::find_arc_intersections;
 

--- a/anise/src/analysis/python.rs
+++ b/anise/src/analysis/python.rs
@@ -262,6 +262,10 @@ pub enum PyScalarExpr {
         location_id: i32,
         obstructing_body: Option<Frame>,
     },
+    LightTimeFromLocation {
+        location_id: i32,
+        obstructing_body: Option<Frame>,
+    },
     RicDiff(PyStateSpec),
     /// FovMargin requires the spacecraft frame in sc_observer_frame and the StateSpec **must** be the target location on target obdy (e.g. IAU Moon).
     FovMargin {
@@ -392,6 +396,13 @@ impl Clone for PyScalarExpr {
                     location_id,
                     obstructing_body,
                 } => Self::RangeRateFromLocation {
+                    location_id: *location_id,
+                    obstructing_body: *obstructing_body,
+                },
+                Self::LightTimeFromLocation {
+                    location_id,
+                    obstructing_body,
+                } => Self::LightTimeFromLocation {
                     location_id: *location_id,
                     obstructing_body: *obstructing_body,
                 },
@@ -935,6 +946,13 @@ impl TryFrom<ScalarExpr> for PyScalarExpr {
                     location_id,
                     obstructing_body,
                 }),
+                ScalarExpr::LightTimeFromLocation {
+                    location_id,
+                    obstructing_body,
+                } => Ok(Self::LightTimeFromLocation {
+                    location_id,
+                    obstructing_body,
+                }),
                 ScalarExpr::SolarEclipsePercentage { eclipsing_frame } => {
                     Ok(Self::SolarEclipsePercentage { eclipsing_frame })
                 }
@@ -1365,6 +1383,13 @@ impl From<PyScalarExpr> for ScalarExpr {
                 location_id,
                 obstructing_body,
             } => ScalarExpr::RangeRateFromLocation {
+                location_id,
+                obstructing_body,
+            },
+            PyScalarExpr::LightTimeFromLocation {
+                location_id,
+                obstructing_body,
+            } => ScalarExpr::LightTimeFromLocation {
                 location_id,
                 obstructing_body,
             },


### PR DESCRIPTION
Adds a LightTime variant to OrbitalElement, giving the one-way light time from the frame origin in seconds, and a matching LightTimeFromLocation variant to ScalarExpr so light time can feed report generation next to range. The element reuses the same to-seconds conversion as Period, and the location variant returns the range to that location divided by the speed of light. I have also mirrored both in the Python bindings and added a location query test that checks the light time equals range over c. Closes #808.