### PR TITLE
Domain check on the eclipsing percentage

### DIFF
--- a/anise/src/almanac/eclipse.rs
+++ b/anise/src/almanac/eclipse.rs
@@ -9,7 +9,6 @@
  */
 
 use hifitime::{Duration, Unit};
-use log::error;
 
 use crate::{
     astro::{Aberration, Occultation},
@@ -347,12 +346,6 @@ fn compute_occultation_percentage(
         let d2 = (d_prime.powi(2) + r_ls_prime.powi(2) - r_fobj_prime.powi(2)) / (2.0 * d_prime);
 
         let shadow_area = circ_seg_area(r_fobj_prime, d1) + circ_seg_area(r_ls_prime, d2);
-        if shadow_area.is_nan() {
-            error!(
-                "Shadow area is NaN! Please file a bug with initial states, eclipsing bodies, etc."
-            );
-            return Ok(100.0);
-        }
         // Compute the nominal area of the back object
         let nominal_area = core::f64::consts::PI * r_ls_prime.powi(2);
         // And return the percentage (between 0 and 1) of the eclipse.
@@ -366,7 +359,15 @@ fn compute_occultation_percentage(
 
 /// Compute the area of the circular segment of radius r and chord length d
 fn circ_seg_area(r: f64, d: f64) -> f64 {
-    r.powi(2) * (d / r).acos() - d * (r.powi(2) - d.powi(2)).sqrt()
+    if d >= r {
+        0.0
+    } else if d <= -r {
+        core::f64::consts::PI * r.powi(2)
+    } else {
+        // Clamp the argument to acos strictly to [-1.0, 1.0] to prevent NaN
+        let cos_theta = (d / r).clamp(-1.0, 1.0);
+        r.powi(2) * cos_theta.acos() - d * (r.powi(2) - d.powi(2)).sqrt()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Summary

In edge cases, the code allowed emitting a warning for ill-conditioned sqrt and cosine in the eclipsing percentage calculations. While I've never encountered this edge case from rounding, it's best if it can be wholly avoided by clamping the cosine and checking the bounds of the sqrt before any computation.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

Prevent ill-conditioning of the eclipsing percentage.

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

No change

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to ANISE! -->