### PR TITLE
Spacecraft data/dhallSet/dhallSetEntry creation and retrieval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py", "anise/fuzz", "anise-cpp"]
 
 [workspace.package]
-version = "1.0.0-alpha"
+version = "1.0.0"
 edition = "2024"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["anise", "anise-cli", "anise-gui", "anise-py", "anise/fuzz", "anise-cpp"]
 
 [workspace.package]
-version = "0.10.6"
+version = "1.0.0-alpha"
 edition = "2024"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "ANISE provides a toolkit and files for Attitude, Navigation, Instrument, Spacecraft, and Ephemeris data. It's a modern replacement of NAIF SPICE file."

--- a/anise-gui/src/spk.rs
+++ b/anise-gui/src/spk.rs
@@ -8,6 +8,22 @@ pub fn spk_ui(
     show_unix: bool,
     selected_time_scale: TimeScale,
 ) {
+    let Some((_, spk)) = almanac.spk_data.get_index(0) else {
+        ui.label(
+            egui::RichText::new("No SPK data available in almanac").color(egui::Color32::KHAKI),
+        );
+        return;
+    };
+
+    let summary_size = match spk.file_record() {
+        Ok(fr) => fr.summary_size(),
+        Err(err) => {
+            log::error!("Failed to read SPK file record: {err}");
+            ui.label(egui::RichText::new("Corrupt SPK file record").color(egui::Color32::RED));
+            return;
+        }
+    };
+
     TableBuilder::new(ui)
         .column(Column::auto().at_least(150.0).resizable(true))
         .column(Column::auto().at_least(150.0).resizable(true))
@@ -40,17 +56,35 @@ pub fn spk_ui(
             });
         })
         .body(|mut body| {
-            let spk = almanac.spk_data.get_index(0).unwrap().1;
-
             // NOTE: Using the explicit loop and index here to we can fetch the name record correctly.
             let mut idx = None;
             loop {
-                for (sno, summary) in spk.data_summaries(idx).unwrap().iter().enumerate() {
-                    let name_rcrd = spk.name_record(idx).unwrap();
-                    let name = name_rcrd.nth_name(sno, spk.file_record().unwrap().summary_size());
+                // Fetch segment summaries safely
+                let summaries = match spk.data_summaries(idx) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        log::error!("Failed to fetch SPK data summaries for index {idx:?}: {err}");
+                        break;
+                    }
+                };
+
+                let name_rcrd = match spk.name_record(idx) {
+                    Ok(r) => Some(r),
+                    Err(err) => {
+                        log::warn!("Missing name record for index {idx:?}: {err}");
+                        None
+                    }
+                };
+
+                for (sno, summary) in summaries.iter().enumerate() {
                     if summary.is_empty() {
                         continue;
                     }
+
+                    let name = name_rcrd
+                        .as_ref()
+                        .map(|r| r.nth_name(sno, summary_size))
+                        .unwrap_or_else(|| "Unknown");
 
                     body.row(30.0, |mut row| {
                         row.col(|ui| {

--- a/anise-gui/src/ui.rs
+++ b/anise-gui/src/ui.rs
@@ -96,10 +96,10 @@ impl eframe::App for UiApp {
     fn ui(&mut self, ctx: &mut egui::Ui, _frame: &mut eframe::Frame) {
         ctx.set_pixels_per_point(1.25);
 
-        egui::Panel::top("header").show_inside(ctx, |ui| {
+        egui::Panel::top("header").show(ctx, |ui| {
             ui.horizontal_centered(|ui| {
                 ui.vertical_centered(|ui| {
-                    ui.heading("ANISE v0.10");
+                    ui.heading("ANISE v1.0.0");
                     ui.label("A modern rewrite of NASA's SPICE toolkit");
                     ui.hyperlink_to(
                         "https://www.nyxspace.com",
@@ -112,7 +112,7 @@ impl eframe::App for UiApp {
         egui::Panel::bottom("bottom_panel")
             .resizable(false)
             .min_size(0.0)
-            .show_inside(ctx, |ui| {
+            .show(ctx, |ui| {
                 ui.vertical_centered(|ui| {
                     ui.heading("Run log");
                 });
@@ -123,7 +123,7 @@ impl eframe::App for UiApp {
                     .show(ui);
             });
 
-        egui::CentralPanel::default().show_inside(ctx, |ui| {
+        egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
                 ui.horizontal_centered(|ui| {
                     ui.vertical_centered(|ui| {

--- a/anise-py/anise/__init__.pyi
+++ b/anise-py/anise/__init__.pyi
@@ -10,22 +10,21 @@ import typing
 class Aberration:
     """Represents the aberration correction options in ANISE.
 
-    In space science and engineering, accurately pointing instruments (like optical cameras or radio antennas) at a target is crucial. This task is complicated by the finite speed of light, necessitating corrections for the apparent position of the target.
+In space science and engineering, accurately pointing instruments (like optical cameras or radio antennas) at a target is crucial. This task is complicated by the finite speed of light, necessitating corrections for the apparent position of the target.
 
-    This structure holds parameters for aberration corrections applied to a target's position or state vector. These corrections account for the difference between the target's geometric (true) position and its apparent position as observed.
+This structure holds parameters for aberration corrections applied to a target's position or state vector. These corrections account for the difference between the target's geometric (true) position and its apparent position as observed.
 
-    # Rule of tumb
-    In most Earth orbits, one does _not_ need to provide any aberration corrections. Light time to the target is less than one second (the Moon is about one second away).
-    In near Earth orbits, e.g. inner solar system, preliminary analysis can benefit from enabling unconverged light time correction. Stellar aberration is probably not required.
-    For deep space missions, preliminary analysis would likely require both light time correction and stellar aberration. Mission planning and operations will definitely need converged light-time calculations.
+# Rule of tumb
+In most Earth orbits, one does _not_ need to provide any aberration corrections. Light time to the target is less than one second (the Moon is about one second away).
+In near Earth orbits, e.g. inner solar system, preliminary analysis can benefit from enabling unconverged light time correction. Stellar aberration is probably not required.
+For deep space missions, preliminary analysis would likely require both light time correction and stellar aberration. Mission planning and operations will definitely need converged light-time calculations.
 
-    For more details, <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html>.
+For more details, <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html>.
 
-    # SPICE Validation
+# SPICE Validation
 
-    The validation test `validate_jplde_de440s_aberration_lt` checks 101,000 pairs of ephemeris computations and shows that the unconverged Light Time computation matches the SPICE computations almost all the time.
-    More specifically, the 99th percentile of error is less than 5 meters, the 75th percentile is less than one meter, and the median error is less than 2 millimeters."""
-
+The validation test `validate_jplde_de440s_aberration_lt` checks 101,000 pairs of ephemeris computations and shows that the unconverged Light Time computation matches the SPICE computations almost all the time.
+More specifically, the 99th percentile of error is less than 5 meters, the 75th percentile is less than one meter, and the median error is less than 2 millimeters."""
     converged: bool
     stellar: bool
     transmit_mode: bool
@@ -36,21 +35,21 @@ class Aberration:
     def __new__(cls, name: str) -> Aberration:
         """Represents the aberration correction options in ANISE.
 
-        In space science and engineering, accurately pointing instruments (like optical cameras or radio antennas) at a target is crucial. This task is complicated by the finite speed of light, necessitating corrections for the apparent position of the target.
+In space science and engineering, accurately pointing instruments (like optical cameras or radio antennas) at a target is crucial. This task is complicated by the finite speed of light, necessitating corrections for the apparent position of the target.
 
-        This structure holds parameters for aberration corrections applied to a target's position or state vector. These corrections account for the difference between the target's geometric (true) position and its apparent position as observed.
+This structure holds parameters for aberration corrections applied to a target's position or state vector. These corrections account for the difference between the target's geometric (true) position and its apparent position as observed.
 
-        # Rule of tumb
-        In most Earth orbits, one does _not_ need to provide any aberration corrections. Light time to the target is less than one second (the Moon is about one second away).
-        In near Earth orbits, e.g. inner solar system, preliminary analysis can benefit from enabling unconverged light time correction. Stellar aberration is probably not required.
-        For deep space missions, preliminary analysis would likely require both light time correction and stellar aberration. Mission planning and operations will definitely need converged light-time calculations.
+# Rule of tumb
+In most Earth orbits, one does _not_ need to provide any aberration corrections. Light time to the target is less than one second (the Moon is about one second away).
+In near Earth orbits, e.g. inner solar system, preliminary analysis can benefit from enabling unconverged light time correction. Stellar aberration is probably not required.
+For deep space missions, preliminary analysis would likely require both light time correction and stellar aberration. Mission planning and operations will definitely need converged light-time calculations.
 
-        For more details, <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html>.
+For more details, <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html>.
 
-        # SPICE Validation
+# SPICE Validation
 
-        The validation test `validate_jplde_de440s_aberration_lt` checks 101,000 pairs of ephemeris computations and shows that the unconverged Light Time computation matches the SPICE computations almost all the time.
-        More specifically, the 99th percentile of error is less than 5 meters, the 75th percentile is less than one meter, and the median error is less than 2 millimeters."""
+The validation test `validate_jplde_de440s_aberration_lt` checks 101,000 pairs of ephemeris computations and shows that the unconverged Light Time computation matches the SPICE computations almost all the time.
+More specifically, the 99th percentile of error is less than 5 meters, the 75th percentile is less than one meter, and the median error is less than 2 millimeters."""
 
     def __eq__(self, value: typing.Any) -> bool:
         """Return self==value."""
@@ -86,112 +85,73 @@ class Almanac:
     def __new__(cls, path: str) -> Almanac:
         """An Almanac contains all of the loaded SPICE and ANISE data. It is the context for all computations."""
 
-    def angular_velocity_deg_s(
-        self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch
-    ) -> numpy.ndarray:
+    def angular_velocity_deg_s(self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch) -> numpy.ndarray:
         """Returns the angular velocity vector in deg/s of the from_frame wrt to the to_frame.
 
-        This can be used to compute the angular velocity of the Earth ITRF93 frame with respect to the J2000 frame for example."""
+This can be used to compute the angular velocity of the Earth ITRF93 frame with respect to the J2000 frame for example."""
 
-    def angular_velocity_rad_s(
-        self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch
-    ) -> numpy.ndarray:
+    def angular_velocity_rad_s(self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch) -> numpy.ndarray:
         """Returns the angular velocity vector in rad/s of the from_frame wrt to the to_frame.
 
-        This can be used to compute the angular velocity of the Earth ITRF93 frame with respect to the J2000 frame for example."""
+This can be used to compute the angular velocity of the Earth ITRF93 frame with respect to the J2000 frame for example."""
 
-    def angular_velocity_wrt_j2000_deg_s(
-        self, from_frame: astro.Frame, epoch: time.Epoch
-    ) -> numpy.ndarray:
+    def angular_velocity_wrt_j2000_deg_s(self, from_frame: astro.Frame, epoch: time.Epoch) -> numpy.ndarray:
         """Returns the angular velocity vector in deg/s of the from_frame wrt to the J2000 frame."""
 
-    def angular_velocity_wrt_j2000_rad_s(
-        self, from_frame: astro.Frame, epoch: time.Epoch
-    ) -> numpy.ndarray:
+    def angular_velocity_wrt_j2000_rad_s(self, from_frame: astro.Frame, epoch: time.Epoch) -> numpy.ndarray:
         """Returns the angular velocity vector in rad/s of the from_frame wrt to the J2000 frame."""
 
-    def azimuth_elevation_range_sez(
-        self,
-        rx: astro.Orbit,
-        tx: astro.Orbit,
-        obstructing_body: typing.Optional[astro.Frame] = None,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.AzElRange:
+    def azimuth_elevation_range_sez(self, rx: astro.Orbit, tx: astro.Orbit, obstructing_body: typing.Optional[astro.Frame]=None, ab_corr: typing.Optional[Aberration]=None) -> astro.AzElRange:
         """Computes the azimuth (in degrees), elevation (in degrees), and range (in kilometers) of the
-        receiver state (`rx`) seen from the transmitter state (`tx`), once converted into the SEZ frame of the transmitter.
+receiver state (`rx`) seen from the transmitter state (`tx`), once converted into the SEZ frame of the transmitter.
 
-        # Warning
-        The obstructing body _should_ be a tri-axial ellipsoid body, e.g. IAU_MOON_FRAME.
+# Warning
+The obstructing body _should_ be a tri-axial ellipsoid body, e.g. IAU_MOON_FRAME.
 
-        # Algorithm
-        1. If any obstructing_bodies are provided, ensure that none of these are obstructing the line of sight between the receiver and transmitter.
-        2. Compute the SEZ (South East Zenith) frame of the transmitter.
-        3. Rotate the receiver position vector into the transmitter SEZ frame.
-        4. Rotate the transmitter position vector into that same SEZ frame.
-        5. Compute the range as the norm of the difference between these two position vectors.
-        6. Compute the elevation, and ensure it is between +/- 180 degrees.
-        7. Compute the azimuth with a quadrant check, and ensure it is between 0 and 360 degrees."""
+# Algorithm
+1. If any obstructing_bodies are provided, ensure that none of these are obstructing the line of sight between the receiver and transmitter.
+2. Compute the SEZ (South East Zenith) frame of the transmitter.
+3. Rotate the receiver position vector into the transmitter SEZ frame.
+4. Rotate the transmitter position vector into that same SEZ frame.
+5. Compute the range as the norm of the difference between these two position vectors.
+6. Compute the elevation, and ensure it is between +/- 180 degrees.
+7. Compute the azimuth with a quadrant check, and ensure it is between 0 and 360 degrees."""
 
-    def azimuth_elevation_range_sez_from_location(
-        self,
-        rx: astro.Orbit,
-        location: astro.Location,
-        obstructing_body: typing.Optional[astro.Frame] = None,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.AzElRange:
+    def azimuth_elevation_range_sez_from_location(self, rx: astro.Orbit, location: astro.Location, obstructing_body: typing.Optional[astro.Frame]=None, ab_corr: typing.Optional[Aberration]=None) -> astro.AzElRange:
         """Computes the azimuth (in degrees), elevation (in degrees), and range (in kilometers) of the
-        receiver state (`rx`) seen from the provided location (as transmitter state, once converted into the SEZ frame of the transmitter.
-        Refer to [azimuth_elevation_range_sez] for algorithm details.
-        Location terrain masks are always applied, i.e. if the terrain masks the object, all data is set to f64::NAN, unless specified otherwise in the Location."""
+receiver state (`rx`) seen from the provided location (as transmitter state, once converted into the SEZ frame of the transmitter.
+Refer to [azimuth_elevation_range_sez] for algorithm details.
+Location terrain masks are always applied, i.e. if the terrain masks the object, all data is set to f64::NAN, unless specified otherwise in the Location."""
 
-    def azimuth_elevation_range_sez_from_location_id(
-        self,
-        rx: astro.Orbit,
-        location_id: int,
-        obstructing_body: typing.Optional[astro.Frame] = None,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.AzElRange:
+    def azimuth_elevation_range_sez_from_location_id(self, rx: astro.Orbit, location_id: int, obstructing_body: typing.Optional[astro.Frame]=None, ab_corr: typing.Optional[Aberration]=None) -> astro.AzElRange:
         """Computes the azimuth (in degrees), elevation (in degrees), and range (in kilometers) of the
-        receiver state (`rx`) seen from the location ID (as transmitter state, once converted into the SEZ frame of the transmitter.
-        Refer to [azimuth_elevation_range_sez] for algorithm details."""
+receiver state (`rx`) seen from the location ID (as transmitter state, once converted into the SEZ frame of the transmitter.
+Refer to [azimuth_elevation_range_sez] for algorithm details."""
 
-    def azimuth_elevation_range_sez_from_location_name(
-        self,
-        rx: astro.Orbit,
-        location_name: str,
-        obstructing_body: typing.Optional[astro.Frame] = None,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.AzElRange:
+    def azimuth_elevation_range_sez_from_location_name(self, rx: astro.Orbit, location_name: str, obstructing_body: typing.Optional[astro.Frame]=None, ab_corr: typing.Optional[Aberration]=None) -> astro.AzElRange:
         """Computes the azimuth (in degrees), elevation (in degrees), and range (in kilometers) of the
-        receiver state (`rx`) seen from the location ID (as transmitter state, once converted into the SEZ frame of the transmitter.
-        Refer to [azimuth_elevation_range_sez] for algorithm details."""
+receiver state (`rx`) seen from the location ID (as transmitter state, once converted into the SEZ frame of the transmitter.
+Refer to [azimuth_elevation_range_sez] for algorithm details."""
 
-    def azimuth_elevation_range_sez_many(
-        self,
-        rx_tx_states: typing.List[astro.Orbit],
-        obstructing_body: typing.Optional[astro.Frame] = None,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> typing.List[astro.AzElRange]:
+    def azimuth_elevation_range_sez_many(self, rx_tx_states: typing.List[astro.Orbit], obstructing_body: typing.Optional[astro.Frame]=None, ab_corr: typing.Optional[Aberration]=None) -> typing.List[astro.AzElRange]:
         """Computes the azimuth (in degrees), elevation (in degrees), and range (in kilometers) of the
-        receiver states (first item in tuple) seen from the transmitter state (second item in states tuple), once converted into the SEZ frame of the transmitter.
+receiver states (first item in tuple) seen from the transmitter state (second item in states tuple), once converted into the SEZ frame of the transmitter.
 
-        Note: if any computation fails, the error will be printed to the stderr.
-        Note: the output AER will be chronologically sorted, regardless of transmitter.
+Note: if any computation fails, the error will be printed to the stderr.
+Note: the output AER will be chronologically sorted, regardless of transmitter.
 
-        Refer to [azimuth_elevation_range_sez] for details."""
+Refer to [azimuth_elevation_range_sez] for details."""
 
-    def beta_angle_deg(
-        self, state: astro.Orbit, ab_corr: typing.Optional[Aberration] = None
-    ) -> float:
+    def beta_angle_deg(self, state: astro.Orbit, ab_corr: typing.Optional[Aberration]=None) -> float:
         """Computes the Beta angle (β) for a given orbital state, in degrees. A Beta angle of 0° indicates that the orbit plane is edge-on to the Sun, leading to maximum eclipse time. Conversely, a Beta angle of +90° or -90° means the orbit plane is face-on to the Sun, resulting in continuous sunlight exposure and no eclipses.
 
-        The Beta angle (β) is defined as the angle between the orbit plane of a spacecraft and the vector from the central body (e.g., Earth) to the Sun. In simpler terms, it measures how much of the time a satellite in orbit is exposed to direct sunlight.
-        The mathematical formula for the Beta angle is: β=arcsin(h⋅usun\u200b)
-        Where:
-        - h is the unit vector of the orbital momentum.
-        - usun\u200b is the unit vector pointing from the central body to the Sun.
+The Beta angle (β) is defined as the angle between the orbit plane of a spacecraft and the vector from the central body (e.g., Earth) to the Sun. In simpler terms, it measures how much of the time a satellite in orbit is exposed to direct sunlight.
+The mathematical formula for the Beta angle is: β=arcsin(h⋅usun\u200b)
+Where:
+- h is the unit vector of the orbital momentum.
+- usun\u200b is the unit vector pointing from the central body to the Sun.
 
-        Original code from GMAT, <https://github.com/ChristopherRabotin/GMAT/blob/GMAT-R2022a/src/gmatutil/util/CalculationUtilities.cpp#L209-L219>"""
+Original code from GMAT, <https://github.com/ChristopherRabotin/GMAT/blob/GMAT-R2022a/src/gmatutil/util/CalculationUtilities.cpp#L209-L219>"""
 
     def bpc_domain(self, id: int) -> typing.Tuple:
         """Returns the applicable domain of the request id, i.e. start and end epoch that the provided id has loaded data."""
@@ -199,40 +159,30 @@ class Almanac:
     def bpc_domains(self) -> typing.Dict:
         """Returns a map of each loaded BPC ID to its domain validity.
 
-        # Warning
-        This function performs a memory allocation."""
+# Warning
+This function performs a memory allocation."""
 
     def bpc_summaries(self, id: int) -> typing.List:
         """Returns a vector of the summaries whose ID matches the desired `id`, in the order in which they will be used, i.e. in reverse loading order.
 
-        # Warning
-        This function performs a memory allocation."""
+# Warning
+This function performs a memory allocation."""
 
     def bpc_swap(self, alias: str, new_bpc_path: str, new_alias: str) -> None:
         """Load a new DAF/BPC file in place of the one in the provided alias.
 
-        This reuses the existing memory buffer, growing it only if the new file
-        is larger than the previous capacity. This effectively adopts a
-        "high watermark" memory strategy, where the memory usage for this slot
-        is determined by the largest file ever loaded into it."""
+This reuses the existing memory buffer, growing it only if the new file
+is larger than the previous capacity. This effectively adopts a
+"high watermark" memory strategy, where the memory usage for this slot
+is determined by the largest file ever loaded into it."""
 
     def bpc_unload(self, alias: str) -> None:
         """Unloads (in-place) the BPC with the provided alias.
-        **WARNING:** This causes the order of the loaded files to be perturbed, which may be an issue if several SPKs with the same IDs are loaded."""
+**WARNING:** This causes the order of the loaded files to be perturbed, which may be an issue if several SPKs with the same IDs are loaded."""
 
-    def describe(
-        self,
-        spk: typing.Optional[bool] = None,
-        bpc: typing.Optional[bool] = None,
-        planetary: typing.Optional[bool] = None,
-        spacecraft: typing.Optional[bool] = None,
-        eulerparams: typing.Optional[bool] = None,
-        locations: typing.Optional[bool] = None,
-        time_scale: typing.Optional[time.TimeScale] = None,
-        round_time: typing.Optional[bool] = None,
-    ) -> None:
+    def describe(self, spk: typing.Optional[bool]=None, bpc: typing.Optional[bool]=None, planetary: typing.Optional[bool]=None, spacecraft: typing.Optional[bool]=None, eulerparams: typing.Optional[bool]=None, locations: typing.Optional[bool]=None, time_scale: typing.Optional[time.TimeScale]=None, round_time: typing.Optional[bool]=None) -> None:
         """Pretty prints the description of this Almanac, showing everything by default. Default time scale is TDB.
-        If any parameter is set to true, then nothing other than that will be printed."""
+If any parameter is set to true, then nothing other than that will be printed."""
 
     def frame_info(self, uid: astro.Frame) -> astro.Frame:
         """Returns the frame information (gravitational param, shape) as defined in this Almanac from an empty frame"""
@@ -241,58 +191,42 @@ class Almanac:
     def from_ccsds_oem_file(path: str, naif_id: int) -> Almanac:
         """Initializes a new Almanac from a file path to CCSDS OEM file, after converting to to SPICE SPK/BSP"""
 
-    def insert_location(
-        self, location: LocationDhallSetEntry, replace: typing.Optional[bool] = None
-    ) -> typing.Any:
+    def insert_location(self, location: LocationDhallSetEntry, replace: typing.Optional[bool]=None) -> typing.Any:
         """Inserts the provided location info, as a DhallSetEntry, into the Almanac. Use this to build a location kernel in memory.
-        Set the optional parameter `replace` to True to replace any preexisting location with this ID.
-        If replace is unset or false, and the location ID is already taken, this function will raise an error."""
+Set the optional parameter `replace` to True to replace any preexisting location with this ID.
+If replace is unset or false, and the location ID is already taken, this function will raise an error."""
 
-    def line_of_sight_obstructed(
-        self,
-        observer: astro.Orbit,
-        observed: astro.Orbit,
-        obstructing_body: astro.Frame,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> bool:
+    def line_of_sight_obstructed(self, observer: astro.Orbit, observed: astro.Orbit, obstructing_body: astro.Frame, ab_corr: typing.Optional[Aberration]=None) -> bool:
         """Computes whether the line of sight between an observer and an observed Cartesian state is obstructed by the obstructing body.
-        Returns true if the obstructing body is in the way, false otherwise.
+Returns true if the obstructing body is in the way, false otherwise.
 
-        For example, if the Moon is in between a Lunar orbiter (observed) and a ground station (observer), then this function returns `true`
-        because the Moon (obstructing body) is indeed obstructing the line of sight.
+For example, if the Moon is in between a Lunar orbiter (observed) and a ground station (observer), then this function returns `true`
+because the Moon (obstructing body) is indeed obstructing the line of sight.
 
-        ```text
-        Observed
-        o  -
-        +    -
-        +      -
-        + ***   -
-        * +    *   -
-        *  + + * + + o
-        *     *     Observer
-        ****
-        ```
+```text
+Observed
+o  -
++    -
++      -
++ ***   -
+* +    *   -
+*  + + * + + o
+*     *     Observer
+****
+```
 
-        Key Elements:
-        - `o` represents the positions of the observer and observed objects.
-        - The dashed line connecting the observer and observed is the line of sight.
+Key Elements:
+- `o` represents the positions of the observer and observed objects.
+- The dashed line connecting the observer and observed is the line of sight.
 
-        Algorithm (source: Algorithm 35 of Vallado, 4th edition, page 308.):
-        - `r1` and `r2` are the transformed radii of the observed and observer objects, respectively.
-        - `r1sq` and `r2sq` are the squared magnitudes of these vectors.
-        - `r1dotr2` is the dot product of `r1` and `r2`.
-        - `tau` is a parameter that determines the intersection point along the line of sight.
-        - The condition `(1.0 - tau) * r1sq + r1dotr2 * tau <= ob_mean_eq_radius_km^2` checks if the line of sight is within the obstructing body's radius, indicating an obstruction."""
+Algorithm (source: Algorithm 35 of Vallado, 4th edition, page 308.):
+- `r1` and `r2` are the transformed radii of the observed and observer objects, respectively.
+- `r1sq` and `r2sq` are the squared magnitudes of these vectors.
+- `r1dotr2` is the dot product of `r1` and `r2`.
+- `tau` is a parameter that determines the intersection point along the line of sight.
+- The condition `(1.0 - tau) * r1sq + r1dotr2 * tau <= ob_mean_eq_radius_km^2` checks if the line of sight is within the obstructing body's radius, indicating an obstruction."""
 
-    def list_kernels(
-        self,
-        spk: typing.Optional[bool] = None,
-        bpc: typing.Optional[bool] = None,
-        planetary: typing.Optional[bool] = None,
-        spacecraft: typing.Optional[bool] = None,
-        eulerparams: typing.Optional[bool] = None,
-        locations: typing.Optional[bool] = None,
-    ) -> list:
+    def list_kernels(self, spk: typing.Optional[bool]=None, bpc: typing.Optional[bool]=None, planetary: typing.Optional[bool]=None, spacecraft: typing.Optional[bool]=None, eulerparams: typing.Optional[bool]=None, locations: typing.Optional[bool]=None) -> list:
         """Returns the list of loaded kernels"""
 
     def load(self, path: str) -> Almanac:
@@ -303,7 +237,7 @@ class Almanac:
 
     def load_from_metafile(self, metafile: MetaFile, autodelete: bool) -> Almanac:
         """Load from the provided MetaFile, downloading it if necessary.
-        Set autodelete to true to automatically delete lock files. Lock files are important in multi-threaded loads."""
+Set autodelete to true to automatically delete lock files. Lock files are important in multi-threaded loads."""
 
     def load_stk_e_file(self, path: str, naif_id: int) -> Almanac:
         """Converts the provided Ansys STK .e file to SPICE SPK/BSP and loads it in the Almanac."""
@@ -314,109 +248,69 @@ class Almanac:
     def location_from_name(self, name: str) -> astro.Location:
         """Returns the Location from its name, searching through all loaded location datasets in reverse order."""
 
-    def occultation(
-        self,
-        back_frame: astro.Frame,
-        front_frame: astro.Frame,
-        observer: astro.Orbit,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Occultation:
+    def occultation(self, back_frame: astro.Frame, front_frame: astro.Frame, observer: astro.Orbit, ab_corr: typing.Optional[Aberration]=None) -> astro.Occultation:
         """Computes the occultation percentage of the `back_frame` object by the `front_frame` object as seen from the observer, when according for the provided aberration correction.
 
-        A zero percent occultation means that the back object is fully visible from the observer.
-        A 100%  percent occultation means that the back object is fully hidden from the observer because of the front frame (i.e. _umbra_ if the back object is the Sun).
-        A value in between means that the back object is partially hidden from the observser (i.e. _penumbra_ if the back object is the Sun).
-        Refer to the [MathSpec](https://nyxspace.com/nyxspace/MathSpec/celestial/eclipse/) for modeling details."""
+A zero percent occultation means that the back object is fully visible from the observer.
+A 100%  percent occultation means that the back object is fully hidden from the observer because of the front frame (i.e. _umbra_ if the back object is the Sun).
+A value in between means that the back object is partially hidden from the observser (i.e. _penumbra_ if the back object is the Sun).
+Refer to the [MathSpec](https://nyxspace.com/nyxspace/MathSpec/celestial/eclipse/) for modeling details."""
 
-    def report_event_arcs(
-        self,
-        state_spec: analysis.StateSpec,
-        event: analysis.Event,
-        start_epoch: time.Epoch,
-        end_epoch: time.Epoch,
-    ) -> list:
+    def report_event_arcs(self, state_spec: analysis.StateSpec, event: analysis.Event, start_epoch: time.Epoch, end_epoch: time.Epoch) -> list:
         """Report the rising and falling edges/states where the event arc happens.
 
-        For example, for a scalar expression less than X, this will report all of the times when the expression falls below X and rises above X.
-        This method uses the report_events function under the hood."""
+For example, for a scalar expression less than X, this will report all of the times when the expression falls below X and rises above X.
+This method uses the report_events function under the hood."""
 
-    def report_events(
-        self,
-        state_spec: analysis.StateSpec,
-        event: analysis.Event,
-        start_epoch: time.Epoch,
-        end_epoch: time.Epoch,
-    ) -> list:
+    def report_events(self, state_spec: analysis.StateSpec, event: analysis.Event, start_epoch: time.Epoch, end_epoch: time.Epoch) -> list:
         """Report all of the states when the provided event happens.
-        This method may only be used for equality events, minimum, and maximum events. For spanned events (e.g. Less Than/Greater Than), use report_event_arcs.
+This method may only be used for equality events, minimum, and maximum events. For spanned events (e.g. Less Than/Greater Than), use report_event_arcs.
 
-        # Method
-        The report event function starts by lineraly scanning the whole state spec from the start to the end epoch.
-        This uses an adaptive step scan modeled on the Runge Kutta adaptive step integrator, but the objective is to ensure that the scalar expression
-        of the event is evaluated at steps where it is linearly changing (to within 10% of linearity). This allows finding coarse brackets where
-        the expression changes signs exactly once.
-        Then, each bracket it sent in parallel to a Brent's method root finder to find the exact time of the event.
+# Method
+The report event function starts by lineraly scanning the whole state spec from the start to the end epoch.
+This uses an adaptive step scan modeled on the Runge Kutta adaptive step integrator, but the objective is to ensure that the scalar expression
+of the event is evaluated at steps where it is linearly changing (to within 10% of linearity). This allows finding coarse brackets where
+the expression changes signs exactly once.
+Then, each bracket it sent in parallel to a Brent's method root finder to find the exact time of the event.
 
-        # Limitation
-        While this approach is both very robust and very fast, if you think the finder may be missing some events, you should _reduce_ the epoch precision
-        of the event as a multiplicative factor of that precision is used to scan the trajectory linearly. Alternatively, you may export the scalars at
-        a fixed interval using the report_scalars or report_scalars_flat function and manually analyze the results of the scalar expression."""
+# Limitation
+While this approach is both very robust and very fast, if you think the finder may be missing some events, you should _reduce_ the epoch precision
+of the event as a multiplicative factor of that precision is used to scan the trajectory linearly. Alternatively, you may export the scalars at
+a fixed interval using the report_scalars or report_scalars_flat function and manually analyze the results of the scalar expression."""
 
-    def report_scalars(
-        self, report: analysis.ReportScalars, time_series: time.TimeSeries
-    ) -> dict:
+    def report_scalars(self, report: analysis.ReportScalars, time_series: time.TimeSeries) -> dict:
         """Report a set of scalar expressions, optionally with aliases, at a fixed time step defined in the TimeSeries."""
 
-    def report_visibility_arcs(
-        self,
-        state_spec: analysis.StateSpec,
-        location_id: int,
-        start_epoch: time.Epoch,
-        end_epoch: time.Epoch,
-        sample_rate: time.Duration,
-        obstructing_body: typing.Optional[astro.Frame] = None,
-    ) -> list:
+    def report_visibility_arcs(self, state_spec: analysis.StateSpec, location_id: int, start_epoch: time.Epoch, end_epoch: time.Epoch, sample_rate: time.Duration, obstructing_body: typing.Optional[astro.Frame]=None) -> list:
         """Report the list of visibility arcs for the desired location ID."""
 
-    def rotate(
-        self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch
-    ) -> rotation.DCM:
+    def rotate(self, from_frame: astro.Frame, to_frame: astro.Frame, epoch: time.Epoch) -> rotation.DCM:
         """Returns the 6x6 DCM needed to rotation the `from_frame` to the `to_frame`.
 
-        # Warning
-        This function only performs the rotation and no translation whatsoever. Use the `transform_from_to` function instead to include rotations.
+# Warning
+This function only performs the rotation and no translation whatsoever. Use the `transform_from_to` function instead to include rotations.
 
-        # Note
-        This function performs a recursion of no more than twice the MAX_TREE_DEPTH."""
+# Note
+This function performs a recursion of no more than twice the MAX_TREE_DEPTH."""
 
     def rotate_to(self, state: astro.Orbit, observer_frame: astro.Frame) -> astro.Orbit:
         """Rotates the provided Cartesian state into the requested observer frame
 
-        **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_to` function instead to include rotations."""
+**WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_to` function instead to include rotations."""
 
-    def solar_eclipsing(
-        self,
-        eclipsing_frame: astro.Frame,
-        observer: astro.Orbit,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Occultation:
+    def solar_eclipsing(self, eclipsing_frame: astro.Frame, observer: astro.Orbit, ab_corr: typing.Optional[Aberration]=None) -> astro.Occultation:
         """Computes the solar eclipsing of the observer due to the eclipsing_frame.
 
-        This function calls `occultation` where the back object is the Sun in the J2000 frame, and the front object
-        is the provided eclipsing frame."""
+This function calls `occultation` where the back object is the Sun in the J2000 frame, and the front object
+is the provided eclipsing frame."""
 
-    def solar_eclipsing_many(
-        self,
-        eclipsing_frame: astro.Frame,
-        observers: typing.List[astro.Orbit],
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> typing.List[astro.Occultation]:
+    def solar_eclipsing_many(self, eclipsing_frame: astro.Frame, observers: typing.List[astro.Orbit], ab_corr: typing.Optional[Aberration]=None) -> typing.List[astro.Occultation]:
         """Computes the solar eclipsing of all the observers due to the eclipsing_frame, computed in parallel under the hood.
 
-        Note: if any computation fails, the error will be printed to the stderr.
-        Note: the output AER will be chronologically sorted, regardless of transmitter.
+Note: if any computation fails, the error will be printed to the stderr.
+Note: the output AER will be chronologically sorted, regardless of transmitter.
 
-        Refer to [solar_eclipsing] for details."""
+Refer to [solar_eclipsing] for details."""
 
     def spk_domain(self, id: int) -> typing.Tuple:
         """Returns the applicable domain of the request id, i.e. start and end epoch that the provided id has loaded data."""
@@ -424,53 +318,38 @@ class Almanac:
     def spk_domains(self) -> typing.Dict:
         """Returns a map of each loaded SPK ID to its domain validity.
 
-        # Warning
-        This function performs a memory allocation."""
+# Warning
+This function performs a memory allocation."""
 
-    def spk_ezr(
-        self,
-        target: int,
-        epoch: time.Epoch,
-        frame: int,
-        observer: int,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def spk_ezr(self, target: int, epoch: time.Epoch, frame: int, observer: int, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Alias fo SPICE's `spkezr` where the inputs must be the NAIF IDs of the objects and frames with the caveat that the aberration is moved to the last positional argument."""
 
     def spk_summaries(self, id: int) -> typing.List:
         """Returns a vector of the summaries whose ID matches the desired `id`, in the order in which they will be used, i.e. in reverse loading order.
 
-        # Warning
-        This function performs a memory allocation."""
+# Warning
+This function performs a memory allocation."""
 
     def spk_swap(self, alias: str, new_spk_path: str, new_alias: str) -> None:
         """Load a new DAF/SPK file in place of the one in the provided alias.
 
-        This reuses the existing memory buffer, growing it only if the new file
-        is larger than the previous capacity. This effectively adopts a
-        "high watermark" memory strategy, where the memory usage for this slot
-        is determined by the largest file ever loaded into it
-        ."""
+This reuses the existing memory buffer, growing it only if the new file
+is larger than the previous capacity. This effectively adopts a
+"high watermark" memory strategy, where the memory usage for this slot
+is determined by the largest file ever loaded into it
+."""
 
     def spk_unload(self, alias: str) -> None:
         """Unloads (in-place) the SPK with the provided alias.
-        **WARNING:** This causes the order of the loaded files to be perturbed, which may be an issue if several SPKs with the same IDs are loaded."""
+**WARNING:** This causes the order of the loaded files to be perturbed, which may be an issue if several SPKs with the same IDs are loaded."""
 
-    def state_of(
-        self,
-        object_id: int,
-        observer: astro.Frame,
-        epoch: time.Epoch,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def state_of(self, object_id: int, observer: astro.Frame, epoch: time.Epoch, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Returns the Cartesian state of the object as seen from the provided observer frame (essentially `spkezr`).
 
-        # Note
-        The units will be those of the underlying ephemeris data (typically km and km/s)"""
+# Note
+The units will be those of the underlying ephemeris data (typically km and km/s)"""
 
-    def sun_angle_deg(
-        self, target_id: int, observer_id: int, epoch: time.Epoch, ab_corr: Aberration
-    ) -> float:
+    def sun_angle_deg(self, target_id: int, observer_id: int, epoch: time.Epoch, ab_corr: Aberration) -> float:
         """Returns the angular separation (between 0 and 180 degrees) between the observer and the Sun, and the observer and the target body ID.
 This is formally known as the "solar elongation".
 This computes the Sun Probe Earth angle (SPE) if the probe is in a loaded SPK, its ID is the "observer_id", and the target is set to its central body.
@@ -515,115 +394,72 @@ Obs. -- Target
 2. Compute the position of the target as seen from the observer
 3. Return the arccosine of the dot product of the norms of these vectors."""
 
-    def sun_angle_deg_from_frame(
-        self,
-        target: astro.Frame,
-        observer: astro.Frame,
-        epoch: time.Epoch,
-        ab_corr: Aberration,
-    ) -> float:
+    def sun_angle_deg_from_frame(self, target: astro.Frame, observer: astro.Frame, epoch: time.Epoch, ab_corr: Aberration) -> float:
         """Convenience function that calls `sun_angle_deg` with the provided frames instead of the ephemeris ID."""
 
     def to_metaalmanac(self) -> MetaAlmanac:
         """Saves the current configuration to a MetaAlmanac for future reloading from the local file system.
 
-        WARNING: If data was loaded from its raw bytes, or if a custom alias was used, then the MetaFile produced will not be usable.
-        The alias used for each data type is expected to be a path. Further, all paths are ASSUMED to be loaded from the same directory.
-        The Almanac does not resolve directories for you."""
+WARNING: If data was loaded from its raw bytes, or if a custom alias was used, then the MetaFile produced will not be usable.
+The alias used for each data type is expected to be a path. Further, all paths are ASSUMED to be loaded from the same directory.
+The Almanac does not resolve directories for you."""
 
-    def transform(
-        self,
-        target_frame: astro.Frame,
-        observer_frame: astro.Frame,
-        epoch: time.Epoch,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def transform(self, target_frame: astro.Frame, observer_frame: astro.Frame, epoch: time.Epoch, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Returns the Cartesian state needed to transform the `from_frame` to the `to_frame`.
 
-        # SPICE Compatibility
-        This function is the SPICE equivalent of spkezr: `spkezr(TARGET_ID, EPOCH_TDB_S, ORIENTATION_ID, ABERRATION, OBSERVER_ID)`
-        In ANISE, the TARGET_ID and ORIENTATION are provided in the first argument (TARGET_FRAME), as that frame includes BOTH
-        the target ID and the orientation of that target. The EPOCH_TDB_S is the epoch in the TDB time system, which is computed
-        in ANISE using Hifitime. THe ABERRATION is computed by providing the optional Aberration flag. Finally, the OBSERVER
-        argument is replaced by OBSERVER_FRAME: if the OBSERVER_FRAME argument has the same orientation as the TARGET_FRAME, then this call
-        will return exactly the same data as the spkerz SPICE call.
+# SPICE Compatibility
+This function is the SPICE equivalent of spkezr: `spkezr(TARGET_ID, EPOCH_TDB_S, ORIENTATION_ID, ABERRATION, OBSERVER_ID)`
+In ANISE, the TARGET_ID and ORIENTATION are provided in the first argument (TARGET_FRAME), as that frame includes BOTH
+the target ID and the orientation of that target. The EPOCH_TDB_S is the epoch in the TDB time system, which is computed
+in ANISE using Hifitime. THe ABERRATION is computed by providing the optional Aberration flag. Finally, the OBSERVER
+argument is replaced by OBSERVER_FRAME: if the OBSERVER_FRAME argument has the same orientation as the TARGET_FRAME, then this call
+will return exactly the same data as the spkerz SPICE call.
 
-        # Note
-        The units will be those of the underlying ephemeris data (typically km and km/s)"""
+# Note
+The units will be those of the underlying ephemeris data (typically km and km/s)"""
 
-    def transform_many(
-        self,
-        target_frame: astro.Frame,
-        observer_frame: astro.Frame,
-        time_series: time.TimeSeries,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> typing.List[astro.Orbit]:
+    def transform_many(self, target_frame: astro.Frame, observer_frame: astro.Frame, time_series: time.TimeSeries, ab_corr: typing.Optional[Aberration]=None) -> typing.List[astro.Orbit]:
         """Returns a chronologically sorted list of the Cartesian states that transform the `from_frame` to the `to_frame` for each epoch of the time series, computed in parallel under the hood.
-        Note: if any transformation fails, the error will be printed to the stderr.
+Note: if any transformation fails, the error will be printed to the stderr.
 
-        Refer to [transform] for details."""
+Refer to [transform] for details."""
 
-    def transform_many_to(
-        self,
-        states: typing.List[astro.Orbit],
-        observer_frame: astro.Frame,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> typing.List[astro.Orbit]:
+    def transform_many_to(self, states: typing.List[astro.Orbit], observer_frame: astro.Frame, ab_corr: typing.Optional[Aberration]=None) -> typing.List[astro.Orbit]:
         """Returns a chronologically sorted list of the provided states as seen from the observer frame, given the aberration.
-        Note: if any transformation fails, the error will be printed to the stderr.
-        Note: the input ordering is lost: the output states will not be in the same order as the input states if these are not chronologically sorted!
+Note: if any transformation fails, the error will be printed to the stderr.
+Note: the input ordering is lost: the output states will not be in the same order as the input states if these are not chronologically sorted!
 
-        Refer to [transform_to] for details."""
+Refer to [transform_to] for details."""
 
-    def transform_to(
-        self,
-        state: astro.Orbit,
-        observer_frame: astro.Frame,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def transform_to(self, state: astro.Orbit, observer_frame: astro.Frame, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Returns the provided state as seen from the observer frame, given the aberration."""
 
-    def translate(
-        self,
-        target_frame: astro.Frame,
-        observer_frame: astro.Frame,
-        epoch: time.Epoch,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def translate(self, target_frame: astro.Frame, observer_frame: astro.Frame, epoch: time.Epoch, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Returns the Cartesian state of the target frame as seen from the observer frame at the provided epoch, and optionally given the aberration correction.
 
-        # SPICE Compatibility
-        This function is the SPICE equivalent of spkezr: `spkezr(TARGET_ID, EPOCH_TDB_S, ORIENTATION_ID, ABERRATION, OBSERVER_ID)`
-        In ANISE, the TARGET_ID and ORIENTATION are provided in the first argument (TARGET_FRAME), as that frame includes BOTH
-        the target ID and the orientation of that target. The EPOCH_TDB_S is the epoch in the TDB time system, which is computed
-        in ANISE using Hifitime. THe ABERRATION is computed by providing the optional Aberration flag. Finally, the OBSERVER
-        argument is replaced by OBSERVER_FRAME: if the OBSERVER_FRAME argument has the same orientation as the TARGET_FRAME, then this call
-        will return exactly the same data as the spkerz SPICE call.
+# SPICE Compatibility
+This function is the SPICE equivalent of spkezr: `spkezr(TARGET_ID, EPOCH_TDB_S, ORIENTATION_ID, ABERRATION, OBSERVER_ID)`
+In ANISE, the TARGET_ID and ORIENTATION are provided in the first argument (TARGET_FRAME), as that frame includes BOTH
+the target ID and the orientation of that target. The EPOCH_TDB_S is the epoch in the TDB time system, which is computed
+in ANISE using Hifitime. THe ABERRATION is computed by providing the optional Aberration flag. Finally, the OBSERVER
+argument is replaced by OBSERVER_FRAME: if the OBSERVER_FRAME argument has the same orientation as the TARGET_FRAME, then this call
+will return exactly the same data as the spkerz SPICE call.
 
-        # Warning
-        This function only performs the translation and no rotation whatsoever. Use the `transform` function instead to include rotations.
+# Warning
+This function only performs the translation and no rotation whatsoever. Use the `transform` function instead to include rotations.
 
-        # Note
-        This function performs a recursion of no more than twice the [MAX_TREE_DEPTH]."""
+# Note
+This function performs a recursion of no more than twice the [MAX_TREE_DEPTH]."""
 
-    def translate_geometric(
-        self, target_frame: astro.Frame, observer_frame: astro.Frame, epoch: time.Epoch
-    ) -> astro.Orbit:
+    def translate_geometric(self, target_frame: astro.Frame, observer_frame: astro.Frame, epoch: time.Epoch) -> astro.Orbit:
         """Returns the geometric position vector, velocity vector, and acceleration vector needed to translate the `from_frame` to the `to_frame`, where the distance is in km, the velocity in km/s, and the acceleration in km/s^2."""
 
-    def translate_to(
-        self,
-        state: astro.Orbit,
-        observer_frame: astro.Frame,
-        ab_corr: typing.Optional[Aberration] = None,
-    ) -> astro.Orbit:
+    def translate_to(self, state: astro.Orbit, observer_frame: astro.Frame, ab_corr: typing.Optional[Aberration]=None) -> astro.Orbit:
         """Translates the provided Cartesian state into the requested observer frame
 
-        **WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_to` function instead to include rotations."""
+**WARNING:** This function only performs the translation and no rotation _whatsoever_. Use the `transform_to` function instead to include rotations."""
 
-    def translate_to_parent(
-        self, source: astro.Frame, epoch: time.Epoch
-    ) -> astro.Orbit:
+    def translate_to_parent(self, source: astro.Frame, epoch: time.Epoch) -> astro.Orbit:
         """Performs the GEOMETRIC translation to the parent. Use translate_from_to for aberration."""
 
     def __repr__(self) -> str:
@@ -635,20 +471,20 @@ Obs. -- Target
 @typing.final
 class LocationDataSet:
     """A wrapper around a location dataset kernel (PyO3 does not handle type aliases).
-    Use this class to load and unload kernels. Manipulate using its LocationDhallSet representation."""
+Use this class to load and unload kernels. Manipulate using its LocationDhallSet representation."""
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def __new__(cls) -> LocationDataSet:
         """A wrapper around a location dataset kernel (PyO3 does not handle type aliases).
-        Use this class to load and unload kernels. Manipulate using its LocationDhallSet representation."""
+Use this class to load and unload kernels. Manipulate using its LocationDhallSet representation."""
 
     @staticmethod
     def load(path: str) -> LocationDataSet:
         """Loads a Location Dataset kernel from the provided path"""
 
-    def save_as(self, path: str, overwrite: typing.Optional[bool] = False) -> None:
+    def save_as(self, path: str, overwrite: typing.Optional[bool]=False) -> None:
         """Save this dataset as a kernel, optionally specifying whether to overwrite the existing file."""
 
     def to_dhallset(self) -> LocationDhallSet:
@@ -657,7 +493,6 @@ class LocationDataSet:
 @typing.final
 class LocationDhallSet:
     """A Dhall-serializable Location DataSet that serves as an optional intermediate to the LocationDataSet kernels."""
-
     data: list
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
@@ -686,7 +521,6 @@ class LocationDhallSet:
 @typing.final
 class LocationDhallSetEntry:
     """Entry of a Location Dhall set"""
-
     alias: str
     id: int
     value: astro.Location
@@ -694,37 +528,31 @@ class LocationDhallSetEntry:
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
-    def __new__(
-        cls,
-        value: astro.Location,
-        id: typing.Optional[int] = None,
-        alias: typing.Optional[str] = None,
-    ) -> LocationDhallSetEntry:
+    def __new__(cls, value: astro.Location, id: typing.Optional[int]=None, alias: typing.Optional[str]=None) -> LocationDhallSetEntry:
         """Entry of a Location Dhall set"""
 
 @typing.final
 class MetaAlmanac:
     """A structure to set up an Almanac, with automatic downloading, local storage, checksum checking, and more.
 
-    # Behavior
-    If the URI is a local path, relative or absolute, nothing will be fetched from a remote. Relative paths are relative to the execution folder (i.e. the current working directory).
-    If the URI is a remote path, the MetaAlmanac will first check if the file exists locally. If it exists, it will check that the CRC32 checksum of this file matches that of the specs.
-    If it does not match, the file will be downloaded again. If no CRC32 is provided but the file exists, then the MetaAlmanac will fetch the remote file and overwrite the existing file.
-    The downloaded path will be stored in the "AppData" folder."""
-
+# Behavior
+If the URI is a local path, relative or absolute, nothing will be fetched from a remote. Relative paths are relative to the execution folder (i.e. the current working directory).
+If the URI is a remote path, the MetaAlmanac will first check if the file exists locally. If it exists, it will check that the CRC32 checksum of this file matches that of the specs.
+If it does not match, the file will be downloaded again. If no CRC32 is provided but the file exists, then the MetaAlmanac will fetch the remote file and overwrite the existing file.
+The downloaded path will be stored in the "AppData" folder."""
     files: typing.List
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
-    def __new__(cls, maybe_path: typing.Optional[str] = None) -> MetaAlmanac:
+    def __new__(cls, maybe_path: typing.Optional[str]=None) -> MetaAlmanac:
         """A structure to set up an Almanac, with automatic downloading, local storage, checksum checking, and more.
 
-        # Behavior
-        If the URI is a local path, relative or absolute, nothing will be fetched from a remote. Relative paths are relative to the execution folder (i.e. the current working directory).
-        If the URI is a remote path, the MetaAlmanac will first check if the file exists locally. If it exists, it will check that the CRC32 checksum of this file matches that of the specs.
-        If it does not match, the file will be downloaded again. If no CRC32 is provided but the file exists, then the MetaAlmanac will fetch the remote file and overwrite the existing file.
-        The downloaded path will be stored in the "AppData" folder."""
+# Behavior
+If the URI is a local path, relative or absolute, nothing will be fetched from a remote. Relative paths are relative to the execution folder (i.e. the current working directory).
+If the URI is a remote path, the MetaAlmanac will first check if the file exists locally. If it exists, it will check that the CRC32 checksum of this file matches that of the specs.
+If it does not match, the file will be downloaded again. If no CRC32 is provided but the file exists, then the MetaAlmanac will fetch the remote file and overwrite the existing file.
+The downloaded path will be stored in the "AppData" folder."""
 
     def dumps(self) -> str:
         """Dumps the configured Meta Almanac into a Dhall string. Equivalent to to_dhall()."""
@@ -734,33 +562,33 @@ class MetaAlmanac:
         """Loads this Meta Almanac from its Dhall string representation"""
 
     @staticmethod
-    def latest(autodelete: typing.Optional[bool] = None) -> Almanac:
+    def latest(autodelete: typing.Optional[bool]=None) -> Almanac:
         """Returns an Almanac loaded from the latest NAIF data via the `default` MetaAlmanac.
-        The MetaAlmanac will download the DE440s.bsp file, the PCK0008.PCA, the full Moon Principal Axis BPC (moon_pa_de440_200625) and the latest high precision Earth kernel from JPL.
+The MetaAlmanac will download the DE440s.bsp file, the PCK0008.PCA, the full Moon Principal Axis BPC (moon_pa_de440_200625) and the latest high precision Earth kernel from JPL.
 
-        # File list
-        - <http://public-data.nyxspace.com/anise/de440s.bsp>
-        - <http://public-data.nyxspace.com/anise/v0.5/pck08.pca>
-        - <http://public-data.nyxspace.com/anise/moon_pa_de440_200625.bpc>
-        - <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc>
+# File list
+- <http://public-data.nyxspace.com/anise/de440s.bsp>
+- <http://public-data.nyxspace.com/anise/v0.5/pck08.pca>
+- <http://public-data.nyxspace.com/anise/moon_pa_de440_200625.bpc>
+- <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc>
 
-        # Reproducibility
+# Reproducibility
 
-        Note that the `earth_latest_high_prec.bpc` file is regularly updated daily (or so). As such,
-        if queried at some future time, the Earth rotation parameters may have changed between two queries.
+Note that the `earth_latest_high_prec.bpc` file is regularly updated daily (or so). As such,
+if queried at some future time, the Earth rotation parameters may have changed between two queries.
 
-        Set `autodelete` to true to delete lock file if a dead lock is detected after 10 seconds."""
+Set `autodelete` to true to delete lock file if a dead lock is detected after 10 seconds."""
 
     @staticmethod
     def loads(s: str) -> MetaAlmanac:
         """Loads the provided string as a Dhall configuration to build a MetaAlmanac"""
 
-    def process(self, autodelete: typing.Optional[bool] = None) -> Almanac:
+    def process(self, autodelete: typing.Optional[bool]=None) -> Almanac:
         """Fetch all of the URIs and return a loaded Almanac.
-        When downloading the data, ANISE will create a temporarily lock file to prevent race conditions
-        where multiple processes download the data at the same time. Set `autodelete` to true to delete
-        this lock file if a dead lock is detected after 10 seconds. Set this flag to false if you have
-        more than ten processes which may attempt to download files in parallel."""
+When downloading the data, ANISE will create a temporarily lock file to prevent race conditions
+where multiple processes download the data at the same time. Set `autodelete` to true to delete
+this lock file if a dead lock is detected after 10 seconds. Set this flag to false if you have
+more than ten processes which may attempt to download files in parallel."""
 
     def to_dhall(self) -> str:
         """Serializes the configurated Meta Almanac into a Dhall string. Equivalent to dumps()."""
@@ -793,27 +621,26 @@ class MetaAlmanac:
 class MetaFile:
     """MetaFile allows downloading a remote file from a URL (http, https only), and interpolation of paths in environment variable using the Dhall syntax `env:MY_ENV_VAR`.
 
-    The data is stored in the user's local temp directory (i.e. `~/.local/share/nyx-space/anise/` on Linux and `AppData/Local/nyx-space/anise/` on Windows).
-    Prior to loading a remote resource, if the local resource exists, its CRC32 will be computed: if it matches the CRC32 of this instance of MetaFile,
-    then the file will not be downloaded a second time."""
-
+The data is stored in the user's local temp directory (i.e. `~/.local/share/nyx-space/anise/` on Linux and `AppData/Local/nyx-space/anise/` on Windows).
+Prior to loading a remote resource, if the local resource exists, its CRC32 will be computed: if it matches the CRC32 of this instance of MetaFile,
+then the file will not be downloaded a second time."""
     crc32: int
     uri: str
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
-    def __new__(cls, uri: str, crc32: typing.Optional[int] = None) -> MetaFile:
+    def __new__(cls, uri: str, crc32: typing.Optional[int]=None) -> MetaFile:
         """MetaFile allows downloading a remote file from a URL (http, https only), and interpolation of paths in environment variable using the Dhall syntax `env:MY_ENV_VAR`.
 
-        The data is stored in the user's local temp directory (i.e. `~/.local/share/nyx-space/anise/` on Linux and `AppData/Local/nyx-space/anise/` on Windows).
-        Prior to loading a remote resource, if the local resource exists, its CRC32 will be computed: if it matches the CRC32 of this instance of MetaFile,
-        then the file will not be downloaded a second time."""
+The data is stored in the user's local temp directory (i.e. `~/.local/share/nyx-space/anise/` on Linux and `AppData/Local/nyx-space/anise/` on Windows).
+Prior to loading a remote resource, if the local resource exists, its CRC32 will be computed: if it matches the CRC32 of this instance of MetaFile,
+then the file will not be downloaded a second time."""
 
-    def process(self, autodelete: typing.Optional[bool] = None) -> None:
+    def process(self, autodelete: typing.Optional[bool]=None) -> None:
         """Processes this MetaFile by downloading it if it's a URL.
 
-        This function modified `self` and changes the URI to be the path to the downloaded file."""
+This function modified `self` and changes the URI to be the path to the downloaded file."""
 
     def __eq__(self, value: typing.Any) -> bool:
         """Return self==value."""
@@ -842,14 +669,14 @@ class MetaFile:
 @typing.final
 class PyReportScalars:
     """A basic report builder that can be serialized seperately from the execution.
-    The scalars must be a tuple of (ScalarExpr, String) where the String is the alias (optional)."""
+The scalars must be a tuple of (ScalarExpr, String) where the String is the alias (optional)."""
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def __new__(cls, scalars: list, state_spec: analysis.StateSpec) -> PyReportScalars:
         """A basic report builder that can be serialized seperately from the execution.
-        The scalars must be a tuple of (ScalarExpr, String) where the String is the alias (optional)."""
+The scalars must be a tuple of (ScalarExpr, String) where the String is the alias (optional)."""
 
     @staticmethod
     def from_s_expr(expr: str) -> analysis.ReportScalars:
@@ -858,7 +685,6 @@ class PyReportScalars:
     def to_s_expr(self) -> str:
         """Converts this report builder to its S-Expression"""
 
-def exec_gui() -> typing.Any: ...
-
-__author__: str = "Christopher Rabotin <christopher.rabotin@gmail.com>"
-__version__: str = "0.10.0"
+def exec_gui() -> typing.Any:...
+__author__: str = 'Christopher Rabotin <christopher.rabotin@gmail.com>'
+__version__: str = '1.0.0-alpha'

--- a/anise-py/anise/__init__.pyi
+++ b/anise-py/anise/__init__.pyi
@@ -312,6 +312,12 @@ Note: the output AER will be chronologically sorted, regardless of transmitter.
 
 Refer to [solar_eclipsing] for details."""
 
+    def spacecraft_data_from_id(self, id: typing.Any) -> typing.Any:
+        """Returns the SpacecraftData from its ID, searching through all loaded spacecraft datasets in reverse order."""
+
+    def spacecraft_data_from_name(self, name: typing.Any) -> typing.Any:
+        """Returns the SpacecraftData from its name, searching through all loaded spacecraft datasets in reverse order."""
+
     def spk_domain(self, id: int) -> typing.Tuple:
         """Returns the applicable domain of the request id, i.e. start and end epoch that the provided id has loaded data."""
 

--- a/anise-py/anise/astro.pyi
+++ b/anise-py/anise/astro.pyi
@@ -1889,7 +1889,7 @@ class SpacecraftDataSet:
 
     @staticmethod
     def load(path: str) -> SpacecraftDataSet:
-        """Loads a Location Dataset kernel from the provided path"""
+        """Loads a Spacecraft Dataset kernel from the provided path"""
 
     def save_as(self, path: str, overwrite: typing.Optional[bool] = False) -> None:
         """Save this dataset as a kernel, optionally specifying whether to overwrite the existing file."""
@@ -1899,7 +1899,7 @@ class SpacecraftDataSet:
 
 @typing.final
 class SpacecraftDhallSet:
-    """A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
+    """A Dhall-serializable Spacecraft DhallSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
 
     data: list
 
@@ -1907,28 +1907,28 @@ class SpacecraftDhallSet:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def __new__(cls, data: list) -> SpacecraftDhallSet:
-        """A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
+        """A Dhall-serializable Spacecraft DhallSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
 
     def dumps(self) -> str:
         """Returns the Dhall representation of this SpacecraftDhallSet. Equivalent to to_dhall."""
 
     @staticmethod
     def from_dhall(repr: str) -> SpacecraftDhallSet:
-        """Loads this Location dataset from its Dhall representation as a string"""
+        """Loads this Spacecraft dataset from its Dhall representation as a string"""
 
     @staticmethod
     def loads(repr: str) -> SpacecraftDhallSet:
-        """Loads this Location dataset from its Dhall representation as a string. Equivalent to from_dhall."""
+        """Loads this Spacecraft dataset from its Dhall representation as a string. Equivalent to from_dhall."""
 
     def to_dataset(self) -> SpacecraftDataSet:
-        """Converts this location Dhall set into a Python-compatible Location DataSet."""
+        """Converts this location Dhall set into a Python-compatible Spacecraft DataSet."""
 
     def to_dhall(self) -> str:
-        """Returns the Dhall representation of this Location"""
+        """Returns the Dhall representation of this Spacecraft"""
 
 @typing.final
 class SpacecraftDhallSetEntry:
-    """Entry of a Location Dhall set"""
+    """Entry of a Spacecraft Dhall set"""
 
     id: typing.Any
     name: typing.Any
@@ -1938,9 +1938,12 @@ class SpacecraftDhallSetEntry:
         """Initialize self.  See help(type(self)) for accurate signature."""
 
     def __new__(
-        cls, value: Location, id: typing.Optional[int] = None, name: typing.Any = None
+        cls,
+        value: SpacecraftData,
+        id: typing.Optional[int] = None,
+        name: typing.Any = None,
     ) -> SpacecraftDhallSetEntry:
-        """Entry of a Location Dhall set"""
+        """Entry of a Spacecraft Dhall set"""
 
     def __eq__(self, value: typing.Any) -> bool:
         """Return self==value."""

--- a/anise-py/anise/astro.pyi
+++ b/anise-py/anise/astro.pyi
@@ -1824,6 +1824,143 @@ class SRPData:
         """Return str(self)."""
 
 @typing.final
+class SpacecraftData:
+    """Spacecraft constants can store the some of the spacecraft constant data as the CCSDS Orbit Parameter Message (OPM) and CCSDS Attitude Parameter Messages (APM)"""
+
+    drag_data: typing.Any
+    inertia: typing.Any
+    mass: typing.Any
+    srp_data: typing.Any
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
+
+    def __new__(
+        cls,
+        mass: typing.Any = None,
+        srp_data: typing.Any = None,
+        drag_data: typing.Any = None,
+        inertia: typing.Any = None,
+    ) -> SpacecraftData:
+        """Spacecraft constants can store the some of the spacecraft constant data as the CCSDS Orbit Parameter Message (OPM) and CCSDS Attitude Parameter Messages (APM)"""
+
+    @staticmethod
+    def from_asn1(data: bytes) -> SpacecraftData:
+        """Decodes an ASN.1 DER encoded byte array into a SpacecraftData object."""
+
+    def to_asn1(self) -> bytes:
+        """Encodes this SpacecraftData object into an ASN.1 DER encoded byte array."""
+
+    def __eq__(self, value: typing.Any) -> bool:
+        """Return self==value."""
+
+    def __ge__(self, value: typing.Any) -> bool:
+        """Return self>=value."""
+
+    def __gt__(self, value: typing.Any) -> bool:
+        """Return self>value."""
+
+    def __le__(self, value: typing.Any) -> bool:
+        """Return self<=value."""
+
+    def __lt__(self, value: typing.Any) -> bool:
+        """Return self<value."""
+
+    def __ne__(self, value: typing.Any) -> bool:
+        """Return self!=value."""
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+
+@typing.final
+class SpacecraftDataSet:
+    """A wrapper around a location dataset kernel (PyO3 does not handle type aliases).
+    Use this class to load and unload kernels. Manipulate using its SpacecraftDhallSet representation."""
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
+
+    def __new__(cls) -> SpacecraftDataSet:
+        """A wrapper around a location dataset kernel (PyO3 does not handle type aliases).
+        Use this class to load and unload kernels. Manipulate using its SpacecraftDhallSet representation."""
+
+    @staticmethod
+    def load(path: str) -> SpacecraftDataSet:
+        """Loads a Location Dataset kernel from the provided path"""
+
+    def save_as(self, path: str, overwrite: typing.Optional[bool] = False) -> None:
+        """Save this dataset as a kernel, optionally specifying whether to overwrite the existing file."""
+
+    def to_dhallset(self) -> SpacecraftDhallSet:
+        """Converts this location dataset into a manipulable location Dhall set."""
+
+@typing.final
+class SpacecraftDhallSet:
+    """A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
+
+    data: list
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
+
+    def __new__(cls, data: list) -> SpacecraftDhallSet:
+        """A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels."""
+
+    def dumps(self) -> str:
+        """Returns the Dhall representation of this SpacecraftDhallSet. Equivalent to to_dhall."""
+
+    @staticmethod
+    def from_dhall(repr: str) -> SpacecraftDhallSet:
+        """Loads this Location dataset from its Dhall representation as a string"""
+
+    @staticmethod
+    def loads(repr: str) -> SpacecraftDhallSet:
+        """Loads this Location dataset from its Dhall representation as a string. Equivalent to from_dhall."""
+
+    def to_dataset(self) -> SpacecraftDataSet:
+        """Converts this location Dhall set into a Python-compatible Location DataSet."""
+
+    def to_dhall(self) -> str:
+        """Returns the Dhall representation of this Location"""
+
+@typing.final
+class SpacecraftDhallSetEntry:
+    """Entry of a Location Dhall set"""
+
+    id: typing.Any
+    name: typing.Any
+    value: typing.Any
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
+
+    def __new__(
+        cls, value: Location, id: typing.Optional[int] = None, name: typing.Any = None
+    ) -> SpacecraftDhallSetEntry:
+        """Entry of a Location Dhall set"""
+
+    def __eq__(self, value: typing.Any) -> bool:
+        """Return self==value."""
+
+    def __ge__(self, value: typing.Any) -> bool:
+        """Return self>=value."""
+
+    def __gt__(self, value: typing.Any) -> bool:
+        """Return self>value."""
+
+    def __le__(self, value: typing.Any) -> bool:
+        """Return self<=value."""
+
+    def __lt__(self, value: typing.Any) -> bool:
+        """Return self<value."""
+
+    def __ne__(self, value: typing.Any) -> bool:
+        """Return self!=value."""
+
+@typing.final
 class TerrainMask:
     """TerrainMask is used to compute obstructions during AER calculations."""
 

--- a/anise-py/anise/astro.pyi
+++ b/anise-py/anise/astro.pyi
@@ -832,6 +832,46 @@ class FrameUid:
         """Return str(self)."""
 
 @typing.final
+class Inertia:
+    """Inertial tensor definition"""
+
+    i_xx_kgm2: typing.Any
+    i_xy_kgm2: typing.Any
+    i_xz_kgm2: typing.Any
+    i_yy_kgm2: typing.Any
+    i_yz_kgm2: typing.Any
+    i_zz_kgm2: typing.Any
+    orientation_id: typing.Any
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
+
+    def __new__(
+        cls,
+        orientation_id: typing.Any,
+        i_xx_kgm2: typing.Any,
+        i_yy_kgm2: typing.Any,
+        i_zz_kgm2: typing.Any,
+        i_xy_kgm2: typing.Any = 0.0,
+        i_xz_kgm2: typing.Any = 0.0,
+        i_yz_kgm2: typing.Any = 0.0,
+    ) -> Inertia:
+        """Inertial tensor definition"""
+
+    @staticmethod
+    def from_asn1(data: bytes) -> Inertia:
+        """Decodes an ASN.1 DER encoded byte array into an Inertia object."""
+
+    def to_asn1(self) -> bytes:
+        """Encodes this Inertia object into an ASN.1 DER encoded byte array."""
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+
+@typing.final
 class LocalFrame:
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Initialize self.  See help(type(self)) for accurate signature."""

--- a/anise-py/src/lib.rs
+++ b/anise-py/src/lib.rs
@@ -29,9 +29,12 @@ use anise::math::rotation::{Quaternion, DCM};
 use anise::naif::daf::DafDataType;
 use anise::structure::dataset::location_dhall::PyLocationDataSet;
 use anise::structure::dataset::location_dhall::{LocationDhallSet, LocationDhallSetEntry};
+use anise::structure::dataset::spacecraft_dhall::{
+    PySpacecraftDataSet, SpacecraftDhallSet, SpacecraftDhallSetEntry,
+};
 use anise::structure::instrument::{FovShape, Instrument};
 use anise::structure::planetocentric::ellipsoid::Ellipsoid;
-use anise::structure::spacecraft::{DragData, Inertia, Mass, SRPData};
+use anise::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
 use hifitime::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
 use hifitime::python::{PyDurationError, PyHifitimeError, PyParsingError};
 use hifitime::ut1::Ut1Provider;
@@ -96,6 +99,10 @@ pub(crate) fn astro(_py: Python, sm: &Bound<'_, PyModule>) -> PyResult<()> {
     sm.add_class::<DragData>()?;
     sm.add_class::<SRPData>()?;
     sm.add_class::<Inertia>()?;
+    sm.add_class::<SpacecraftData>()?;
+    sm.add_class::<PySpacecraftDataSet>()?;
+    sm.add_class::<SpacecraftDhallSet>()?;
+    sm.add_class::<SpacecraftDhallSetEntry>()?;
 
     // Also add the constants as a submodule to astro for backward compatibility
     sm.add_wrapped(wrap_pymodule!(crate::constants::constants))?;

--- a/anise-py/src/lib.rs
+++ b/anise-py/src/lib.rs
@@ -8,24 +8,24 @@
  * Documentation: https://nyxspace.com/
  */
 
-use anise::almanac::metaload::{MetaAlmanac, MetaFile};
 use anise::almanac::Almanac;
+use anise::almanac::metaload::{MetaAlmanac, MetaFile};
 use anise::analysis::prelude::{
-    find_arc_intersections, Condition, Event, EventArc, EventDetails, EventEdge, OrbitalElement,
-    Plane, VisibilityArc,
+    Condition, Event, EventArc, EventDetails, EventEdge, OrbitalElement, Plane, VisibilityArc,
+    find_arc_intersections,
 };
 use anise::analysis::python::{
     PyFrameSpec, PyOrthogonalFrame, PyScalarExpr, PyStateSpec, PyVectorExpr,
 };
 use anise::analysis::report::PyReportScalars;
-use anise::astro::orbit::Orbit;
 use anise::astro::Aberration;
+use anise::astro::orbit::Orbit;
 use anise::astro::{AzElRange, Location, Occultation, TerrainMask};
 use anise::ephemerides::ephemeris::{Covariance, Ephemeris, EphemerisRecord, LocalFrame};
 use anise::ephemerides::opm::{Maneuver, Opm};
 use anise::frames::FrameUid;
 use anise::frames::{DynamicFrame, EarthNutationModel, EarthPrecessionModel, Frame};
-use anise::math::rotation::{Quaternion, DCM};
+use anise::math::rotation::{DCM, Quaternion};
 use anise::naif::daf::DafDataType;
 use anise::structure::dataset::location_dhall::PyLocationDataSet;
 use anise::structure::dataset::location_dhall::{LocationDhallSet, LocationDhallSetEntry};
@@ -38,7 +38,7 @@ use anise::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftD
 use hifitime::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
 use hifitime::python::{PyDurationError, PyHifitimeError, PyParsingError};
 use hifitime::ut1::Ut1Provider;
-use hifitime::{prelude::*, MonthName, Polynomial};
+use hifitime::{MonthName, Polynomial, prelude::*};
 
 use pyo3::{prelude::*, wrap_pyfunction, wrap_pymodule};
 

--- a/anise-py/src/lib.rs
+++ b/anise-py/src/lib.rs
@@ -8,34 +8,34 @@
  * Documentation: https://nyxspace.com/
  */
 
-use anise::almanac::Almanac;
 use anise::almanac::metaload::{MetaAlmanac, MetaFile};
+use anise::almanac::Almanac;
 use anise::analysis::prelude::{
-    Condition, Event, EventArc, EventDetails, EventEdge, OrbitalElement, Plane, VisibilityArc,
-    find_arc_intersections,
+    find_arc_intersections, Condition, Event, EventArc, EventDetails, EventEdge, OrbitalElement,
+    Plane, VisibilityArc,
 };
 use anise::analysis::python::{
     PyFrameSpec, PyOrthogonalFrame, PyScalarExpr, PyStateSpec, PyVectorExpr,
 };
 use anise::analysis::report::PyReportScalars;
-use anise::astro::Aberration;
 use anise::astro::orbit::Orbit;
+use anise::astro::Aberration;
 use anise::astro::{AzElRange, Location, Occultation, TerrainMask};
 use anise::ephemerides::ephemeris::{Covariance, Ephemeris, EphemerisRecord, LocalFrame};
 use anise::ephemerides::opm::{Maneuver, Opm};
 use anise::frames::FrameUid;
 use anise::frames::{DynamicFrame, EarthNutationModel, EarthPrecessionModel, Frame};
-use anise::math::rotation::{DCM, Quaternion};
+use anise::math::rotation::{Quaternion, DCM};
 use anise::naif::daf::DafDataType;
 use anise::structure::dataset::location_dhall::PyLocationDataSet;
 use anise::structure::dataset::location_dhall::{LocationDhallSet, LocationDhallSetEntry};
 use anise::structure::instrument::{FovShape, Instrument};
 use anise::structure::planetocentric::ellipsoid::Ellipsoid;
-use anise::structure::spacecraft::{DragData, Mass, SRPData};
+use anise::structure::spacecraft::{DragData, Inertia, Mass, SRPData};
 use hifitime::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
 use hifitime::python::{PyDurationError, PyHifitimeError, PyParsingError};
 use hifitime::ut1::Ut1Provider;
-use hifitime::{MonthName, Polynomial, prelude::*};
+use hifitime::{prelude::*, MonthName, Polynomial};
 
 use pyo3::{prelude::*, wrap_pyfunction, wrap_pymodule};
 
@@ -95,6 +95,7 @@ pub(crate) fn astro(_py: Python, sm: &Bound<'_, PyModule>) -> PyResult<()> {
     sm.add_class::<Mass>()?;
     sm.add_class::<DragData>()?;
     sm.add_class::<SRPData>()?;
+    sm.add_class::<Inertia>()?;
 
     // Also add the constants as a submodule to astro for backward compatibility
     sm.add_wrapped(wrap_pymodule!(crate::constants::constants))?;

--- a/anise-py/tests/test_almanac.py
+++ b/anise-py/tests/test_almanac.py
@@ -12,7 +12,7 @@ from anise import (
     LocationDhallSet,
     LocationDhallSetEntry,
     MetaAlmanac,
-    MetaFile,
+    MetaFile
 )
 from anise.analysis import OrbitalElement
 from anise.astro import (
@@ -30,6 +30,14 @@ from anise.astro import (
     Location,
     Orbit,
     TerrainMask,
+    SpacecraftData,
+    Mass,
+    SRPData,
+    DragData,
+    Inertia,
+    SpacecraftDataSet,
+    SpacecraftDhallSet,
+    SpacecraftDhallSetEntry,
 )
 from anise.constants import Frames, Orientations
 from anise.rotation import DCM, Quaternion
@@ -573,6 +581,31 @@ def test_frame_uid():
     uid = FrameUid(399, 399)
     assert isinstance(uid.to_frame(), Frame)
 
+def test_spacecraft_data():
+    inertia = Inertia(orientation_id=-159, i_xx_kgm2=15.0, i_yy_kgm2=16.0, i_zz_kgm2=17.0, i_xy_kgm2=18.0, i_xz_kgm2=19.0, i_yz_kgm2=20.0)
+    srp = SRPData(area_m2=23.4, coeff_reflectivity= 1.23)
+    drag = DragData(area_m2=12.3, coeff_drag=1.23)
+    mass = Mass(dry_mass_kg=15.0, prop_mass_kg=16.0, extra_mass_kg=17.0)
+
+    sc_data = SpacecraftData(mass, srp, drag, inertia)
+
+    # Add it to a Dhall Set by creating the entry first.
+    entry = SpacecraftDhallSetEntry(value=sc_data, id=20, name="my spacecraft config")
+
+    dhallset = SpacecraftDhallSet([entry])
+
+    # Convert to the binary data set representation
+    dataset = dhallset.to_dataset()
+    dataset.save_as("pytest_spacecraft_kernel.ska", True)
+
+    # Check that we can load it
+    almanac = Almanac("pytest_spacecraft_kernel.ska")
+    sc_data_from_id = almanac.spacecraft_data_from_id(20)
+    sc_data_from_name = almanac.spacecraft_data_from_name("my spacecraft config")
+
+    assert sc_data_from_id == sc_data
+    assert sc_data_from_name == sc_data
+
 
 if __name__ == "__main__":
     # test_meta_load()
@@ -581,4 +614,5 @@ if __name__ == "__main__":
     # test_convert_tpc()
     # test_state_transformation()
     # test_location()
-    test_oem()
+    # test_oem()
+    test_spacecraft_data()

--- a/anise-py/tests/test_almanac.py
+++ b/anise-py/tests/test_almanac.py
@@ -35,7 +35,6 @@ from anise.astro import (
     SRPData,
     DragData,
     Inertia,
-    SpacecraftDataSet,
     SpacecraftDhallSet,
     SpacecraftDhallSetEntry,
 )

--- a/anise/src/almanac/mod.rs
+++ b/anise/src/almanac/mod.rs
@@ -40,6 +40,7 @@ pub mod eclipse;
 pub mod instrument;
 pub mod planetary;
 pub mod solar;
+pub mod spacecraft;
 pub mod spk;
 pub mod transform;
 

--- a/anise/src/almanac/spacecraft.rs
+++ b/anise/src/almanac/spacecraft.rs
@@ -1,0 +1,124 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use super::Almanac;
+use crate::{
+    NaifId,
+    errors::{AlmanacError, AlmanacResult},
+    structure::{dataset::DataSetError, lookuptable::LutError, spacecraft::SpacecraftData},
+};
+
+impl Almanac {
+    /// Returns the SpacecraftData from its ID, searching through all loaded spacecraft datasets in reverse order.
+    pub fn spacecraft_data_from_id(&self, id: NaifId) -> AlmanacResult<SpacecraftData> {
+        for data in self.spacecraft_data.values().rev() {
+            if let Ok(datum) = data.get_by_id(id) {
+                return Ok(datum);
+            }
+        }
+
+        Err(AlmanacError::TLDataSet {
+            action: "spacecraft data from ID",
+            source: DataSetError::DataSetLut {
+                action: "seeking spacecraft data by ID",
+                source: LutError::UnknownId { id },
+            },
+        })
+    }
+
+    /// Alias for [Self::spacecraft_data_from_id].
+    pub fn spacecraft_from_id(&self, id: NaifId) -> AlmanacResult<SpacecraftData> {
+        self.spacecraft_data_from_id(id)
+    }
+
+    /// Returns the SpacecraftData from its name, searching through all loaded spacecraft datasets in reverse order.
+    pub fn spacecraft_data_from_name(&self, name: &str) -> AlmanacResult<SpacecraftData> {
+        for data in self.spacecraft_data.values().rev() {
+            if let Ok(datum) = data.get_by_name(name) {
+                return Ok(datum);
+            }
+        }
+
+        Err(AlmanacError::TLDataSet {
+            action: "spacecraft data from name",
+            source: DataSetError::DataSetLut {
+                action: "seeking spacecraft data by name",
+                source: LutError::UnknownName {
+                    name: name.to_string(),
+                },
+            },
+        })
+    }
+
+    /// Alias for [Self::spacecraft_data_from_name].
+    pub fn spacecraft_from_name(&self, name: &str) -> AlmanacResult<SpacecraftData> {
+        self.spacecraft_data_from_name(name)
+    }
+}
+
+#[cfg(test)]
+mod ut_spacecraft {
+    use crate::prelude::Almanac;
+    use crate::structure::SpacecraftDataSet;
+    use crate::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
+
+    #[test]
+    fn test_spacecraft_retrieval() {
+        let sc_data1 = SpacecraftData {
+            mass: Some(Mass::from_dry_and_prop_masses(100.0, 20.0)),
+            srp_data: Some(SRPData {
+                area_m2: 5.0,
+                coeff_reflectivity: 1.2,
+            }),
+            drag_data: Some(DragData {
+                area_m2: 2.0,
+                coeff_drag: 2.1,
+            }),
+            inertia: Some(Inertia {
+                orientation_id: -101,
+                i_xx_kgm2: 10.0,
+                i_yy_kgm2: 20.0,
+                i_zz_kgm2: 30.0,
+                i_xy_kgm2: 0.0,
+                i_xz_kgm2: 0.0,
+                i_yz_kgm2: 0.0,
+            }),
+        };
+
+        let sc_data2 = SpacecraftData {
+            mass: Some(Mass::from_dry_and_prop_masses(200.0, 50.0)),
+            ..Default::default()
+        };
+
+        let mut sc_dataset = SpacecraftDataSet::default();
+        sc_dataset.push(sc_data1, Some(-101), Some("SC1")).unwrap();
+        sc_dataset.push(sc_data2, Some(-102), Some("SC2")).unwrap();
+
+        let almanac = Almanac::default().with_spacecraft_data(sc_dataset);
+
+        // Fetch by ID
+        assert_eq!(almanac.spacecraft_data_from_id(-101).unwrap(), sc_data1);
+        assert_eq!(almanac.spacecraft_from_id(-101).unwrap(), sc_data1);
+        assert_eq!(almanac.spacecraft_data_from_id(-102).unwrap(), sc_data2);
+        assert_eq!(almanac.spacecraft_from_id(-102).unwrap(), sc_data2);
+
+        // Fetch by Name
+        assert_eq!(almanac.spacecraft_data_from_name("SC1").unwrap(), sc_data1);
+        assert_eq!(almanac.spacecraft_from_name("SC1").unwrap(), sc_data1);
+        assert_eq!(almanac.spacecraft_data_from_name("SC2").unwrap(), sc_data2);
+        assert_eq!(almanac.spacecraft_from_name("SC2").unwrap(), sc_data2);
+
+        // Error cases
+        assert!(almanac.spacecraft_data_from_id(-999).is_err());
+        assert!(almanac.spacecraft_from_id(-999).is_err());
+        assert!(almanac.spacecraft_data_from_name("Unknown").is_err());
+        assert!(almanac.spacecraft_from_name("Unknown").is_err());
+    }
+}

--- a/anise/src/almanac/spacecraft.rs
+++ b/anise/src/almanac/spacecraft.rs
@@ -10,9 +10,9 @@
 
 use super::Almanac;
 use crate::{
+    NaifId,
     errors::{AlmanacError, AlmanacResult},
     structure::{dataset::DataSetError, lookuptable::LutError, spacecraft::SpacecraftData},
-    NaifId,
 };
 
 #[cfg(feature = "python")]
@@ -60,8 +60,8 @@ impl Almanac {
 #[cfg(test)]
 mod ut_spacecraft {
     use crate::prelude::Almanac;
-    use crate::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
     use crate::structure::SpacecraftDataSet;
+    use crate::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
 
     #[test]
     fn test_spacecraft_retrieval() {

--- a/anise/src/almanac/spacecraft.rs
+++ b/anise/src/almanac/spacecraft.rs
@@ -99,20 +99,14 @@ mod ut_spacecraft {
 
         // Fetch by ID
         assert_eq!(almanac.spacecraft_data_from_id(-101).unwrap(), sc_data1);
-        assert_eq!(almanac.spacecraft_from_id(-101).unwrap(), sc_data1);
         assert_eq!(almanac.spacecraft_data_from_id(-102).unwrap(), sc_data2);
-        assert_eq!(almanac.spacecraft_from_id(-102).unwrap(), sc_data2);
 
         // Fetch by Name
         assert_eq!(almanac.spacecraft_data_from_name("SC1").unwrap(), sc_data1);
-        assert_eq!(almanac.spacecraft_from_name("SC1").unwrap(), sc_data1);
         assert_eq!(almanac.spacecraft_data_from_name("SC2").unwrap(), sc_data2);
-        assert_eq!(almanac.spacecraft_from_name("SC2").unwrap(), sc_data2);
 
         // Error cases
         assert!(almanac.spacecraft_data_from_id(-999).is_err());
-        assert!(almanac.spacecraft_from_id(-999).is_err());
         assert!(almanac.spacecraft_data_from_name("Unknown").is_err());
-        assert!(almanac.spacecraft_from_name("Unknown").is_err());
     }
 }

--- a/anise/src/almanac/spacecraft.rs
+++ b/anise/src/almanac/spacecraft.rs
@@ -10,11 +10,15 @@
 
 use super::Almanac;
 use crate::{
-    NaifId,
     errors::{AlmanacError, AlmanacResult},
     structure::{dataset::DataSetError, lookuptable::LutError, spacecraft::SpacecraftData},
+    NaifId,
 };
 
+#[cfg(feature = "python")]
+use pyo3::pymethods;
+
+#[cfg_attr(feature = "python", pymethods)]
 impl Almanac {
     /// Returns the SpacecraftData from its ID, searching through all loaded spacecraft datasets in reverse order.
     pub fn spacecraft_data_from_id(&self, id: NaifId) -> AlmanacResult<SpacecraftData> {
@@ -31,11 +35,6 @@ impl Almanac {
                 source: LutError::UnknownId { id },
             },
         })
-    }
-
-    /// Alias for [Self::spacecraft_data_from_id].
-    pub fn spacecraft_from_id(&self, id: NaifId) -> AlmanacResult<SpacecraftData> {
-        self.spacecraft_data_from_id(id)
     }
 
     /// Returns the SpacecraftData from its name, searching through all loaded spacecraft datasets in reverse order.
@@ -56,18 +55,13 @@ impl Almanac {
             },
         })
     }
-
-    /// Alias for [Self::spacecraft_data_from_name].
-    pub fn spacecraft_from_name(&self, name: &str) -> AlmanacResult<SpacecraftData> {
-        self.spacecraft_data_from_name(name)
-    }
 }
 
 #[cfg(test)]
 mod ut_spacecraft {
     use crate::prelude::Almanac;
-    use crate::structure::SpacecraftDataSet;
     use crate::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
+    use crate::structure::SpacecraftDataSet;
 
     #[test]
     fn test_spacecraft_retrieval() {

--- a/anise/src/naif/daf/daf.rs
+++ b/anise/src/naif/daf/daf.rs
@@ -222,29 +222,6 @@ impl<R: NAIFSummaryRecord> DAF<R> {
     /// The file record is always the first 1024 bytes of the file.
     pub fn file_record(&self) -> Result<FileRecord, DAFError> {
         Ok(self.file_record)
-        // let file_record = FileRecord::read_from_bytes(
-        //     self.bytes
-        //         .get(..FileRecord::SIZE)
-        //         .ok_or_else(|| DecodingError::InaccessibleBytes {
-        //             start: 0,
-        //             end: FileRecord::SIZE,
-        //             size: self.bytes.len(),
-        //         })
-        //         .context(DecodingDataSnafu {
-        //             idx: 0_usize,
-        //             kind: R::NAME,
-        //         })?,
-        // )
-        // .map_err(|_| DAFError::DecodingData {
-        //     kind: R::NAME,
-        //     idx: 0,
-        //     source: DecodingError::Casting,
-        // })?;
-        // // Check that the endian-ness is compatible with this platform.
-        // file_record
-        //     .endianness()
-        //     .context(FileRecordSnafu { kind: R::NAME })?;
-        // Ok(file_record)
     }
 
     /// Reads and parses the name record from the DAF bytes.

--- a/anise/src/structure/dataset/location_dhall.rs
+++ b/anise/src/structure/dataset/location_dhall.rs
@@ -208,7 +208,7 @@ impl LocationDataSet {
 
         for (id, pos) in &self.lut.by_id {
             many_me.insert(
-                pos,
+                *pos,
                 LocationDhallSetEntry {
                     id: Some(*id),
                     alias: None,
@@ -222,7 +222,7 @@ impl LocationDataSet {
                 entry.alias = Some(name.to_string());
             } else {
                 many_me.insert(
-                    pos,
+                    *pos,
                     LocationDhallSetEntry {
                         id: None,
                         alias: Some(name.clone()),

--- a/anise/src/structure/dataset/location_dhall.rs
+++ b/anise/src/structure/dataset/location_dhall.rs
@@ -218,7 +218,7 @@ impl LocationDataSet {
         }
 
         for (name, pos) in &self.lut.by_name {
-            if let Some(entry) = many_me.get_mut(&pos) {
+            if let Some(entry) = many_me.get_mut(pos) {
                 entry.alias = Some(name.to_string());
             } else {
                 many_me.insert(

--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -9,19 +9,19 @@
  */
 use self::error::{DataDecodingSnafu, DataSetLutSnafu};
 use super::{
-    ANISE_VERSION,
     lookuptable::{LookUpTable, LutError},
     metadata::Metadata,
     semver::Semver,
+    ANISE_VERSION,
 };
 use crate::{
-    NaifId,
     errors::{DecodingError, IntegrityError},
     structure::dataset::error::DataSetIntegritySnafu,
+    NaifId,
 };
 use core::fmt;
 use core::ops::Deref;
-use der::{Decode, Encode, Reader, Writer, asn1::OctetString};
+use der::{asn1::OctetString, Decode, Encode, Reader, Writer};
 use log::error;
 use snafu::prelude::*;
 
@@ -41,6 +41,8 @@ mod error;
 #[cfg(feature = "analysis")]
 pub mod location_dhall;
 mod pretty_print;
+#[cfg(feature = "analysis")]
+pub mod spacecraft_dhall;
 
 pub use datatype::DataSetType;
 pub use error::DataSetError;
@@ -573,8 +575,8 @@ mod dataset_ut {
     use std::mem::size_of;
 
     use crate::structure::{
-        SpacecraftDataSet,
         spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData},
+        SpacecraftDataSet,
     };
 
     use super::{DataSet, Decode, Encode};
@@ -738,12 +740,10 @@ mod dataset_ut {
             .rename("SRP spacecraft", "Renamed SRP spacecraft")
             .unwrap();
         // Calling this a second time will lead to an error
-        assert!(
-            dataset
-                .lut
-                .rename("SRP spacecraft", "Renamed SRP spacecraft")
-                .is_err()
-        );
+        assert!(dataset
+            .lut
+            .rename("SRP spacecraft", "Renamed SRP spacecraft")
+            .is_err());
         // Calling the original will lead to an error
         assert!(dataset.get_by_name("SRP spacecraft").is_err());
         // Check that we can fetch that data as we modified it.

--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -41,7 +41,7 @@ mod error;
 #[cfg(feature = "analysis")]
 pub mod location_dhall;
 mod pretty_print;
-#[cfg(feature = "analysis")]
+#[cfg(feature = "metaload")]
 pub mod spacecraft_dhall;
 
 pub use datatype::DataSetType;

--- a/anise/src/structure/dataset/mod.rs
+++ b/anise/src/structure/dataset/mod.rs
@@ -9,19 +9,19 @@
  */
 use self::error::{DataDecodingSnafu, DataSetLutSnafu};
 use super::{
+    ANISE_VERSION,
     lookuptable::{LookUpTable, LutError},
     metadata::Metadata,
     semver::Semver,
-    ANISE_VERSION,
 };
 use crate::{
+    NaifId,
     errors::{DecodingError, IntegrityError},
     structure::dataset::error::DataSetIntegritySnafu,
-    NaifId,
 };
 use core::fmt;
 use core::ops::Deref;
-use der::{asn1::OctetString, Decode, Encode, Reader, Writer};
+use der::{Decode, Encode, Reader, Writer, asn1::OctetString};
 use log::error;
 use snafu::prelude::*;
 
@@ -575,8 +575,8 @@ mod dataset_ut {
     use std::mem::size_of;
 
     use crate::structure::{
-        spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData},
         SpacecraftDataSet,
+        spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData},
     };
 
     use super::{DataSet, Decode, Encode};
@@ -740,10 +740,12 @@ mod dataset_ut {
             .rename("SRP spacecraft", "Renamed SRP spacecraft")
             .unwrap();
         // Calling this a second time will lead to an error
-        assert!(dataset
-            .lut
-            .rename("SRP spacecraft", "Renamed SRP spacecraft")
-            .is_err());
+        assert!(
+            dataset
+                .lut
+                .rename("SRP spacecraft", "Renamed SRP spacecraft")
+                .is_err()
+        );
         // Calling the original will lead to an error
         assert!(dataset.get_by_name("SRP spacecraft").is_err());
         // Check that we can fetch that data as we modified it.

--- a/anise/src/structure/dataset/spacecraft_dhall.rs
+++ b/anise/src/structure/dataset/spacecraft_dhall.rs
@@ -162,7 +162,7 @@ impl SpacecraftDhallSet {
     ///
     /// :rtype: SpacecraftDataSet
     #[pyo3(name = "to_dataset")]
-    fn py_to_dataset(&mut self) -> Result<PySpacecraftDataSet, PyErr> {
+    fn py_to_dataset(&self) -> Result<PySpacecraftDataSet, PyErr> {
         Ok(PySpacecraftDataSet {
             inner: self
                 .to_dataset()
@@ -178,7 +178,7 @@ impl SpacecraftDataSet {
 
         for (id, pos) in &self.lut.by_id {
             many_me.insert(
-                pos,
+                *pos,
                 SpacecraftDhallSetEntry {
                     id: Some(*id),
                     name: None,
@@ -192,7 +192,7 @@ impl SpacecraftDataSet {
                 entry.name = Some(name.to_string());
             } else {
                 many_me.insert(
-                    pos,
+                    *pos,
                     SpacecraftDhallSetEntry {
                         id: None,
                         name: Some(name.clone()),

--- a/anise/src/structure/dataset/spacecraft_dhall.rs
+++ b/anise/src/structure/dataset/spacecraft_dhall.rs
@@ -28,11 +28,11 @@ use std::path::PathBuf;
 
 use super::{DataSet, DataSetType};
 
-/// Entry of a Location Dhall set
+/// Entry of a Spacecraft Dhall set
 ///
 /// :type id: int, optional
 /// :type alias: str, optional
-/// :type value: Location
+/// :type value: SpacecraftData
 #[derive(Clone, Debug, StaticType, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "python", pyclass(from_py_object, get_all, set_all))]
 #[cfg_attr(feature = "python", pyo3(module = "anise"))]
@@ -55,7 +55,7 @@ impl SpacecraftDhallSetEntry {
         self == other
     }
 }
-/// A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels.
+/// A Dhall-serializable Spacecraft DhallSet that serves as an optional intermediate to the SpacecraftDataSet kernels.
 ///
 /// :type data: list
 #[derive(Clone, Debug, StaticType, Serialize, Deserialize, PartialEq)]
@@ -66,14 +66,12 @@ pub struct SpacecraftDhallSet {
 }
 
 impl SpacecraftDhallSet {
-    /// Convert this Dhall representation of locations to a SpacecraftDataSet kernel.
-    ///
-    /// Function is mutable because the terrain mask is sanitized prior to building the kernel.
-    pub fn to_dataset(&mut self) -> Result<SpacecraftDataSet, String> {
+    /// Convert this Dhall representation of a spacecraft dhallset to a SpacecraftDataSet kernel.
+    pub fn to_dataset(&self) -> Result<SpacecraftDataSet, String> {
         let mut dataset = DataSet::default();
         dataset.metadata.dataset_type = DataSetType::SpacecraftData;
 
-        for e in &mut self.data {
+        for e in &self.data {
             dataset
                 .push(
                     e.value.clone(),
@@ -88,7 +86,7 @@ impl SpacecraftDhallSet {
         Ok(dataset)
     }
 
-    /// Deserialize the Dhall string of a Location data set into its Dhall representation structure.
+    /// Deserialize the Dhall string of a Spacecraft data set into its Dhall representation structure.
     pub fn from_dhall(repr: &str) -> Result<Self, String> {
         let me: Self = serde_dhall::from_str(repr)
             .static_type_annotation()
@@ -126,7 +124,7 @@ impl SpacecraftDhallSet {
         self.data = data;
     }
 
-    /// Loads this Location dataset from its Dhall representation as a string. Equivalent to from_dhall.
+    /// Loads this Spacecraft dataset from its Dhall representation as a string. Equivalent to from_dhall.
     ///
     /// :type repr: str
     /// :rtype: SpacecraftDhallSet
@@ -142,7 +140,7 @@ impl SpacecraftDhallSet {
         self.to_dhall().map_err(PyException::new_err)
     }
 
-    /// Returns the Dhall representation of this Location
+    /// Returns the Dhall representation of this Spacecraft
     ///
     /// :rtype: str
     #[pyo3(name = "to_dhall")]
@@ -150,7 +148,7 @@ impl SpacecraftDhallSet {
         self.to_dhall().map_err(PyException::new_err)
     }
 
-    /// Loads this Location dataset from its Dhall representation as a string
+    /// Loads this Spacecraft dataset from its Dhall representation as a string
     ///
     /// :type repr: str
     /// :rtype: SpacecraftDhallSet
@@ -160,7 +158,7 @@ impl SpacecraftDhallSet {
         Self::from_dhall(repr).map_err(PyException::new_err)
     }
 
-    /// Converts this location Dhall set into a Python-compatible Location DataSet.
+    /// Converts this location Dhall set into a Python-compatible Spacecraft DataSet.
     ///
     /// :rtype: SpacecraftDataSet
     #[pyo3(name = "to_dataset")]
@@ -227,7 +225,7 @@ pub struct PySpacecraftDataSet {
 #[cfg(feature = "python")]
 #[cfg_attr(feature = "python", pymethods)]
 impl PySpacecraftDataSet {
-    /// Loads a Location Dataset kernel from the provided path
+    /// Loads a Spacecraft Dataset kernel from the provided path
     ///
     /// :type path: str
     /// :rtype: SpacecraftDataSet
@@ -350,7 +348,7 @@ mod ut_sc_dhall {
         let as_dhall = set.to_dhall().unwrap();
         println!("{as_dhall}");
 
-        let mut from_dhall = SpacecraftDhallSet::from_dhall(&as_dhall).unwrap();
+        let from_dhall = SpacecraftDhallSet::from_dhall(&as_dhall).unwrap();
 
         assert_eq!(from_dhall, set);
 

--- a/anise/src/structure/dataset/spacecraft_dhall.rs
+++ b/anise/src/structure/dataset/spacecraft_dhall.rs
@@ -8,9 +8,9 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::structure::spacecraft::SpacecraftData;
-use crate::structure::SpacecraftDataSet;
 use crate::NaifId;
+use crate::structure::SpacecraftDataSet;
+use crate::structure::spacecraft::SpacecraftData;
 use serde::{Deserialize, Serialize};
 use serde_dhall::StaticType;
 use std::collections::BTreeMap;
@@ -74,7 +74,7 @@ impl SpacecraftDhallSet {
         for e in &self.data {
             dataset
                 .push(
-                    e.value.clone(),
+                    e.value,
                     e.id,
                     match e.name.as_ref() {
                         Some(s) => Some(s.as_str()),

--- a/anise/src/structure/dataset/spacecraft_dhall.rs
+++ b/anise/src/structure/dataset/spacecraft_dhall.rs
@@ -1,0 +1,362 @@
+/*
+ * ANISE Toolkit
+ * Copyright (C) 2021-onward Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. AUTHORS.md)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use crate::structure::spacecraft::SpacecraftData;
+use crate::structure::SpacecraftDataSet;
+use crate::NaifId;
+use serde::{Deserialize, Serialize};
+use serde_dhall::StaticType;
+use std::collections::BTreeMap;
+
+#[cfg(feature = "python")]
+use crate::file2heap;
+#[cfg(feature = "python")]
+use pyo3::exceptions::PyException;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pyo3::types::PyType;
+#[cfg(feature = "python")]
+use std::path::PathBuf;
+
+use super::{DataSet, DataSetType};
+
+/// Entry of a Location Dhall set
+///
+/// :type id: int, optional
+/// :type alias: str, optional
+/// :type value: Location
+#[derive(Clone, Debug, StaticType, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "python", pyclass(from_py_object, get_all, set_all))]
+#[cfg_attr(feature = "python", pyo3(module = "anise"))]
+pub struct SpacecraftDhallSetEntry {
+    pub id: Option<NaifId>,
+    pub name: Option<String>,
+    pub value: SpacecraftData,
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl SpacecraftDhallSetEntry {
+    #[new]
+    #[pyo3(signature=(value, id=None, name=None))]
+    fn py_new(value: SpacecraftData, id: Option<NaifId>, name: Option<String>) -> Self {
+        Self { id, name, value }
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+/// A Dhall-serializable Location DataSet that serves as an optional intermediate to the SpacecraftDataSet kernels.
+///
+/// :type data: list
+#[derive(Clone, Debug, StaticType, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "python", pyclass(from_py_object))]
+#[cfg_attr(feature = "python", pyo3(module = "anise"))]
+pub struct SpacecraftDhallSet {
+    data: Vec<SpacecraftDhallSetEntry>,
+}
+
+impl SpacecraftDhallSet {
+    /// Convert this Dhall representation of locations to a SpacecraftDataSet kernel.
+    ///
+    /// Function is mutable because the terrain mask is sanitized prior to building the kernel.
+    pub fn to_dataset(&mut self) -> Result<SpacecraftDataSet, String> {
+        let mut dataset = DataSet::default();
+        dataset.metadata.dataset_type = DataSetType::SpacecraftData;
+
+        for e in &mut self.data {
+            dataset
+                .push(
+                    e.value.clone(),
+                    e.id,
+                    match e.name.as_ref() {
+                        Some(s) => Some(s.as_str()),
+                        None => None,
+                    },
+                )
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(dataset)
+    }
+
+    /// Deserialize the Dhall string of a Location data set into its Dhall representation structure.
+    pub fn from_dhall(repr: &str) -> Result<Self, String> {
+        let me: Self = serde_dhall::from_str(repr)
+            .static_type_annotation()
+            .parse()
+            .map_err(|e| e.to_string())?;
+
+        Ok(me)
+    }
+
+    /// Serializes to a Dhall string
+    pub fn to_dhall(&self) -> Result<String, String> {
+        serde_dhall::serialize(&self)
+            .static_type_annotation()
+            .to_string()
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl SpacecraftDhallSet {
+    #[new]
+    fn py_new(data: Vec<SpacecraftDhallSetEntry>) -> Self {
+        Self { data }
+    }
+
+    /// :rtype: list
+    #[getter]
+    fn get_data(&self) -> Vec<SpacecraftDhallSetEntry> {
+        self.data.clone()
+    }
+    /// :type data: list
+    #[setter]
+    fn set_data(&mut self, data: Vec<SpacecraftDhallSetEntry>) {
+        self.data = data;
+    }
+
+    /// Loads this Location dataset from its Dhall representation as a string. Equivalent to from_dhall.
+    ///
+    /// :type repr: str
+    /// :rtype: SpacecraftDhallSet
+    #[classmethod]
+    fn loads(_cls: &Bound<'_, PyType>, repr: &str) -> Result<Self, PyErr> {
+        Self::from_dhall(repr).map_err(PyException::new_err)
+    }
+
+    /// Returns the Dhall representation of this SpacecraftDhallSet. Equivalent to to_dhall.
+    ///
+    /// :rtype: str
+    fn dumps(&self) -> Result<String, PyErr> {
+        self.to_dhall().map_err(PyException::new_err)
+    }
+
+    /// Returns the Dhall representation of this Location
+    ///
+    /// :rtype: str
+    #[pyo3(name = "to_dhall")]
+    fn py_to_dhall(&self) -> Result<String, PyErr> {
+        self.to_dhall().map_err(PyException::new_err)
+    }
+
+    /// Loads this Location dataset from its Dhall representation as a string
+    ///
+    /// :type repr: str
+    /// :rtype: SpacecraftDhallSet
+    #[classmethod]
+    #[pyo3(name = "from_dhall")]
+    fn py_from_dhall(_cls: Bound<'_, PyType>, repr: &str) -> Result<Self, PyErr> {
+        Self::from_dhall(repr).map_err(PyException::new_err)
+    }
+
+    /// Converts this location Dhall set into a Python-compatible Location DataSet.
+    ///
+    /// :rtype: SpacecraftDataSet
+    #[pyo3(name = "to_dataset")]
+    fn py_to_dataset(&mut self) -> Result<PySpacecraftDataSet, PyErr> {
+        Ok(PySpacecraftDataSet {
+            inner: self
+                .to_dataset()
+                .map_err(|e| PyException::new_err(e.to_string()))?,
+        })
+    }
+}
+
+impl SpacecraftDataSet {
+    /// Converts a location dataset kernel into its Dhall representation struct
+    pub fn to_dhallset(&self) -> Result<SpacecraftDhallSet, String> {
+        let mut many_me = BTreeMap::new();
+
+        for (id, pos) in &self.lut.by_id {
+            many_me.insert(
+                pos,
+                SpacecraftDhallSetEntry {
+                    id: Some(*id),
+                    name: None,
+                    value: self.get_by_id(*id).map_err(|e| e.to_string())?,
+                },
+            );
+        }
+
+        for (name, pos) in &self.lut.by_name {
+            if let Some(entry) = many_me.get_mut(&pos) {
+                entry.name = Some(name.to_string());
+            } else {
+                many_me.insert(
+                    pos,
+                    SpacecraftDhallSetEntry {
+                        id: None,
+                        name: Some(name.clone()),
+                        value: self.get_by_name(name).map_err(|e| e.to_string())?,
+                    },
+                );
+            }
+        }
+
+        // The BTreeMap ensures that everything is organized in the same way as in the dataset.
+        let data = many_me
+            .values()
+            .cloned()
+            .collect::<Vec<SpacecraftDhallSetEntry>>();
+
+        Ok(SpacecraftDhallSet { data })
+    }
+}
+
+/// A wrapper around a location dataset kernel (PyO3 does not handle type aliases).
+/// Use this class to load and unload kernels. Manipulate using its SpacecraftDhallSet representation.
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "anise"))]
+#[pyo3(name = "SpacecraftDataSet")]
+pub struct PySpacecraftDataSet {
+    inner: SpacecraftDataSet,
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl PySpacecraftDataSet {
+    /// Loads a Location Dataset kernel from the provided path
+    ///
+    /// :type path: str
+    /// :rtype: SpacecraftDataSet
+    #[classmethod]
+    fn load(_cls: Bound<'_, PyType>, path: &str) -> Result<Self, PyErr> {
+        let dataset = SpacecraftDataSet::try_from_bytes(
+            file2heap!(path).map_err(|e| PyException::new_err(e.to_string()))?,
+        )
+        .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        Ok(Self { inner: dataset })
+    }
+
+    /// Save this dataset as a kernel, optionally specifying whether to overwrite the existing file.
+    ///
+    /// :type path: str
+    /// :type overwrite: bool, optional
+    /// :rtype: None
+    #[pyo3(signature=(path, overwrite=false))]
+    fn save_as(&mut self, path: &str, overwrite: Option<bool>) -> Result<(), PyErr> {
+        self.inner.set_crc32();
+        self.inner
+            .save_as(&PathBuf::from(path), overwrite.unwrap_or_default())
+            .map_err(|e| PyException::new_err(e.to_string()))
+    }
+
+    /// Converts this location dataset into a manipulable location Dhall set.
+    ///
+    /// :rtype: SpacecraftDhallSet
+    fn to_dhallset(&self) -> Result<SpacecraftDhallSet, PyErr> {
+        self.inner
+            .to_dhallset()
+            .map_err(|e| PyException::new_err(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod ut_sc_dhall {
+
+    use crate::structure::spacecraft::{DragData, Inertia, Mass, SRPData, SpacecraftData};
+
+    use super::{SpacecraftDhallSet, SpacecraftDhallSetEntry};
+
+    #[test]
+    fn test_spacecraft_dhallset() {
+        let inertia = Inertia {
+            orientation_id: -159,
+            i_xx_kgm2: 15.0,
+            i_yy_kgm2: 16.0,
+            i_zz_kgm2: 17.0,
+            ..Default::default()
+        };
+        let srp = SRPData {
+            area_m2: 23.4,
+            coeff_reflectivity: 1.23,
+        };
+        let drag = DragData {
+            area_m2: 12.3,
+            coeff_drag: 1.01,
+        };
+        let mass = Mass {
+            dry_mass_kg: 15.9,
+            prop_mass_kg: 75.3,
+            extra_mass_kg: 45.6,
+        };
+
+        let all_set = SpacecraftData {
+            mass: Some(mass),
+            srp_data: Some(srp),
+            drag_data: Some(drag),
+            inertia: Some(inertia),
+        };
+
+        let no_inertia = SpacecraftData {
+            mass: Some(mass),
+            srp_data: Some(srp),
+            drag_data: Some(drag),
+            inertia: None,
+        };
+
+        let deep_space = SpacecraftData {
+            mass: Some(mass),
+            srp_data: Some(srp),
+            drag_data: None,
+            inertia: None,
+        };
+
+        let mass_only = SpacecraftData {
+            mass: Some(mass),
+            srp_data: None,
+            drag_data: None,
+            inertia: None,
+        };
+
+        let set = SpacecraftDhallSet {
+            data: vec![
+                SpacecraftDhallSetEntry {
+                    id: Some(1),
+                    name: Some("all".to_string()),
+                    value: all_set,
+                },
+                SpacecraftDhallSetEntry {
+                    id: None,
+                    name: Some("3dof".to_string()),
+                    value: no_inertia,
+                },
+                SpacecraftDhallSetEntry {
+                    id: None,
+                    name: Some("deep space".to_string()),
+                    value: deep_space,
+                },
+                SpacecraftDhallSetEntry {
+                    id: None,
+                    name: Some("mass".to_string()),
+                    value: mass_only,
+                },
+            ],
+        };
+
+        let as_dhall = set.to_dhall().unwrap();
+        println!("{as_dhall}");
+
+        let mut from_dhall = SpacecraftDhallSet::from_dhall(&as_dhall).unwrap();
+
+        assert_eq!(from_dhall, set);
+
+        let to_dataset = from_dhall.to_dataset().unwrap();
+        println!("{to_dataset}");
+
+        assert!(!to_dataset.lut.is_empty());
+    }
+}

--- a/anise/src/structure/dataset/spacecraft_dhall.rs
+++ b/anise/src/structure/dataset/spacecraft_dhall.rs
@@ -188,7 +188,7 @@ impl SpacecraftDataSet {
         }
 
         for (name, pos) in &self.lut.by_name {
-            if let Some(entry) = many_me.get_mut(&pos) {
+            if let Some(entry) = many_me.get_mut(pos) {
                 entry.name = Some(name.to_string());
             } else {
                 many_me.insert(

--- a/anise/src/structure/spacecraft/inertia.rs
+++ b/anise/src/structure/spacecraft/inertia.rs
@@ -26,6 +26,7 @@ use crate::NaifId;
     pyclass(from_py_object, get_all, set_all, module = "anise.astro")
 )]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 pub struct Inertia {
     /// Inertia tensor reference frame hash
     pub orientation_id: NaifId,

--- a/anise/src/structure/spacecraft/inertia.rs
+++ b/anise/src/structure/spacecraft/inertia.rs
@@ -11,9 +11,20 @@ use der::{Decode, Encode, Reader, Writer};
 use nalgebra::Matrix3;
 use serde_derive::{Deserialize, Serialize};
 
+#[cfg(feature = "python")]
+use pyo3::exceptions::PyValueError;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pyo3::types::{PyBytes, PyType};
+
 use crate::NaifId;
 
 /// Inertial tensor definition
+#[cfg_attr(
+    feature = "python",
+    pyclass(from_py_object, get_all, set_all, module = "anise.astro")
+)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Inertia {
     /// Inertia tensor reference frame hash
@@ -45,6 +56,63 @@ impl Inertia {
             self.i_yz_kgm2,
             self.i_zz_kgm2,
         )
+    }
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl Inertia {
+    #[new]
+    #[pyo3(signature = (orientation_id, i_xx_kgm2, i_yy_kgm2, i_zz_kgm2, i_xy_kgm2 = 0.0, i_xz_kgm2 = 0.0, i_yz_kgm2 = 0.0))]
+    fn py_new(
+        orientation_id: NaifId,
+        i_xx_kgm2: f64,
+        i_yy_kgm2: f64,
+        i_zz_kgm2: f64,
+        i_xy_kgm2: f64,
+        i_xz_kgm2: f64,
+        i_yz_kgm2: f64,
+    ) -> Self {
+        Self {
+            orientation_id,
+            i_xx_kgm2,
+            i_yy_kgm2,
+            i_zz_kgm2,
+            i_xy_kgm2,
+            i_xz_kgm2,
+            i_yz_kgm2,
+        }
+    }
+
+    fn __str__(&self) -> String {
+        format!("{self:?}")
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self:?} @ {self:p}")
+    }
+
+    /// Decodes an ASN.1 DER encoded byte array into an Inertia object.
+    ///
+    /// :type data: bytes
+    /// :rtype: Inertia
+    #[classmethod]
+    pub fn from_asn1(_cls: &Bound<'_, PyType>, data: &[u8]) -> PyResult<Self> {
+        match Self::from_der(data) {
+            Ok(obj) => Ok(obj),
+            Err(e) => Err(PyValueError::new_err(format!("ASN.1 decoding error: {e}"))),
+        }
+    }
+
+    /// Encodes this Inertia object into an ASN.1 DER encoded byte array.
+    ///
+    /// :rtype: bytes
+    pub fn to_asn1<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let mut buf = Vec::new();
+        match self.encode_to_vec(&mut buf) {
+            Ok(_) => Ok(PyBytes::new(py, &buf)),
+            Err(e) => Err(PyValueError::new_err(format!("ASN.1 encoding error: {e}"))),
+        }
     }
 }
 

--- a/anise/src/structure/spacecraft/mod.rs
+++ b/anise/src/structure/spacecraft/mod.rs
@@ -7,15 +7,15 @@
  *
  * Documentation: https://nyxspace.com/
  */
-use super::dataset::DataSetT;
 use super::SpacecraftDataSet;
+use super::dataset::DataSetT;
 use der::{Decode, Encode, Reader, Writer};
 pub use drag::DragData;
 pub use inertia::Inertia;
 pub use mass::Mass;
 use serde::{Deserialize, Serialize};
 pub use srp::SRPData;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 mod drag;
 mod inertia;

--- a/anise/src/structure/spacecraft/mod.rs
+++ b/anise/src/structure/spacecraft/mod.rs
@@ -7,15 +7,15 @@
  *
  * Documentation: https://nyxspace.com/
  */
-use super::SpacecraftDataSet;
 use super::dataset::DataSetT;
+use super::SpacecraftDataSet;
 use der::{Decode, Encode, Reader, Writer};
 pub use drag::DragData;
 pub use inertia::Inertia;
 pub use mass::Mass;
 use serde::{Deserialize, Serialize};
 pub use srp::SRPData;
-use tabled::{Table, Tabled, settings::Style};
+use tabled::{settings::Style, Table, Tabled};
 
 mod drag;
 mod inertia;
@@ -34,6 +34,7 @@ use pyo3::types::{PyBytes, PyType};
     feature = "python",
     pyclass(from_py_object, get_all, set_all, module = "anise.astro")
 )]
+#[cfg_attr(feature = "metaload", derive(serde_dhall::StaticType))]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SpacecraftData {
     /// Mass of the spacecraft in kg
@@ -71,6 +72,10 @@ impl SpacecraftData {
 
     fn __repr__(&self) -> String {
         format!("{self:?} @ {self:p}")
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
     }
 
     /// Decodes an ASN.1 DER encoded byte array into a SpacecraftData object.

--- a/anise/src/structure/spacecraft/mod.rs
+++ b/anise/src/structure/spacecraft/mod.rs
@@ -22,7 +22,18 @@ mod inertia;
 mod mass;
 mod srp;
 
+#[cfg(feature = "python")]
+use pyo3::exceptions::PyValueError;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pyo3::types::{PyBytes, PyType};
+
 /// Spacecraft constants can store the some of the spacecraft constant data as the CCSDS Orbit Parameter Message (OPM) and CCSDS Attitude Parameter Messages (APM)
+#[cfg_attr(
+    feature = "python",
+    pyclass(from_py_object, get_all, set_all, module = "anise.astro")
+)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SpacecraftData {
     /// Mass of the spacecraft in kg
@@ -33,6 +44,57 @@ pub struct SpacecraftData {
     pub drag_data: Option<DragData>,
     // Inertia tensor
     pub inertia: Option<Inertia>,
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl SpacecraftData {
+    #[new]
+    #[pyo3(signature = (mass = None, srp_data = None, drag_data = None, inertia = None))]
+    fn py_new(
+        mass: Option<Mass>,
+        srp_data: Option<SRPData>,
+        drag_data: Option<DragData>,
+        inertia: Option<Inertia>,
+    ) -> Self {
+        Self {
+            mass,
+            srp_data,
+            drag_data,
+            inertia,
+        }
+    }
+
+    fn __str__(&self) -> String {
+        format!("{self:?}")
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self:?} @ {self:p}")
+    }
+
+    /// Decodes an ASN.1 DER encoded byte array into a SpacecraftData object.
+    ///
+    /// :type data: bytes
+    /// :rtype: SpacecraftData
+    #[classmethod]
+    pub fn from_asn1(_cls: &Bound<'_, PyType>, data: &[u8]) -> PyResult<Self> {
+        match Self::from_der(data) {
+            Ok(obj) => Ok(obj),
+            Err(e) => Err(PyValueError::new_err(format!("ASN.1 decoding error: {e}"))),
+        }
+    }
+
+    /// Encodes this SpacecraftData object into an ASN.1 DER encoded byte array.
+    ///
+    /// :rtype: bytes
+    pub fn to_asn1<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let mut buf = Vec::new();
+        match self.encode_to_vec(&mut buf) {
+            Ok(_) => Ok(PyBytes::new(py, &buf)),
+            Err(e) => Err(PyValueError::new_err(format!("ASN.1 encoding error: {e}"))),
+        }
+    }
 }
 
 impl DataSetT for SpacecraftData {


### PR DESCRIPTION
# Summary

Allows the creation and modification of a spacecraft data kernel to build spacecraft templates with mass, drag data, SRP data, and inertia tensor. These can be saved as their own spacecraft kernel anise file, `ska`, though in practice, one would likely want to track this file in git for better version tracking as a `dhall` file.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

- Creation of SpacecraftDhallSet
- Retrieval of SpacecraftData from the kernel

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

From Python and Rust, check that I could build and retrieve the correct info.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->