### PR TITLE
wrap the frame-id multiply in uuid_from_epoch

### DIFF
--- a/anise/src/lib.rs
+++ b/anise/src/lib.rs
@@ -40,7 +40,29 @@ pub mod time {
             .floor()
             .rem_euclid(f64::from(i32::MAX)) as i32;
 
-        (id * 10_000).wrapping_add(wrapped_days)
+        id.wrapping_mul(10_000).wrapping_add(wrapped_days)
+    }
+
+    #[cfg(test)]
+    mod ut_uuid_from_epoch {
+        use super::{Epoch, uuid_from_epoch};
+
+        #[test]
+        fn large_orientation_id_does_not_overflow() {
+            // `orientation_id` is read from a loaded kernel (a PCA body id, a BPC frame id,
+            // a location/instrument dataset frame), so it can exceed the ~214_748 point where
+            // `id * 10_000` overflows i32. A body-fixed frame for a high-numbered body (e.g.
+            // an asteroid at 2_000_001) reaches this through the topocentric / RIC / VNC DCM
+            // helpers on an Orbit. The multiply must wrap like the neighbouring add rather than
+            // panicking in debug or diverging from the release result.
+            let epoch = Epoch::from_tdb_seconds(0.0);
+            let big = 2_000_001;
+            let offset = uuid_from_epoch(0, epoch); // only the epoch term
+            assert_eq!(
+                uuid_from_epoch(big, epoch),
+                big.wrapping_mul(10_000).wrapping_add(offset)
+            );
+        }
     }
 }
 


### PR DESCRIPTION
# Summary

`uuid_from_epoch` in `anise/src/lib.rs` builds a frame UUID as `(id * 10_000).wrapping_add(wrapped_days)`. The add already wraps but the multiply does not, so a frame `orientation_id` whose magnitude passes ~214_748 overflows the `i32` multiply: it panics in debug (`attempt to multiply with overflow`) and wraps silently in release. `orientation_id` comes from a loaded kernel (a PCA body id, a BPC frame id, a location or instrument dataset frame), and a body-fixed frame for a high-numbered body such as an asteroid at `2_000_001` reaches this through the topocentric / RIC / VNC DCM helpers on an `Orbit` (for example via `azimuth_elevation_range_sez`). Switching to `wrapping_mul` makes the multiply wrap like the neighbouring add. The value is identical for every in-range id and matches the existing release result, so valid inputs behave exactly as before.

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

Wrap the `id * 10_000` multiply in `uuid_from_epoch` so a large frame `orientation_id` no longer overflows the `i32` multiply before the existing `wrapping_add`.

## Testing and validation

Added `ut_uuid_from_epoch::large_orientation_id_does_not_overflow`, which feeds an `orientation_id` of `2_000_001`: it panics on the current multiply in a debug build and now wraps consistently with the release value.

## Documentation

This PR does not primarily deal with documentation changes.
