### PR TITLE
saturate num_records size multiply in lagrange and hermite decoders

### DIFF
--- a/anise/src/naif/daf/datatypes/hermite.rs
+++ b/anise/src/naif/daf/datatypes/hermite.rs
@@ -364,7 +364,10 @@ impl<'a> NAIFDataSet<'a> for HermiteSetType13<'a> {
             });
         }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
-        let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
+        // num_records is an untrusted f64 cast to usize, so a crafted footer value saturates the
+        // cast and this record-area size multiply overflows; saturate so the .get below rejects it.
+        let state_data_end_idx =
+            (PositionVelocityRecord::SIZE / DBL_SIZE).saturating_mul(num_records);
         let state_data =
             slice
                 .get(0..state_data_end_idx)
@@ -655,6 +658,21 @@ mod hermite_ut {
                     },
                 }
             ),
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_num_records_without_overflow() {
+        // num_records is read from the footer as an f64 and cast to usize, so a huge finite value
+        // saturates the cast and the state-area size multiply `6 * num_records` used to overflow
+        // and panic during decode. The equal-step Type 12 decoder already guards this with
+        // saturating_mul, so only Type 13 was affected.
+        let mut slice = vec![0.0_f64; 20];
+        slice[18] = 2.0; // window size minus one
+        slice[19] = 6e18; // num_records: 6 * 6e18 exceeds usize::MAX
+        match HermiteSetType13::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized record count must be rejected"),
+            Err(e) => assert!(matches!(e, DecodingError::InaccessibleBytes { .. })),
         }
     }
 

--- a/anise/src/naif/daf/datatypes/lagrange.rs
+++ b/anise/src/naif/daf/datatypes/lagrange.rs
@@ -103,11 +103,15 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType8<'a> {
         let num_records = slice[slice.len() - 1] as usize;
 
         let record_data = &slice[0..slice.len() - 4];
+        // num_records is an untrusted f64 cast to usize, so a crafted footer value saturates the
+        // cast and the record-area size multiply overflows before the length check runs. Match the
+        // Type 12 Hermite decoder and compute the size with saturating_mul.
+        let need = num_records.saturating_mul(6);
         ensure!(
-            record_data.len() == 6 * num_records,
+            record_data.len() == need,
             TooFewDoublesSnafu {
                 dataset: Self::DATASET_NAME,
-                need: 6 * num_records,
+                need,
                 got: record_data.len(),
             }
         );
@@ -320,7 +324,10 @@ impl<'a> NAIFDataSet<'a> for LagrangeSetType9<'a> {
             });
         }
         // NOTE: The ::SIZE returns the C representation memory size of this, but we only want the number of doubles.
-        let state_data_end_idx = PositionVelocityRecord::SIZE / DBL_SIZE * num_records;
+        // num_records is an untrusted f64 cast to usize, so a crafted footer value saturates the
+        // cast and this record-area size multiply overflows; saturate so the .get below rejects it.
+        let state_data_end_idx =
+            (PositionVelocityRecord::SIZE / DBL_SIZE).saturating_mul(num_records);
         let state_data =
             slice
                 .get(0..state_data_end_idx)
@@ -608,6 +615,30 @@ mod ut_lagrange {
                     },
                 }
             ),
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_num_records_without_overflow() {
+        // num_records is read from the footer as an f64 and cast to usize, so a huge finite value
+        // saturates the cast and the record-area size multiply `6 * num_records` used to overflow
+        // and panic during decode. The equal-step Type 8 decoder builds the record slice length
+        // from that product directly.
+        let mut slice = vec![0.0_f64; 20];
+        slice[18] = 2.0; // degree
+        slice[19] = 6e18; // num_records: 6 * 6e18 exceeds usize::MAX
+        match LagrangeSetType8::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized record count must be rejected"),
+            Err(e) => assert!(matches!(e, DecodingError::TooFewDoubles { .. })),
+        }
+
+        // The unequal-step Type 9 decoder slices the state area with the same product.
+        let mut slice = vec![0.0_f64; 20];
+        slice[18] = 2.0; // degree
+        slice[19] = 6e18; // num_records
+        match LagrangeSetType9::from_f64_slice(&slice) {
+            Ok(_) => panic!("an oversized record count must be rejected"),
+            Err(e) => assert!(matches!(e, DecodingError::InaccessibleBytes { .. })),
         }
     }
 


### PR DESCRIPTION
# Summary

The Lagrange Type 8/9 and Hermite Type 13 decoders size the record area as `6 * num_records`, where `num_records` comes from the segment footer as an `f64` cast to `usize`. A crafted DAF/SPK segment with a large finite count saturates the cast, and that multiply overflows and panics while the segment is being decoded, before the length check can reject it. The equal-step Type 12 Hermite decoder already computes the same product with `saturating_mul`; its three siblings were missed.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

`LagrangeSetType8`, `LagrangeSetType9`, and `HermiteSetType13` now build the record-area size with `saturating_mul`, so an oversized count degrades to a `TooFewDoubles` / `InaccessibleBytes` decode error instead of a panic. A footer value like `6e18` triggers it, since `6 * 6e18` exceeds `usize::MAX`.

## Testing and validation

Added a regression test to the Lagrange and Hermite decoder suites that feeds an oversized `num_records` and checks the decode returns an error rather than panicking. The datatype `cargo test` set passes, and `cargo fmt` and `cargo clippy -p anise -- -D warnings` are clean.

## Documentation

This PR does not primarily deal with documentation changes.
